### PR TITLE
docs(kubernetes): "remove alpha from csi" int-rm-kubernetes

### DIFF
--- a/compute/kubernetes/api-cli/managing-storage.mdx
+++ b/compute/kubernetes/api-cli/managing-storage.mdx
@@ -21,11 +21,6 @@ dates:
 
 The [Scaleway Block Volume](https://www.scaleway.com/en/block-storage/) Container Storage Interface (CSI) driver is an implementation of the [CSI interface](https://github.com/container-storage-interface/spec/blob/master/spec.md) to provide a way to manage Scaleway Block Volumes through a container orchestration system, like Kubernetes.
 
-<Message type="important">
-
-This project is under active development and should be considered alpha. You can [raise an issue](https://github.com/scaleway/scaleway-csi/issues/new) if you think you have found a bug.
-
-</Message>
 
 ## CSI Specification Compability Matrix
 


### PR DESCRIPTION
### Your checklist for this pull request

- [ x] Check that the commit messages match our requested structure.
- [ x] Name your pull request according to the [contribution guidelines](../docs/CONTRIBUTING.md).

### Description
Following discution with some customers seeing the "alpha" on this doc, i asked the Kapsule team if the CSI was still in alpha but they confirmed it is now stable and used widely with no known bugs.
