### PR TITLE
Correct ACCESS_KEY typo

### DIFF
--- a/storage/object/api-cli/generate-aws4-auth-signature.mdx
+++ b/storage/object/api-cli/generate-aws4-auth-signature.mdx
@@ -30,7 +30,7 @@ AWS4-HMAC-SHA256
 : Indicates AWS Signature Version 4 (AWS4) and the signing algorithm (HMAC-SHA256).
 
 Credential
-: Contains your access key and information about the request in the format: `${ACESS_KEY}/${YYYMMDD}/${REGION_SLUG}/s3/aws4_request`
+: Contains your access key and information about the request in the format: `${ACCESS_KEY}/${YYYMMDD}/${REGION_SLUG}/s3/aws4_request`
 
 SignedHeaders
 : A lower-cased list of the names of the request headers used when computing the signature. (e.g. `host;x-amz-acl;x-amz-content-sha256;x-amz-date`)


### PR DESCRIPTION
Change `ACESS_KEY` to `ACCESS_KEY` which is more commonly used in the documentation