### PR TITLE
update documentation to use cert-manager v1.6.0

### DIFF
--- a/tutorials/traefik-v2-cert-manager/index.mdx
+++ b/tutorials/traefik-v2-cert-manager/index.mdx
@@ -239,7 +239,7 @@ Any modification to the Traefik2 deployed by Kapsule may be overwritten by the r
 3. Use the command below to install cert-manager and its needed CRD ([Custom Resource Definitions](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)):
 
   ```
-  $ kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.1.1/cert-manager.yaml
+  $ kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.6.1/cert-manager.yaml
   customresourcedefinition.apiextensions.k8s.io/certificaterequests.cert-manager.io created
   customresourcedefinition.apiextensions.k8s.io/certificates.cert-manager.io created
   customresourcedefinition.apiextensions.k8s.io/challenges.acme.cert-manager.io created
@@ -309,7 +309,7 @@ Any modification to the Traefik2 deployed by Kapsule may be overwritten by the r
       solvers:
         - http01:
             ingress:
-              class: traefik-cert-manager
+              class: traefik
   ```
 
 2. Use `kubectl` to apply the configuration:


### PR DESCRIPTION
Cert-manager v1.1.0 has trouble managing k8s clusters in 1.23 version.

I updated the documentation to use the v1.6.0 of cert-manager. It implies the solvers.http01.ingress.class must exist in IngressClass
Upgrading from an existing installed v1.1.0 should be done following the documentation, and more importantly, the CRD replacement https://cert-manager.io/docs/installation/upgrading/upgrading-1.1-1.2/