### PR TITLE
feat(functions): add doc about new Go runtimes (1.17 and 1.18)

### DIFF
--- a/compute/functions/api-cli/fun-uploading-with-serverless-framework.mdx
+++ b/compute/functions/api-cli/fun-uploading-with-serverless-framework.mdx
@@ -139,21 +139,23 @@ functions:
     handler: src/handlers/secondHandler.my_second_handler
 ```
 
-### Golang
-	
-If you have the following structure, the path to your handler's **package** should resemble the following:
+### Golang (>= 1.17)
+
+If you have the following structure, the path to your handler's **package** should look like the following:
 
 ```
-- src
-  - testing
-    - handler.go -> package main in src/testing subdirectory
-  - second
-    - handler.go -> package main in src/second subdirectory
-- serverless.yml
-- handler.go -> package main at the root of project
+src/
+├── go.mod
+├── go.sum
+├── first
+│   └── handler.go -> Handle function defined here
+├── second
+│   └── handler.go -> Handle function defined here
+├── serverless.yml
+└── handler.go     -> Handle function defined here
 ```
 
-Your serverless.yml `functions` should be similar to:
+Your `serverless.yml` should be similar to:
 
 ```yml
 provider:
@@ -161,11 +163,44 @@ provider:
   runtime: go118
 functions:
   main:
-    handler: "."
-  testing:
-    handler: src/testing
+    handler: "Handle"
+  first:
+    handler: "first/Handle"
   second:
-    handler: src/second
+    handler: "second/Handle"
+```
+
+For further details, see the [Serverless Scaleway plugin example and documentation](https://github.com/scaleway/serverless-scaleway-functions/tree/master/examples/go).
+
+### Golang (< 1.17)
+
+If you have the following structure, the path to your handler's **package** should look like the following:
+
+```
+src/
+├── go.mod
+├── go.sum
+├── first
+│   └── handler.go -> package main in src/first subdirectory
+├── second
+│   └── handler.go -> package main in src/second subdirectory
+├── serverless.yml
+└── handler.go     -> package main at the root of project
+```
+
+Your `serverless.yml` should be similar to:
+
+```yml
+provider:
+  # ...
+  runtime: go113
+functions:
+  main:
+    handler: "."
+  first:
+    handler: first
+  second:
+    handler: second
 ```
 
 ## Configuring events

--- a/compute/functions/reference-content/code-examples.mdx
+++ b/compute/functions/reference-content/code-examples.mdx
@@ -450,7 +450,64 @@ Please refer to our guide on [code packaging](https://www.scaleway.com/en/docs/c
   };
   ```
 
-## Go
+## Go (>= 1.17)
+
+Unlike old versions of Go runtime (< 1.17), there is no additional dependencies to use when writing a Go function.
+
+But there are also requirements:
+
+- your code must be a valid Go module: a `go.mod` file is expected in the root directory
+- your handler function should be in a file at the root of your module
+- your handler must be exported, example: `Handle` is correct, `handle` is not because it is not exported
+- your handler must have the following signature: `func Handle(w http.ResponseWriter, r *http.Request)`
+- `main` package is reserved: you must not have any package named `main` in your module
+
+Suggested code layout:
+
+```
+.
+├── go.mod        # your go.mod defines your module
+├── go.sum        # not always necessary
+├── myfunc.go     # your handler method (exported) must be defined here
+└── subpackage    # you can have subpackages
+   └── hello.go  # with files inside
+```
+
+### Hello world
+
+```go
+package myfunc
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// Handle - Handle event
+func Handle(w http.ResponseWriter, r *http.Request) {
+	response := map[string]interface{}{
+		"message": "We're all good",
+		"healthy": true,
+		"number":  4,
+	}
+
+	responseB, err := json.Marshal(response)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	fmt.Fprint(w, string(responseB))
+}
+```
+
+Using [`r *http.Request`](https://pkg.go.dev/net/http#Request) object, you can get the method, the headers, the body, etc, as if you were using a simple http server.
+
+You must use the [`w http.ResponseWriter`](https://pkg.go.dev/net/http#ResponseWriter) parameter to send a response to the function caller.
+
+## Go (< 1.17)
 Our Go runtime is based on AWS lambda’s, hence you will find similarities between the two runtimes.
 
 ### Hello world

--- a/compute/functions/reference-content/code-examples.mdx
+++ b/compute/functions/reference-content/code-examples.mdx
@@ -470,7 +470,7 @@ Suggested code layout:
 ├── go.sum        # not always necessary
 ├── myfunc.go     # your handler method (exported) must be defined here
 └── subpackage    # you can have subpackages
-   └── hello.go  # with files inside
+   └── hello.go   # with files inside
 ```
 
 ### Hello world


### PR DESCRIPTION
### Description

Doc about Go runtimes >= 1.17 (differs from the old Go runtimes `go113` and `golang`).

