### PR TITLE
fix(iot): Change link to Serverless documentation

### DIFF
--- a/iot/iot-hub/api-cli/trigger-functions-from-messages.mdx
+++ b/iot/iot-hub/api-cli/trigger-functions-from-messages.mdx
@@ -79,7 +79,7 @@ If you require authentication to protect your Serverless Function, here is how t
 
 1. Click the settings tab of your function settings tab and tick the `Private` option.
 
-2. [Generate a token](https://developers.scaleway.com/en/products/serverless/api/#tokens) for your function.
+2. [Generate a token](/compute/functions/api-cli/restricting-access-to-a-function) for your function.
 
 3. Re-create your IoT Hub Route with the following HTTP header: `SCW_FUNCTIONS_TOKEN: <function token here>`.
 


### PR DESCRIPTION
Change link from developers console to the documentation WebSite
https://jira.infra.online.net/browse/MTA-1521