### PR TITLE
Ingress configuration now allowed after cluster creation

### DIFF
--- a/compute/kubernetes/how-to/deploy-ingress-controller.mdx
+++ b/compute/kubernetes/how-to/deploy-ingress-controller.mdx
@@ -20,12 +20,6 @@ An [Ingress Controller](/compute/kubernetes/concepts#ingress-controller) is an e
 
 </Message>
 
-<Message type="important">
-
-It is only possible to configure an Ingress Controller during [cluster creation](/compute/kubernetes/how-to/create-cluster). 
-
-</Message>
-
 1. Click **Kubernetes** in the **Compute** section of the [Scaleway Console](https://console.scaleway.com) side menu. The Kubernetes Kapsule dashboard displays.
 
 2. Click **Create a cluster**. The first page of the Cluster Creation Wizard displays.


### PR DESCRIPTION
At least for kapsule clusters I was allowed to configure cluster ingress after the creation of the cluster. I believe this may be an outdated warning.