### PR TITLE
fix(tutorials): coffee service name misspelled on lb host rule

### DIFF
--- a/tutorials/lb-ingress-controller/index.mdx
+++ b/tutorials/lb-ingress-controller/index.mdx
@@ -272,7 +272,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: cofee-svc
+                name: coffee-svc
                 port:
                   number: 80
 ```


### PR DESCRIPTION
The target backend that redirect to coffee-svc was misspelled.
_**Note :** It's late (at the time i do this PR) and I spent a "little bit" of time on it, if that can prevent someone else to live the same..._