### PR TITLE
fix(quickstart block storage) Update command for persistent mounting 

### DIFF
--- a/storage/block/quickstart.mdx
+++ b/storage/block/quickstart.mdx
@@ -138,7 +138,7 @@ With the current configuration, the block device will not be mounted automatical
 Add this line to the `/etc/fstab` file of your instance:
 
   ```
-  echo '/dev/sda /mnt/volume-block ext4 defaults 0 0' >> /etc/fstab
+  /dev/sda /mnt/volume-block ext4 defaults 0 0
   ```
 
 You can now use your block storage volume like a regular disk of your instance, and store data on it as you wish.


### PR DESCRIPTION
The persistant mounting command displayed an echo and quotes which created an error if these items are copied as is to fstab.

*Sorry if the format not comply with the requirements, first contribution here*