### PR TITLE
fix(docs): fix multiplication in comment

### DIFF
--- a/storage/object/api-cli/object-storage-aws-cli.mdx
+++ b/storage/object/api-cli/object-storage-aws-cli.mdx
@@ -56,7 +56,7 @@ To interact with AWS, `aws-cli` and `awscli-plugin-endpoint` need to be installe
     max_concurrent_requests = 100
     max_queue_size = 1000
     multipart_threshold = 50MB
-    # Edit the multipart_chunksize value according to the file sizes that you want to upload. The present configuration allows to upload files up to 10 GB (100 requests * 10MB). For example setting it to 5GB allows you to upload files up to 5TB.
+    # Edit the multipart_chunksize value according to the file sizes that you want to upload. The present configuration allows to upload files up to 10 GB (1000 requests * 10MB). For example setting it to 5GB allows you to upload files up to 5TB.
     multipart_chunksize = 10MB
   s3api =
     endpoint_url = https://s3.nl-ams.scw.cloud


### PR DESCRIPTION
The maximum number of requests is one thousand, 100 is the maximum of concurrent ones.