### PR TITLE
docs(changelog): howto in editor page WDOC-322

### DIFF
--- a/editor-components.mdx
+++ b/editor-components.mdx
@@ -134,6 +134,69 @@ content:
 
 ---
 
+## Log (Changelog)
+
+🧩 &nbsp;This functionality uses **MDX** files.
+
+See [Changelog page](https://www.scaleway.com/en/docs/changelog/).
+
+Each "Log" is an MDX file:
+
+- Go to the `changelog/` folder
+- Add or choose a directory relative to the log you want to add
+- Create a `.mdx` file in it 
+
+NOTES: 
+- Organize the `changelog/` folder structure as you want
+- The `.mdx` filename does not matter 
+- Assets should be in an `asset` directory, sibling of your `.mdx` file
+
+### Log file frontmatter
+
+At the top of the `.mdx` file, you MUST add the frontmatter data:
+
+```
+---
+title: Migration to the new S3 backend (HIVE) for all regions
+status: changed
+author:
+    fullname: 'Join the #container-registry channel on Slack.'
+    url: 'https://slack.scaleway.com/'
+date: 2022-01-02
+category: compute
+product: container-registry
+---
+```
+
+- **title** (mandatory)
+- **status** (mandatory)
+    - `added`
+    - `security`
+    - `changed`
+    - `deprecated`
+    - `removed`
+    - `fixed`
+- **author**
+    - **fullname** (optional / mandatory IF url is set). It could be a name or a sentence, as you prefer.
+    - **url** (optional)
+- **date** (mandatory) `YYYY-MM-DD`
+- **category** (mandatory) `kebab-case`
+- **product** (mandatory) `kebab-case`
+
+### Log file contents
+
+The content section works as any documentation `.mdx` file. It accepts both markdown and components. Be concise !
+
+#### About Download link in content
+
+- Use `[Download](document-pdf-name.pdf) the document as PDF file.`
+- Place the PDF file in a sibling assets directory
+    - This is useful to automatically get the filesize data
+- Then, it should appear like this (with PDF icon):
+    - > 📄 <strong style="text-decoration: underline; color: #bc4fff">Download (PDF, 2.26MB)</strong> the document as PDF file.
+
+---
+
 ## Navigation
 
 ### PreviousButton, NextButton


### PR DESCRIPTION
## What

- Add doc for changelog use in `/editor-component` page

## Check

- `yarn clean && yarn develop`
- open http://localhost:8003/editor-components/#log-(changelog)

