### PR TITLE
fix(tutorial): API key link

### DIFF
--- a/tutorials/deploy-nextcloud-s3/index.mdx
+++ b/tutorials/deploy-nextcloud-s3/index.mdx
@@ -259,8 +259,8 @@ You can use Nextcloud as a client for Object Storage while using the local stora
     - `Port` = The port for your bucket, leave this empty
     - `Region` = The geographical region of your bucket (Either: `nl-ams` for Amsterdam, The Netherlands, `pl-waw` for Warsaw, Poland or `fr-par` for Paris, France)
     - `Enable SSL` = Activate this checkbox to encrypt the connection between your Nextcloud and the Bucket
-    - `Access Key` = Your [Access Key](/console/my-project/how-to/create-ssh-key/)
-    - `Secret Key` = Your [Secret Key](/console/my-project/how-to/create-ssh-key/)
+    - `Access Key` = Your [Access Key](/console/my-project/how-to/generate-api-key/)
+    - `Secret Key` = Your [Secret Key](/console/my-project/how-to/generate-api-key/)
 
     Once you have entered all details, click the checkmark to validate your configuration. If everything works well, a green dot will appear on the left.
 


### PR DESCRIPTION
It links to ssh key creation, but it should link to API key generation tutorial

### Your checklist for this pull request

- [x] Check that the commit messages match our requested structure.
- [x] Name your pull request according to the [contribution guidelines](../docs/CONTRIBUTING.md).

### Description
Please describe your pull request.

