### PR TITLE
docs(container-privacy): fix tokens claims name

### DIFF
--- a/compute/containers/api-cli/restricting-access-to-a-container.mdx
+++ b/compute/containers/api-cli/restricting-access-to-a-container.mdx
@@ -48,7 +48,7 @@ The token will have the following claims:
  "application_claim": [
    {
      "namespace_id": "string",
-     "container_id": "string" // optional: id of the container
+     "application_id": "string" // optional: id of the container
    }
  ]
 }


### PR DESCRIPTION
tokens generated from Scaleway API will contain an application_id in its claims, not container_id

### Your checklist for this pull request

- [X] Check that the commit messages match our requested structure.
- [X] Name your pull request according to the [contribution guidelines](../docs/CONTRIBUTING.md).

