### PR TITLE
docs(fix): typo in tutorial gitea MTA-1932

### DIFF
--- a/tutorials/self-hosted-repository-gitea/index.mdx
+++ b/tutorials/self-hosted-repository-gitea/index.mdx
@@ -275,7 +275,7 @@ For increased security it is possible to configure [NGINX reverse proxy](/tutori
   ufw default allow outgoing
   ```
 
-4. Enable connections on the ports `21` (SSH), `80` (HTTP), `443` (HTTPS) via [TCP](https://en.wikipedia.org/wiki/Transmission_Control_Protocol) and `53` (DNS) via [TCP](https://en.wikipedia.org/wiki/Transmission_Control_Protocol) and [UDP](https://en.wikipedia.org/wiki/User_Datagram_Protocol) as both are required for DNS:
+4. Enable connections on the ports `22` (SSH), `80` (HTTP), `443` (HTTPS) via [TCP](https://en.wikipedia.org/wiki/Transmission_Control_Protocol) and `53` (DNS) via [TCP](https://en.wikipedia.org/wiki/Transmission_Control_Protocol) and [UDP](https://en.wikipedia.org/wiki/User_Datagram_Protocol) as both are required for DNS:
 
   ```
   ufw allow 22/tcp


### PR DESCRIPTION
### Description
Fix typo for SSH port in tutorial.
