### PR TITLE
fix(vpc): update following split of Network menu MTA-1494 (wip)

### DIFF
--- a/network/vpc/how-to/configure-a-public-gateway.mdx
+++ b/network/vpc/how-to/configure-a-public-gateway.mdx
@@ -26,19 +26,17 @@ This page shows how to attach a [Public Gateway](/network/vpc/concepts#public-ga
 
 ## How to attach a Public Gateway to a Private Network
 
-1. Click **VPC** in the **Network** section of the side menu. The VPC page displays.
-
-2. Navigate to the **Public Gateways** tab.
+1. Click **Public Gateways** in the **VPC** section of the side menu.
    
-3. Click the Public Gateway that you want to attach to a Private Network. You are taken to the **Overview** page for that Public Gateway. 
+2. Click the Public Gateway that you want to attach to a Private Network. You are taken to the **Overview** page for that Public Gateway. 
 
-4. Click the **Private Networks** tab. A list of Private Networks attached to the Public Gateway displays. If no Private Networks are attached, the list will be empty.
+3. Click the **Private Networks** tab. A list of Private Networks attached to the Public Gateway displays. If no Private Networks are attached, the list will be empty.
 
-5. Click <Icon name="plus" /> to attach a new Private Network to the Public Gateway. The following pop-up displays:
+4. Click <Icon name="plus" /> to attach a new Private Network to the Public Gateway. The following pop-up displays:
 
   <Lightbox src="scaleway-vpc-gw-attach-pn.png" alt="" />
 
-6. Choose to attach an existing or a new Private Network. The default parameters should be appropriate for most cases (DHCP enabled, subnet automatically computed, NAT enabled). However, if you wish you can alter them now, or later once you have attached the Public Gateway.
+5. Choose to attach an existing or a new Private Network. The default parameters should be appropriate for most cases (DHCP enabled, subnet automatically computed, NAT enabled). However, if you wish you can alter them now, or later once you have attached the Public Gateway.
 
     - If you want to attach an existing Private Network, select **Attach an existing Private Network** and choose the desired network from the drop-down list.
     <Message type="note">
@@ -53,7 +51,7 @@ This page shows how to attach a [Public Gateway](/network/vpc/concepts#public-ga
         - **Enable Dynamic NAT**: Private IP addresses in the private network are automatically mapped to the public IP address of the Public Gateway, enabling automatic routing of egress traffic to and from multiple devices within the private network. Note: you will also be able to configure static NAT settings for ingress traffic.
         - **Disable Dynamic NAT**: The above functionality is not applied.
 
-7. Click **Attach a Private Network** to finish. You are taken back to the Private Networks tab, where the network you attached now appears, along with the services configured and the IP address of the Public Gateway.
+6. Click **Attach a Private Network** to finish. You are taken back to the Private Networks tab, where the network you attached now appears, along with the services configured and the IP address of the Public Gateway.
 
   <Lightbox src="scaleway-vpc-gw-pn-attached.png" alt="" />
 
@@ -63,22 +61,20 @@ Your Private Network is now attached to your Public Gateway. You can repeat the 
 
 You can review and (if you wish) modify the DHCP configuration of an existing Public Gateway as follows:
 
-1. Click **VPC** in the **Network** section of the side menu. The VPC page displays.
+1. Click **Public Gateways** in the **VPC** section of the side menu.
+  
+2. Click the Public Gateway whose configuration you wish to modify. You are taken to the Overview page for that Public Gateway. 
 
-2. Navigate to the **Public Gateways** tab.
-   
-3. Click the Public Gateway whose configuration you wish to modify. You are taken to the Overview page for that Public Gateway. 
-
-4. Click the **DHCP** tab. The following page displays:
+3. Click the **DHCP** tab. The following page displays:
 
   <Lightbox src="scaleway-dhcp.png" alt="" />
 
-5. DHCP is configured per private network. Select a private network from the drop-down menu to review its configuration.
+4. DHCP is configured per private network. Select a private network from the drop-down menu to review its configuration.
 
     - Toggle <Icon name="toggle" /> to **View DHCP Status** to view the current MAC/IP associations (aka DHCP leases).
     - Toggle <Icon name="toggle" /> to **Configure DHCP** and click <Icon name="edit" /> **Edit** to modify the network’s DHCP configuration.
 
-6. Modify the following configuration parameters according to your needs:
+5. Modify the following configuration parameters according to your needs:
 
   <Lightbox src="scaleway-dhcp-edit.png" alt="" />
 
@@ -89,7 +85,7 @@ You can review and (if you wish) modify the DHCP configuration of an existing Pu
     - Modify the dynamic range used to dynamically assign IP addresses to devices on the network. This range should fall within the configured subnet and should not overlap with the static associations.
     - Create or delete static associations to assign IP addresses based on the MAC addresses of the Instance. Statically assigned IP addresses should fall within the configured subnet, but be outside the dynamic range.
 
-7. Click <Icon name="validate" /> to save your configuration changes, or the red cross to cancel.
+6. Click <Icon name="validate" /> to save your configuration changes, or the red cross to cancel.
 
 <Message type="note">
 
@@ -101,30 +97,28 @@ You can review and (if you wish) modify the DHCP configuration of an existing Pu
 
 You can review and (if you wish) modify the NAT configuration of an existing Public Gateway as follows:
 
-1. Click **VPC** in the **Network** section of the side menu. The VPC page displays.
+1. Click **Public Gateways** in the **VPC** section of the side menu.
 
-2. Navigate to the **Public Gateways** tab.
-   
-3. Click the Public Gateway whose configuration you wish to modify. You are taken to the Overview page for that Public Gateway. 
+2. Click the Public Gateway whose configuration you wish to modify. You are taken to the Overview page for that Public Gateway. 
 
-4. Click the **NAT** tab. The following page displays, allowing you to review your NAT configuration:
+3. Click the **NAT** tab. The following page displays, allowing you to review your NAT configuration:
 
   <Lightbox src="scaleway-nat-tab.png" alt="" />
 
-5. In the **Dynamic NAT** panel, toggle <Icon name="toggle" /> Dynamic NAT on or off for each Private Network attached to this Public Gateway, as you wish.
+4. In the **Dynamic NAT** panel, toggle <Icon name="toggle" /> Dynamic NAT on or off for each Private Network attached to this Public Gateway, as you wish.
 
-6. In the **Static NAT** panel, click **Add Static NAT** to add a new configuration for any Private Network attached to this Gateway. The following screen displays:
+5. In the **Static NAT** panel, click **Add Static NAT** to add a new configuration for any Private Network attached to this Gateway. The following screen displays:
 
   <Lightbox src="scaleway-nat-add-static.png" alt="" />
 
-7. Add the following information for your new static NAT configuration:
+6. Add the following information for your new static NAT configuration:
 
     - **Protocol**: Choose TCP, UDP or Both from the drop-down menu
     - **Public Port**: Choose the Public Gateway port you want to use for this mapping
     - **Private IP address**: Enter the Private IP address of the Instance you want to map to. This should be included within one of the configured subnets of an attached private network. Usually, a static DHCP association is used too, to make sure this address does not change.
     - **Private Port**: Choose which of the Instance's ports you want to map to.
 
-8. Click <Icon name="validate" /> to save your configuration changes, or <Icon name="cancel" /> to cancel.
+7. Click <Icon name="validate" /> to save your configuration changes, or <Icon name="cancel" /> to cancel.
 
 Your new static NAT configuration is now saved, and displays on the NAT panel. You can repeat steps 6-8 to add new static NAT configurations as you wish.
 

--- a/network/vpc/how-to/create-a-public-gateway.mdx
+++ b/network/vpc/how-to/create-a-public-gateway.mdx
@@ -25,7 +25,9 @@ This page shows how to create a [Public Gateway](/network/vpc/concepts#public-ga
 
 ## How to create a Public Gateway
 
-1. Click **VPC** in the **Network** section of the side menu. The VPC page displays.
+1. Click **Public Gateways** in the **VPC** section of the side menu.
+
+[todo]: # update screenshot
 
   <Lightbox src="scaleway-vpc-tab.png" alt="" />
 
@@ -43,7 +45,7 @@ This page shows how to create a [Public Gateway](/network/vpc/concepts#public-ga
 
 4. Click **Create a Public Gateway** to finish. 
 
-Your Public Gateway is created and you are redirected to the **Public Gateways** tab, where your newly-created Public Gateway now displays.
+Your Public Gateway is created and you are redirected to the **Public Gateways** homepage, where your newly-created Public Gateway now displays.
 
 <Navigation title="See Also">
   <NextButton to="/network/vpc/how-to/configure-a-public-gateway/">How to configure a Public Gateway</NextButton>

--- a/network/vpc/how-to/delete-a-public-gateway.mdx
+++ b/network/vpc/how-to/delete-a-public-gateway.mdx
@@ -24,15 +24,13 @@ This page shows how to delete a [Public Gateway](/network/vpc/concepts#public-ga
 
 </Message>
 
-1. Click **VPC** in the **Network** section of the side menu. The VPC page displays.
-
-2. Click the **Public Gateways** tab.
+1. Click **Public Gateways** in the **VPC** section of the side menu.
    
-3. Click <Icon name="more" /> next to the Public Gateway you wish to delete, and select **Delete** from the drop-down menu.
+2. Click <Icon name="more" /> next to the Public Gateway you wish to delete, and select **Delete** from the drop-down menu.
 
   <Lightbox src="scaleway-delete-gw.png" alt="" />
 
-4. Confirm the action when prompted by typing **DELETE** in the pop-up window, then click **Delete this Public Gateway**.
+3. Confirm the action when prompted by typing **DELETE** in the pop-up window, then click **Delete this Public Gateway**.
 
 <Navigation title="See Also">
   <PreviousButton to="/network/vpc/how-to/use-private-networks/">How to use Private Networks</PreviousButton>

--- a/network/vpc/how-to/use-flexible-ips.mdx
+++ b/network/vpc/how-to/use-flexible-ips.mdx
@@ -33,7 +33,7 @@ You can hold flexible IP addresses independently of any Public Gateway, and atta
 
 ## How to create a new flexible IP address
 
-1. Click **VPC** in the **Network** section of the side menu. The VPC page displays.
+1. Click **Public Gateways** in the **VPC** section of the side menu.
 
 2. Navigate to the **Flexible IPs** tab.
 
@@ -51,7 +51,7 @@ You are taken to the list of your flexible IPs, where the new flexible IP addres
 
 ## How to attach an existing flexible IP address to a Public Gateway
 
-1. Click **VPC** in the **Network** section of the side menu. The VPC page displays.
+1. Click **Public Gateways** in the **VPC** section of the side menu.
 
 2. Navigate to the **Flexible IPs** tab.
 
@@ -69,7 +69,7 @@ You are taken to the list of your flexible IPs, where the new flexible IP addres
 
 ## How to detach an existing flexible IP address to a Public Gateway
 
-1. Click **VPC** in the **Network** section of the side menu. The VPC page displays.
+1. Click **Public Gateways** in the **VPC** section of the side menu.
 
 2. Navigate to the **Flexible IPs** tab.
 
@@ -85,7 +85,7 @@ When you no longer want one of your existing flexible IP addresses, you can dele
   The flexible IP must be detached from any Public Gateways in order to be deleted.
 </Message>
 
-1. Click **VPC** in the **Network** section of the side menu. The VPC page displays.
+1. Click **Public Gateways** in the **VPC** section of the side menu.
 
 2. Navigate to the **Flexible IPs** tab.
 

--- a/network/vpc/how-to/use-private-networks.mdx
+++ b/network/vpc/how-to/use-private-networks.mdx
@@ -28,9 +28,9 @@ Private Networks are a LAN-like layer 2 ethernet network. A new network interfac
 
 ## How to create a Private Network
 
-1. Click **VPC** in the **Network** section of the side menu
+1. Click **Private Networks** in the **VPC** section of the side menu.
 
-2. Click the **Private Networks** tab
+[todo]: # udpate screenshot
 
   <Lightbox src="scaleway-create-pn.png" alt="" />
 
@@ -43,21 +43,19 @@ Private Networks are a LAN-like layer 2 ethernet network. A new network interfac
     - Enter a **Name** for your private network, or leave the randomly-generated name in place. Optionally, you can also add [tags](/network/vpc/concepts#tags) to help you organize your private networks. 
     - Choose an **Availability Zone**, which is the geographical region where your private network will be deployed. You can only add Instances from this  same Availability Zone to the private network. 
 
-4. Click **Create a Private Network** to finish. Your private network is created. You are taken back to the Private Networks tab, where your new private network is now displayed in the list.
+4. Click **Create a Private Network** to finish. Your private network is created. You are taken back to the **Private Networks** homepage, where your new private network is now displayed in the list.
 
 ## How to attach and detach Instances to/from a Private Network
 
 Remember that Instances must be within the same Availability Zone as a private network in order to be attached to it. If you have not yet created an Instance, see how to do so [here](/compute/instances/how-to/create-an-instance/).
 
-1. Click **VPC** in the **Network** section of the side menu
+1. Click **Private Networks** in the **VPC** section of the side menu.
 
-2. Click the **Private Networks** tab
+2. Click the private network you want to add/remove Instances to. Alternatively, click <Icon name="more" /> next to the private network in question and select **More Info** from the dropdown list. You are taken to the **Overview** page for that network.
 
-3. Click the private network you want to add/remove Instances to. Alternatively, click <Icon name="more" /> next to the private network in question and select **More Info** from the dropdown list. You are taken to the **Overview** page for that network.
+3. Click the **Attached Resources** tab.
 
-4. Click the **Attached Resources** tab
-
-5. To add an Instance, use the the dropdown menu to select an Instance to add to your private network (B), then click **Add Instance**.
+4. To add an Instance, use the the dropdown menu to select an Instance to add to your private network (B), then click **Add Instance**.
 
     To detach an Instance, use the <Icon name="unlink" /> icon next to the Instance in question to remove it from your private network. Confirm this action when prompted by clicking **Detach this Instance**
 
@@ -79,15 +77,13 @@ Learn more about attaching Public Gateways to Private Networks and detaching the
 
 </Message>
 
-1. Click **VPC** in the **Network** section of the side menu
+1. Click **Private Networks** in the **VPC** section of the side menu.
 
-2. Click the **Private Networks** tab
+3. Click <Icon name="more" /> next to the private network you wish to delete, and select **Delete**. A pop up displays asking you to confirm the action.
 
-3. Click **...** next to the private network you wish to delete, and select **Delete**. A pop up displays asking you to confirm the action
+3. Confirm by typing **DELETE** in the box, and clicking **Delete this Private Network**.
 
-3. Confirm by typing **DELETE** in the box, and clicking **Delete this Private Network**
-
-You are taken back to the Private Networks tab, where the network you just deleted no longer displays.
+You are taken back to the **Private Networks** homepage, where the network you just deleted no longer displays.
 
 <Navigation title="See Also">
   <PreviousButton to="/network/vpc/how-to/use-flexible-ips/">How to use flexible IPs</PreviousButton>

--- a/network/vpc/quickstart.mdx
+++ b/network/vpc/quickstart.mdx
@@ -27,32 +27,28 @@ dates:
 
 ## How to create a Private Network
 
-1. Click **VPC** in the **Network** section of the side menu.
+1. Click **Private Networks** in the **VPC** section of the side menu.
 
-2. Click the **Private Networks** tab.
+2. Click the **Create a Private Network** button. The creation wizard displays.
 
-3. Click the **Create a Private Network** button. The creation wizard displays.
-
-4. Complete the following steps in the wizard: 
+3. Complete the following steps in the wizard: 
 
     - Enter a **Name** for your private network, or leave the randomly-generated name in place. Optionally, you can also add **tags** (/network/vpc/concepts/#tags) to help you organize your private networks. 
     - Choose an **Availability Zone**, which is the geographical region where your private network will be deployed. You can only add Instances from this  same Availability Zone to the private network. 
 
-5. Click **Create a Private Network** to finish. Your private network is created. You are taken back to the Private Networks tab, where your new private network is now displayed in the list.
+4. Click **Create a Private Network** to finish. Your private network is created. You are taken back to the **Private Networks** homepage, where your new private network is now displayed in the list.
 
 ## How to attach and detach Instances to/from a Private Network
 
 Remember that Instances must be within the same Availability Zone as a private network in order to be attached to it. If you have not yet created an Instance, see how to do so [here](/compute/instances/how-to/create-an-instance/).
 
-1. Click **VPC** in the **Network** section of the side menu.
+1. Click **Private Networks** in the **VPC** section of the side menu.
 
-2. Click the **Private Networks** tab.
+2. Click the private network you want to add/remove Instances to. Alternatively, click the <Icon name="more" /> icon next to the private network in question and select **More Info** from the dropdown list. You are taken to the **Overview** page for that network.
 
-3. Click the private network you want to add/remove Instances to. Alternatively, click the <Icon name="more" /> icon next to the private network in question and select **More Info** from the dropdown list. You are taken to the **Overview** page for that network.
+3. Click the **Attached Resources** tab.
 
-4. Click the **Attached Resources** tab.
-
-5. Use the dropdown menu to select an Instance to add to your private network, then click **Add Instance**.
+4. Use the dropdown menu to select an Instance to add to your private network, then click **Add Instance**.
 
   <Message type="tip">
 
@@ -65,7 +61,7 @@ To **detach an Instance**, use the <Icon name="unlink" /> icon next to the Insta
 
 ## How to create a Public Gateway
 
-1. Click **VPC** in the **Network** section of the side menu. The VPC page displays.
+1. Click **Public Gateways** in the **VPC** section of the side menu.
 
 2. Click **Create a new Public Gateway** to launch the Public Gateway creation wizard.
 
@@ -79,23 +75,21 @@ To **detach an Instance**, use the <Icon name="unlink" /> icon next to the Insta
 
 4. Click **Create a Public Gateway** to finish. 
 
-Your Public Gateway is created and you are redirected to the **Public Gateways** tab, where your newly-created Public Gateway now displays.
+Your Public Gateway is created and you are redirected to the **Public Gateways** homepage, where your newly-created Public Gateway now displays.
 
 ## How to attach your Public Gateway to your Private Network
 
-1. Click **VPC** in the **Network** section of the side menu. The VPC page displays.
-
-2. Navigate to the **Public Gateways** tab.
+1. Click **Public Gateways** in the **VPC** section of the side menu.
    
-3. Click the Public Gateway that you want to attach to a Private Network. You are taken to the **Overview** page for that Public Gateway. 
+2. Click the Public Gateway that you want to attach to a Private Network. You are taken to the **Overview** page for that Public Gateway. 
 
-4. Click the **Private Networks** tab. A list of Private Networks attached to the Public Gateway displays.
+3. Click the **Private Networks** tab. A list of Private Networks attached to the Public Gateway displays.
 
-5. Click <Icon name="plus" /> to attach a new Private Network to the Public Gateway. The following pop-up displays:
+4. Click <Icon name="plus" /> to attach a new Private Network to the Public Gateway. The following pop-up displays:
 
   <Lightbox src="scaleway-vpc-gw-attach-pn.png" alt="" />
 
-6. Choose to attach an existing or a new Private Network. The default parameters should be appropriate for most cases (DHCP enabled, subnet automatically computed, NAT enabled). However, if you wish you can alter them now, or later once you have attached the Public Gateway.
+5. Choose to attach an existing or a new Private Network. The default parameters should be appropriate for most cases (DHCP enabled, subnet automatically computed, NAT enabled). However, if you wish you can alter them now, or later once you have attached the Public Gateway.
 
     - If you want to attach an existing Private Network, select **Attach an existing Private Network** and choose the desired network from the drop-down list.
     <Message type="note">
@@ -110,6 +104,6 @@ Your Public Gateway is created and you are redirected to the **Public Gateways**
         - **Enable Dynamic NAT**: Private IP addresses in the private network are automatically mapped to the public IP address of the Public Gateway, enabling automatic routing of egress traffic to and from multiple devices within the private network. Note: you will also be able to configure static NAT settings for ingress traffic.
         - **Disable Dynamic NAT**: The above functionality is not applied.
 
-7. Click **Attach a Private Network** to finish. You are taken back to the Private Networks tab, where the network you attached now appears, along with the services configured and the IP address of the Public Gateway.
+5. Click **Attach a Private Network** to finish. You are taken back to the Private Networks tab, where the network you attached now appears, along with the services configured and the IP address of the Public Gateway.
 
 Your Private Network is now attached to your Public Gateway. You can repeat the steps above to attach more Private Networks to the same Public Gateway if you wish.


### PR DESCRIPTION
In order to manage PN and Pub GW as separate products in the console, VPC is extracted from the Network menu, which impacts the navigation.

Note: this will have to be reviewed against the final implementation and some screenshots will have to be updated (see [todo] in the text)