### PR TITLE
Add let's encrypt configuration to gitlab documentation

### DIFF
--- a/tutorials/gitlab-instant-app/index.mdx
+++ b/tutorials/gitlab-instant-app/index.mdx
@@ -54,14 +54,18 @@ The new security group configuration will be applied automatically on Virtual Cl
 
 1. Copy the public IP of your Instance and paste it in your favorite browser.
 
-2. Define a new password for your GitLab account.
+2. Define a new password for your GitLab account. You may also use `sudo gitlab-rake "gitlab:password:reset"` from the server.
 
   <Lightbox src="scaleway-gitlab-login.webp" alt="" />
 
 3. Enter the new password twice and click the button to save it.
 
-4. login now with the `root` user and your new password.
+4. Login now with the `root` user and your new password.
 
 5. Configure GitLab from the "Admin area".
 
 <Lightbox src="scaleway-gitlab-interface.webp" alt="" />
+
+## Configuring Let's Encrypt
+
+Gitlab can automatically fetch and renew [let's encrypt](https://letsencrypt.org/) certificates. Follow this [tutorial from Gitlab documentation](https://docs.gitlab.com/omnibus/settings/ssl.html#lets-encrypt-integration). 


### PR DESCRIPTION
Also add optional configuration to change the default password as the proposed method does not work in the current version.