### PR TITLE
ci(POC): add changelog-contribution

### DIFF
--- a/.github/workflows/changelog-contribution.yml
+++ b/.github/workflows/changelog-contribution.yml
@@ -1,0 +1,51 @@
+name: Changelog contribution
+on:
+  workflow_dispatch:
+    inputs:
+      reporter:
+        description: 'Reporter (Name and Surname)'
+        required: true
+      status:
+        description: 'Status of the new logs'
+        required: true
+      description:
+        description: 'Description of the new logs'
+        required: true
+
+jobs:
+  create-pull-request:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3.0.2
+      - name: Generate branch id
+        id: branch_id
+        run: echo "::set-output name=id::$(date +'%Y-%m-%d-%H%M%S')"
+      - name: Get current date
+        id: current_date
+        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+      - name: Create file
+        run: |
+          mkdir -p ./changelog/billing/$(date +'%B%Y')
+          cat > ./changelog/billing/$(date +'%B%Y')/${{ steps.current_date.outputs.date }}-${{ github.event.inputs.status }}.mdx << EOF
+          ---
+          title: Lorem ipsum dolor sit amet
+          status: ${{ github.event.inputs.status }}
+          author: 
+              fullname: ${{ github.event.inputs.reporter }}
+              url: 'http://www.scaleway.com'
+          date: ${{ steps.current_date.outputs.date }}
+          category: storage
+          product: object-storage
+          ---
+          ${{ github.event.inputs.description }}
+          EOF
+      - name: Create pull request towards the main branch
+        uses: peter-evans/create-pull-request@v4.1.1
+        with:
+          token: ${{ secrets.GH_TOKEN }}
+          commit-message: Auto Pull Request
+          title: New changelog - ${{ github.event.inputs.reporter }} ${{ steps.current_date.outputs.date }}
+          body: Auto-created Pull Request
+          branch: changelog/${{ github.event.inputs.status }}/${{ steps.branch_id.outputs.id }}
+          delete-branch: true


### PR DESCRIPTION
## What

- Add a github action to automatically generate a pr when a contributor submit a new changelog

## To test

- Don't forget to add the `GITHUB_TOKEN` secret, the key is `GH_TOKEN`, follow these [instructions](https://docs.github.com/en/enterprise-server@3.4/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)  if you don't know how to do it
- Then use this url `https://api.github.com/repos/scaleway/docs-content/actions/workflows/changelog-contribution.yml/dispatches` and make a post request. You'll need to add the `Bearer Token` (use the github token) (e.g: Authorization: Bearer {GH_TOKEN}) and this line `Accept: application/vnd.github+json`, to the head. Check this [doc](https://docs.github.com/en/rest/actions/workflows#create-a-workflow-dispatch-event) for more information
- Pass this data to the body
 ```
{
  "ref": "main",
  "inputs": {
    "reporter": "John doe",
    "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
    "status": "security"
  }
}
```
- Check the `Actions` tab on github, make sure that it triggered the `changelog-contribution` workflow
- If it succeeds, check the `Pull requests` tab on github, it should have created a new pr
