### PR TITLE
fix(containers/functions): add quotas information on limits

### DIFF
--- a/compute/containers/reference-content/containers-limitations.mdx
+++ b/compute/containers/reference-content/containers-limitations.mdx
@@ -10,9 +10,9 @@ This section contains usage limits that apply when using Serverless Containers. 
 
 | Ressources                                        | Criteria   | Limits          | Scope                 |
 |---------------------------------------------------|------------|-----------------|-----------------------|
-| Namespaces                                        | Max Number | 5*               | Project               |
-| Containers                                        | Max Number | 100*             | Namespace             |
-| Containers                                        | Max Number | 500*             | Organisation          |
+| Namespaces                                        | Max Number | 5*              | Project               |
+| Containers                                        | Max Number | 100*            | Namespace             |
+| Containers                                        | Max Number | 500*            | Organisation          |
 | Image size Compressed                             | Max size   | 250MB           | Container             |
 | Image size Uncompressed                           | Max size   | 1G              | Container             |
 | Temporary disk size                               | Max size   | 512 MB          | Container             |

--- a/compute/containers/reference-content/containers-limitations.mdx
+++ b/compute/containers/reference-content/containers-limitations.mdx
@@ -6,13 +6,13 @@ dates:
   posted: 2021-10-12
 ---
 
-This section contains usage limits that apply when using Serverless Containers.
+This section contains usage limits that apply when using Serverless Containers. For limits marked with an asterisk (*), lower quotas might apply, please reach our support to increase them.
 
 | Ressources                                        | Criteria   | Limits          | Scope                 |
 |---------------------------------------------------|------------|-----------------|-----------------------|
-| Namespaces                                        | Max Number | 5               | Project               |
-| Containers                                        | Max Number | 100             | Namespace             |
-| Containers                                        | Max Number | 500             | Organisation          |
+| Namespaces                                        | Max Number | 5*               | Project               |
+| Containers                                        | Max Number | 100*             | Namespace             |
+| Containers                                        | Max Number | 500*             | Organisation          |
 | Image size Compressed                             | Max size   | 250MB           | Container             |
 | Image size Uncompressed                           | Max size   | 1G              | Container             |
 | Temporary disk size                               | Max size   | 512 MB          | Container             |

--- a/compute/functions/reference-content/functions-limitations.mdx
+++ b/compute/functions/reference-content/functions-limitations.mdx
@@ -10,9 +10,9 @@ This section contains usage limits that apply when using Serverless Functions. F
 
 | Resources                                        | Criteria   | Limits          | Scope                |
 |--------------------------------------------------|------------|-----------------|----------------------|
-| Namespaces                                       | Max Number | 5*               | Project              |
-| Functions                                        | Max Number | 100*             | Namespace            |
-| Functions                                        | Max Number | 500*             | Organisation         |
+| Namespaces                                       | Max Number | 5*              | Project              |
+| Functions                                        | Max Number | 100*            | Namespace            |
+| Functions                                        | Max Number | 500*            | Organisation         |
 | Zip Size                                         | Max size   | 100 MB          | Function             |
 | Code Size                                        | Max size   | 500 MB          | Function             |
 | Temporary disk size                              | Max size   | 512 MB          | Function Instance    |

--- a/compute/functions/reference-content/functions-limitations.mdx
+++ b/compute/functions/reference-content/functions-limitations.mdx
@@ -6,13 +6,13 @@ dates:
   posted: 2021-10-12
 ---
 
-This section contains usage limits that apply when using Serverless Functions.
+This section contains usage limits that apply when using Serverless Functions. For limits marked with an asterisk (*), lower quotas might apply, please reach our support to increase them.
 
 | Resources                                        | Criteria   | Limits          | Scope                |
 |--------------------------------------------------|------------|-----------------|----------------------|
-| Namespaces                                       | Max Number | 5               | Project              |
-| Functions                                        | Max Number | 100             | Namespace            |
-| Functions                                        | Max Number | 500             | Organisation         |
+| Namespaces                                       | Max Number | 5*               | Project              |
+| Functions                                        | Max Number | 100*             | Namespace            |
+| Functions                                        | Max Number | 500*             | Organisation         |
 | Zip Size                                         | Max size   | 100 MB          | Function             |
 | Code Size                                        | Max size   | 500 MB          | Function             |
 | Temporary disk size                              | Max size   | 512 MB          | Function Instance    |


### PR DESCRIPTION
Limits indicated in the document reference-content/functions-limitations/ and reference-content/containers-limitations/ were not taken into account T&S quotas.
I made a fix proposition