### PR TITLE
Fix typo

### DIFF
--- a/tutorials/migrate-data-minio-client/index.mdx
+++ b/tutorials/migrate-data-minio-client/index.mdx
@@ -86,7 +86,7 @@ dates:
 4. Start the migration of your data:
   ```
   mc cp --recursive s3/<BUCKET_NAME> scw-fr-par/<BUCKET_NAME>
-  mc cp --recursive gcs/<OTTHER_BUCKET_NAME> scw-nl-ams/<OTHER_BUCKET_NAME>
+  mc cp --recursive gcs/<OTHER_BUCKET_NAME> scw-nl-ams/<OTHER_BUCKET_NAME>
   ```
   The commands above
 


### PR DESCRIPTION
I fixed a typo in the public documentation from OTTHER to OTHER