### PR TITLE
doc(tip) [traefik-v2] Adding args to redirect to https by default

### DIFF
--- a/tutorials/traefik-v2-cert-manager/index.mdx
+++ b/tutorials/traefik-v2-cert-manager/index.mdx
@@ -229,6 +229,17 @@ Any modification to the Traefik2 deployed by Kapsule may be overwritten by the r
           - --providers.kubernetesingress
   []
   ```
+  
+<Message type="tip">
+
+If you want to redirect http to https by default you can also add this to the args
+```  
+        - --entrypoints.web.http.redirections.entryPoint.to=:443
+        - --entrypoints.web.http.redirections.entryPoint.scheme=https
+        - --entrypoints.web.http.redirections.entrypoint.permanent=true
+```
+
+</Message>
 
 2. Delete the existing Traefik pods in order to get the new arguments.
 


### PR DESCRIPTION
Because the websecure port is 8443 we force redirect to port 443 to avoid https://xxx:8443 redirection

### Your checklist for this pull request

- [x] Check that the commit messages match our requested structure.
- [x] Name your pull request according to the [contribution guidelines](../docs/CONTRIBUTING.md).

### Description
Adding a tip message to force http to https redirection

### Organisation ID for the Community program
`79d5616e-a3ad-4561-9237-7b0576023e45`

