### PR TITLE
Change MistServer article script link to always use latest version

### DIFF
--- a/tutorials/mist-streaming-server/index.mdx
+++ b/tutorials/mist-streaming-server/index.mdx
@@ -46,7 +46,7 @@ Mist server is one of the leading OTT (Internet Streaming) toolkits with an [ope
 2. Download the [latest version](https://mistserver.org/download) of the open source edition of Mist Server:
 
   ```
-  curl -o - https://releases.mistserver.org/is/mistserver_64V2.17.tar.gz 2>/dev/null | sh
+  curl -o - https://releases.mistserver.org/is/mistserver_64Vlatest.tar.gz 2>/dev/null | sh
   ```
 
 3. Mist Server is being installed automatically. Once the installation completes a message displays:
@@ -124,4 +124,4 @@ MistServer provides several ways to access your stream, either directly from a d
 
 Once everything is set, copy the code and paste it into your website. Alternatively you can use the dedicated HTML page to link to the stream. It will be available at `http://<your_compute_instance_ip>:8080/<stream-name>.html`
 
-You can now start streaming your viedo content directly using your compute instance. To learn more about MistServer, refer to the [official documentation](https://mistserver.org/guides/latest).
+You can now start streaming your video content directly using your compute instance. To learn more about MistServer, refer to the [official documentation](https://mistserver.org/guides/latest).


### PR DESCRIPTION
Hey there, 

MistServer team here. We noticed you were linking to an older version of MistServer in this article. So here's an edit that makes it use the latest version at any time. 
Thanks for writing the article of course, we'd be happy to clarify/help if you run into any questions/trouble for your customers as well.

With kind regards,
Balder - Head of Testing at MistServer