### PR TITLE
Some modifications

### DIFF
--- a/compute/instances/api-cli/using-cloud-init.mdx
+++ b/compute/instances/api-cli/using-cloud-init.mdx
@@ -31,23 +31,35 @@ You can give provisioning instructions to cloud-init using the *cloud-init* key 
 
 For *user_data* to be effective, it has to be added prior to the creation of the instance since `cloud-init` gets activated early in the first phases of the boot process.
 
-* **Server ID** refers to the unique identification string of your server. It will be displayed when you create your server. You can also recover it from the list of your servers, by typing `scw ps`.
+* **Server ID** refers to the unique identification string of your server. It will be displayed when you create your server. You can also recover it from the list of your servers, by typing `scw instance server list`.
 
-1. Create your Instance by specifying the path to your cloud-init configuration file.
+1. Create a stopped Instance 
   ```
-  $ scw instance server create image=ubuntu_focal name=myinstance cloud-init=@/path/to/cloud-config-file
+  $ scw instance server create image=ubuntu_focal name=myinstance stopped=true
   ```
+
+2. Provision your cloud-init configuration file in the created instance
+  ```
+  $ scw instance user-data set key=cloud-init server-id=instanceid content=@/path/to/cloud-config-file
+  ```
+
   <Message type="note">
 
-  `@/path/to/cloud-config-file` is the path of your [Cloud-Init](/compute/instances/concepts/#cloud-init/) configuration file. Edit it towards your requirements.
+  `@/path/to/cloud-config-file` is the path of your [Cloud-Init](/compute/instances/how-to/use-boot-modes.mdx#how-to-use-cloud-init) configuration file. Edit it towards your requirements.
 
   </Message>
 
-2. Start your Instance
+3. Start your Instance
   ```
   $ scw start {server Id}
   ```
 
+Since [version 2.3.1](https://github.com/scaleway/scaleway-cli/releases/tag/v2.3.1) of the Scaleway CLI a shorter command is available :
+
+  ```
+  $ scw instance server create image=ubuntu_focal name=myinstance cloud-init=@/path/to/cloud-config-file
+  ```
+  
 ## Cloud-Init CLI (Command Line Interface)
 
 The command line documentation is accessible on any cloud-init installed system.


### PR DESCRIPTION
- scw ps is outdated
- cloud-init link was outdated
- commands for the stopped instance process were not detailed
- the new shorter way cloud-init=@file is not working yet, so mentionned here as an alternative until it's fixed