### PR TITLE
chore(precommit): fix error on linux

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,7 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-[[ $(bin/count-invalid-slugs) == "0" ]] && \
-yarn lint-staged || \
-(echo "💔 \033[0;31mSlug error(s): \033[0;36m" && bin/list-invalid-slugs \ 
-echo "⚠️ \033[0;31mYou must fix slugs in 'menu/navigation.json' before commit!\033[0;0m"; exit 1)
+bash bin/check-pre-commit

--- a/bin/check-pre-commit
+++ b/bin/check-pre-commit
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+[[ $(bin/count-invalid-slugs) == "0" ]] && \
+yarn lint-staged || \
+(echo "💔 Slug error(s):" && bin/list-invalid-slugs \ 
+echo "⚠️ You must fix slugs in 'menu/navigation.json' before commit"; exit 1)

--- a/bin/count-invalid-slugs
+++ b/bin/count-invalid-slugs
@@ -1,3 +1,3 @@
 #!/bin/bash
-source bin/slug-regex
+. bin/slug-regex
 grep -Ev "${SLUG_REGEX}" ./menu/navigation.json | grep -c '\"slug\":' 

--- a/bin/list-invalid-slugs
+++ b/bin/list-invalid-slugs
@@ -1,3 +1,3 @@
 #!/bin/bash
-source bin/slug-regex
+. bin/slug-regex
 grep -Ev "${SLUG_REGEX}" ./menu/navigation.json | grep -n '\"slug\":' | tr -s [:space:]


### PR DESCRIPTION
## What

- Script sh error on Linux (Ubuntu)

## Why

- `husky` is calling `pre-commit` script with `sh`. Bash syntax does not work for Linux when it is sh that called the script, even if the hashbang specify bash 

## Changes

- force check slugs script to be called by `bash` in pre-commit script

## Test

- check if Mac OS still right with commit, and the same with an error in `navigation.json` for slug
- check the same under Linux (@RoRoJ 😄 )
