### PR TITLE
ci(POC): add image input + format created log

### DIFF
--- a/.github/workflows/changelog-contribution.yml
+++ b/.github/workflows/changelog-contribution.yml
@@ -11,6 +11,8 @@ on:
       description:
         description: 'Description of the new logs'
         required: true
+      image:
+        description: 'Image encoded in base64'
 
 jobs:
   create-pull-request:
@@ -27,7 +29,7 @@ jobs:
       - name: Create file
         run: |
           mkdir -p ./changelog/billing/$(date +'%B%Y')
-          cat > ./changelog/billing/$(date +'%B%Y')/${{ steps.current_date.outputs.date }}-${{ github.event.inputs.status }}.mdx << EOF
+          cat > ./changelog/billing/$(date +'%B%Y')/${{ steps.current_date.outputs.date }}-${{ github.event.inputs.status }}.mdx << "EOF"
           ---
           title: Lorem ipsum dolor sit amet
           status: ${{ github.event.inputs.status }}
@@ -38,8 +40,15 @@ jobs:
           category: storage
           product: object-storage
           ---
+
           ${{ github.event.inputs.description }}
+          
           EOF
+      - name: Add image asset
+        if: "${{ github.event.inputs.image != '' }}"
+        run: |
+          mkdir -p ./changelog/billing/$(date +'%B%Y')/assets
+          echo "${{ github.event.inputs.image }}" | base64 --decode > ./changelog/billing/$(date +'%B%Y')/assets/image.webp
       - name: Create pull request towards the main branch
         uses: peter-evans/create-pull-request@v4.1.1
         with:


### PR DESCRIPTION
## What

- Add image input to add an image in the log
- Format the new log, by adding whitespace at the beginning and at the end and by preventing `here document` to remove special char like back quote(`)
-
## To test

- Don't forget to add the `GITHUB_TOKEN` secret, the key is `GH_TOKEN`, follow these [instructions](https://docs.github.com/en/enterprise-server@3.4/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)  if you don't know how to do it
- Then fill the inputs manually to add a new log
- Make sure it created a new pr once the github action is done