### PR TITLE
wireguard-mesh-tutorial: fix instance naming in peer config (s/AMS/PAR/)

### DIFF
--- a/tutorials/wireguard-mesh-vpn/index.mdx
+++ b/tutorials/wireguard-mesh-vpn/index.mdx
@@ -108,7 +108,7 @@ Create the file `/etc/wireguard/wg0.conf` with the following content:
   ListenPort = 52345
 
   [Peer]
-  PublicKey = AMS-1 Instances strings
+  PublicKey = PAR-1 Instances strings
   AllowedIPs = 192.168.1.1
   Endpoint = 212.47.15.33:52345
   ```


### PR DESCRIPTION
Hi,

Unless I'm mistaking, in the wireguard mesh tutorial, both peer configuration files should mirror each other.

This (micro) PR fixes a naming inconsistency between those two.

Best regards,

Evomassiny