### PR TITLE
docs(functions): Reformat python code blocks

### DIFF
--- a/compute/functions/how-to/package-function-in-zip.mdx
+++ b/compute/functions/how-to/package-function-in-zip.mdx
@@ -45,12 +45,12 @@ This feature enables you to add your librairies or static files to your function
 
 The Handler name is a path to the handler file, suffixed with the function name to use as a handler. In the following example, we use two handlers `hello.py` and `world.py` inside the `src/handlers` folder.
 
-  ```bash
-  src
-   | -- handlers
-     | -- hello.py => def say_hello
-     |-- world.py => def to_the_world
-  ```
+```bash
+src
+ | -- handlers
+   | -- hello.py => def say_hello
+   | -- world.py => def to_the_world
+```
 
 1. Make sure to provide the right handler name, namely `src/handlers/hello.say_hello` and `src/handlers/world.to_the_world`
 
@@ -68,13 +68,19 @@ Additional dependencies must be included inside a package directory at the root 
 ```bash
 # At the root of your archive
 mkdir package
- | --requirements.txt
+```
+
+Your project will look like this:
+
+```bash
+src
+ | -- requirements.txt
  | -- handlers
-| -- handler.py => import requests
-| -- secondHandler.py => import requests
-| - package
-  | -- requests
-  | -- ...
+   | -- handler.py => import requests
+   | -- secondHandler.py => import requests
+ | - package
+   | -- requests
+   | -- ...
 ```
 
 ### Standard dependencies


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Check that the commit messages match our requested structure.
- [x] Name your pull request according to the [contribution guidelines](../docs/CONTRIBUTING.md).

### Description

In the `Additional dependencies` python example code block `mkdir` command was mixed with the project directory structure and the indentation  of the file hierarchy was incorrect.

By the way you might want to take a look at the Go examples, the layout seems to differ from the file hierarchy representation for Python and JS examples introduced in #642, as I don't know Go I wasn't able to fix them.

