### PR TITLE
add psycopg2 to python C dependencies

### DIFF
--- a/compute/functions/how-to/package-function-in-zip.mdx
+++ b/compute/functions/how-to/package-function-in-zip.mdx
@@ -91,6 +91,7 @@ In some specific cases, you might need to install libraries that require specifi
 - tensorflow
 - pandas
 - scikit-learn
+- psycopg2
 and others.
 
 Our Python runtimes run on top of [Alpine linux](https://alpinelinux.org/) environments, for these specific dependencies, you will have to install your dependencies inside a **Docker container**, with a specific image, that we are providing to our users.


### PR DESCRIPTION
to match the tutorial on postgres I add psycopg2 to the list of Python Libraries which required C dependecies