### PR TITLE
chore: check slugs - WDOC-223

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,9 +1,7 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-RED='\033[0;31m'
-
 [[ $(bin/count-invalid-slugs) == "0" ]] && \
 yarn lint-staged || \
-(echo "💔 \033[0;31mSlugs error(s): \033[0;36m" && bin/list-invalid-slugs \ 
+(echo "💔 \033[0;31mSlug error(s): \033[0;36m" && bin/list-invalid-slugs \ 
 echo "⚠️ \033[0;31mYou must fix slugs in 'menu/navigation.json' before commit!\033[0;0m"; exit 1)

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,9 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn lint-staged
+RED='\033[0;31m'
+
+[[ $(bin/count-invalid-slugs) == "0" ]] && \
+yarn lint-staged || \
+(echo "💔 \033[0;31mSlugs error(s): \033[0;36m" && bin/list-invalid-slugs \ 
+echo "⚠️ \033[0;31mYou must fix slugs in 'menu/navigation.json' before commit!\033[0;0m"; exit 1)

--- a/bin/count-invalid-slugs
+++ b/bin/count-invalid-slugs
@@ -1,0 +1,2 @@
+#!/bin/bash
+grep -Ev '\"slug\": \"([a-z0-9]+)([a-z0-9])([a-z0-9-]*)\"' ./menu/navigation.json | grep -c '\"slug\":' 

--- a/bin/count-invalid-slugs
+++ b/bin/count-invalid-slugs
@@ -1,2 +1,3 @@
 #!/bin/bash
-grep -Ev '\"slug\": \"([a-z0-9]+)([a-z0-9])([a-z0-9-]*)\"' ./menu/navigation.json | grep -c '\"slug\":' 
+source bin/slug-regex
+grep -Ev "${SLUG_REGEX}" ./menu/navigation.json | grep -c '\"slug\":' 

--- a/bin/list-invalid-slugs
+++ b/bin/list-invalid-slugs
@@ -1,2 +1,3 @@
 #!/bin/bash
-grep -Ev '\"slug\": \"([a-z0-9]+)([a-z0-9])([a-z0-9-]*)\"' ./menu/navigation.json | grep -n '\"slug\":' | tr -s [:space:]
+source bin/slug-regex
+grep -Ev "${SLUG_REGEX}" ./menu/navigation.json | grep -n '\"slug\":' | tr -s [:space:]

--- a/bin/list-invalid-slugs
+++ b/bin/list-invalid-slugs
@@ -1,0 +1,2 @@
+#!/bin/bash
+grep -Ev '\"slug\": \"([a-z0-9]+)([a-z0-9])([a-z0-9-]*)\"' ./menu/navigation.json | grep -n '\"slug\":' | tr -s [:space:]

--- a/bin/slug-regex
+++ b/bin/slug-regex
@@ -1,0 +1,2 @@
+#!/bin/bash
+export SLUG_REGEX='\"slug\": \"([a-z0-9]+)(-?)(([a-z0-9]+)-?)*([a-z0-9]+)\"'

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,3 @@
-module.exports = { extends: ['@commitlint/config-conventional'] }
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+}

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,3 +1,1 @@
-module.exports = {
-  extends: ['@commitlint/config-conventional'],
-}
+module.exports = { extends: ['@commitlint/config-conventional'] }

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -57,7 +57,13 @@ git clone git@github.com:[your-docs-content-fork]/docs-content.git | bash -s -- 
 2. Ensure `yarn` has been run, if not run `yarn install`.
 3. Edit files.
 
-## Commit conventions
+## Git commit
+
+Helpfull pre-commit commands:
+
+- `yarn check-slugs` Output slugs that are not kebab-case well formatted.
+
+### Commit conventions
 
 This project uses [conventionalcommits](https://www.conventionalcommits.org/en/v1.0.0/) based on the [Angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#-commit-message-guidelines).
 
@@ -82,7 +88,7 @@ Here is the list of `type` to use (commons in bold):
 - `style`
   - _For simple format changes that are not content changes_
 
-### examples
+#### examples
 
 `feat(console): add vpc how-to page MTA-2342`
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "scripts": {
     "prepare": "husky install",
+    "check-slugs": "bin/list-invalid-slugs",
     "format": "yarn run prettier --config .prettierrc --write \"**/*.json\""
   }
 }


### PR DESCRIPTION
https://jira.infra.online.net/browse/WDOC-223

---

## What

If slugs are not `kebab-case` valid, prod is break

## Changes

- Add scripts for slugs validation
- use scripts in pre-commit husky hook
    - git commit is stopped on slug error!
- set yarn command to manually check slugs

## Test

- change slugs with a mix of no "kebab-case" valid formats
    - space before/middle/after
    - special chars
    - uppercase
- `git add . && git commit -m "fake commit"`
- Error should pop, list of no valid slugs should print and husky stop
- `yarn check-slugs` for manual check
- fix slugs
- do manual check again > nothing output
- do fake commit again > linter & conventional commit should run

---
![Capture d’écran 2021-11-30 à 1 54 24 PM](https://user-images.githubusercontent.com/341803/144057406-8b163418-5ff0-49ac-853c-336fe2d4fd8e.png)


