### PR TITLE
fix(messaging): few mistakes / typo

### DIFF
--- a/compute/messaging/api-cli/python-node-sns.mdx
+++ b/compute/messaging/api-cli/python-node-sns.mdx
@@ -63,7 +63,7 @@ Be careful: messages sent to topics with no subscriptions are automatically dele
 
 ```python
 for i in range (0,10):
-  queue.send_message(MessageBody="Hello World: "+str(i))
+  topic.Publish(Message="Hello World: "+str(i))
 ```
 
 ### Create subscriptions to this topic
@@ -92,13 +92,16 @@ subscription_functions = topic.subscribe(
 )
 ```
 
-You can also set up an SQS queue from the same namesapce, as a [Dead Letter Queue](/compute/messaging/concepts#dead-letter-queue):
+You can also set up an SQS queue from the same namespace, as a [Dead Letter Queue](/compute/messaging/concepts#dead-letter-queue):
 
 ```python
 subscription_functions = topic.subscribe(
     Protocol='lambda',
     Endpoint=[Function URL],
-    ReturnSubscriptionArn=True
+    ReturnSubscriptionArn=True,
+    Attributes={
+      'RedrivePolicy': '{"deadLetterTargetArn": "[Queue ARN]"}'
+    }
 )
 ```
 
@@ -179,7 +182,7 @@ var params = {
 };
 ```
 
-### Send messages to this topic
+### Publish messages to this topic
 
 Be careful: messages sent to topics with no subscriptions are automatically deleted.
 
@@ -247,7 +250,7 @@ sns.subscribe(params, function(err, data) {
 });
 ```
 
-You can also set up an SQS queue from the same namesapce, as a [Dead Letter Queue](/compute/messaging/concepts#dead-letter-queue):
+You can also set up an SQS queue from the same namespace, as a [Dead Letter Queue](/compute/messaging/concepts#dead-letter-queue):
 
 ```javascript
 var params = {

--- a/compute/messaging/api-cli/python-node-sqs.mdx
+++ b/compute/messaging/api-cli/python-node-sqs.mdx
@@ -52,7 +52,7 @@ Once connected to the SQS service, you can use any functions available with the 
 
 ```python
 # Create the queue. This returns an SQS.Queue instance
-queue = sqs.create_queue(QueueName='my test queue')
+queue = sqs.create_queue(QueueName='my-test-queue')
  
 # You can now access identifiers and attributes
 print(queue.url)


### PR DESCRIPTION
Hi,

Just a few fixes:

- SQS queue names cannot contain spaces
- the dead letter attribute was missing

 It's not tested but I am pretty sure the proposed changes are good.

