### PR TITLE
fix(instances): link formatting in migrate-instances.mdx

### DIFF
--- a/compute/instances/how-to/migrate-instances.mdx
+++ b/compute/instances/how-to/migrate-instances.mdx
@@ -48,7 +48,7 @@ Follow the instructions to [create a backup](/compute/instances/how-to/create-a-
 
 ## How to move the flexible IP to the new Instance
 
-Next, we will move the original DEV1-S Instance's [flexible IP address][flexible IP](/compute/instances/concepts#flexible-ip) to the new GP1-XS Instance. 
+Next, we will move the original DEV1-S Instance's [flexible IP address](/compute/instances/concepts#flexible-ip) to the new GP1-XS Instance. 
 
 1. Click **Instances** in the **Compute** section of the side menu. The Instances page displays.
 


### PR DESCRIPTION
Link formatting was incorrect (two text sections) which broke rendering.