### PR TITLE
fix(object): fix markdown on bucket-website-api

### DIFF
--- a/storage/object/api-cli/bucket-website-api.mdx
+++ b/storage/object/api-cli/bucket-website-api.mdx
@@ -154,11 +154,7 @@ If you want your website to be accessible, you need to set up a bucket policy.
 1. Set the `"Action"` as `"s3:GetObject"` in the `bucket-policy.json` file,
 
 2. Specify which resources they can access under `"Resource"`:
-
-        - `"<BUCKET_NAME>/*"` - Grants access to all objects inside a bucket, but not to the bucket itself. 
-        - `"<BUCKET_NAME>/<PREFIX>/*"` - Grants access only to objects with the specified prefix inside a bucket, but not to the bucket itself. For example, if you apply a bucket policy that specifies `"my_files/movie/*"` under **Resource**, you would grant access to all objects with the `movie/` prefix, but not to other objects in `my_files/` bucket. 
-
-    ```json
+  ```json
         {
             "Version": "2012-10-17",
             "Id":"MyBucketPolicy",
@@ -176,7 +172,10 @@ If you want your website to be accessible, you need to set up a bucket policy.
                 }
             ]
         }
-    ``` 
+    ```
+
+    - `"<BUCKET_NAME>/*"` - Grants access to all objects inside a bucket, but not to the bucket itself.
+    - `"<BUCKET_NAME>/<PREFIX>/*"` - Grants access only to objects with the specified prefix inside a bucket, but not to the bucket itself. For example, if you apply a bucket policy that specifies `"my_files/movie/*"` under **Resource**, you would grant access to all objects with the `movie/` prefix, but not to other objects in `my_files/` bucket.
 
 3. Use [PUT Bucket Policy](/storage/object/api-cli/bucket-operations#put-bucket-policy) or run the following command to implement the policy via the AWS-CLI:
 


### PR DESCRIPTION
Fix this page: https://www.scaleway.com/en/docs/storage/object/api-cli/bucket-website-api/#configuring-access

It should look similar to this now: 

<img width="929" alt="screenshot_2021-08-25_19-36-39" src="https://user-images.githubusercontent.com/11699655/130838522-9d27d510-f098-44ea-9149-77f0aa0529d0.png">
