### PR TITLE
docs(kubernetes): document loadbalancer zone annotation

### DIFF
--- a/compute/kubernetes/api-cli/using-load-balancer-annotations.mdx
+++ b/compute/kubernetes/api-cli/using-load-balancer-annotations.mdx
@@ -238,6 +238,14 @@ This is the annotation to set the Load Balancer offer type.
 
 <Concept>
 
+## service.beta.kubernetes.io/scw-loadbalancer-zone
+
+The Availability Zone in which the Load Balancer will be created.
+
+</Concept>
+
+<Concept>
+
 ## service.beta.kubernetes.io/scw-loadbalancer-timeout-server
 
 This is the annotation to set the maximum server connection inactivity time.


### PR DESCRIPTION
When trying to control the AZ in which a load balancer was created, I had to guess the annotation based on the structure of other documented annotations and it worked.

I propose to add the annotation to the documentation.