### PR TITLE
fix(docs): Small typo in s3cmd config

### DIFF
--- a/tutorials/s3cmd/index.mdx
+++ b/tutorials/s3cmd/index.mdx
@@ -69,7 +69,7 @@ Carry out the following commands from your terminal.
   # Object Storage Region NL-AMS
 
   host_base = s3.nl-ams.scw.cloud
-  host_bucket = %(bucket)s.s3.nl-ams.scw.cloud
+  host_bucket = %(bucket).s3.nl-ams.scw.cloud
   bucket_location = nl-ams
   use_https = True
 


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Check that the commit messages match our requested structure.
- [x] Name your pull request according to the [contribution guidelines](../docs/CONTRIBUTING.md).

### Description
The doc contain this line :
```
host_bucket = %(bucket)s.s3.nl-ams.scw.cloud
```

There is a small typo with a s after bucket variable.

