### PR TITLE
docs(kubernetes): fix nginx, traefik service manifests ext-fix-kubernetes

### DIFF
--- a/compute/kubernetes/api-cli/exposing-services.mdx
+++ b/compute/kubernetes/api-cli/exposing-services.mdx
@@ -37,20 +37,20 @@ Scaleway Kubernetes has implemented the following ingress controllers: `nginx`, 
     apiVersion: v1
     kind: Service
     metadata:
-    name: nginx-ingress
-    namespace: kube-system
-    labels:
+      name: nginx-ingress
+      namespace: kube-system
+      labels:
         k8s.scw.cloud/ingress: nginx
     spec:
-    type: Load Balancer
-    ports:
-    - port: 80
+      type: LoadBalancer
+      ports:
+      - port: 80
         name: http
         targetPort: 8000
-    - port: 443
+      - port: 443
         name: https
         targetPort: 8443
-    selector:
+      selector:
         app.kubernetes.io/name: nginx
     ```
 
@@ -92,20 +92,20 @@ To expose Traefik2 with a Scaleway Load Balancer, deploy the following `yaml` fi
     apiVersion: v1
     kind: Service
     metadata:
-    name: traefik-ingress
-    namespace: kube-system
-    labels:
+      name: traefik-ingress
+      namespace: kube-system
+      labels:
         k8s.scw.cloud/ingress: traefik2
     spec:
-    type: Load Balancer
-    ports:
-    - port: 80
+      type: LoadBalancer
+      ports:
+      - port: 80
         name: http
         targetPort: 8000
-    - port: 443
+      - port: 443
         name: https
         targetPort: 8443
-    selector:
+      selector:
         app.kubernetes.io/name: traefik
     ```
 
@@ -145,20 +145,20 @@ To expose Traefik2 with a Scaleway Load Balancer, deploy the following `yaml` fi
     apiVersion: v1
     kind: Service
     metadata:
-    name: traefik-ingress
-    namespace: kube-system
-    labels:
+      name: traefik-ingress
+      namespace: kube-system
+      labels:
         k8s-app: traefik-ingress-lb
     spec:
-    type: Load Balancer
-    ports:
-    - port: 80
+      type: LoadBalancer
+      ports:
+      - port: 80
         name: http
         targetPort: 80
-    - port: 443
+      - port: 443
         name: https
         targetPort: 443
-    selector:
+      selector:
         k8s-app: traefik-ingress-lb
     ```
 


### PR DESCRIPTION
* fix spec.type to LoadBalancer for nginx, traefik manifests
* fix yaml indentation