### PR TITLE
fix: deploy page should link to upload page, not itself NOPROJECT-XXX

### DIFF
--- a/compute/containers/how-to/deploy-a-container.mdx
+++ b/compute/containers/how-to/deploy-a-container.mdx
@@ -16,7 +16,7 @@ This page shows you how to deploy your first Serverless Container. A container i
 
   - You have an account and are logged into the [Scaleway console](https://console.scaleway.com)
   - You have [created a containers namespace](/compute/containers/how-to/create-a-containers-namespace/)
-  - You have [created a Container Registry namespace](/compute/container-registry/how-to/create-namespace/) and [pushed a container image](/compute/containers/how-to/deploy-a-container/) to it
+  - You have [created a Container Registry namespace](/compute/container-registry/how-to/create-namespace/) and [pushed a container image](/compute/container-registry/how-to/push-images/) to it
 
 </Message>
 


### PR DESCRIPTION
### Your checklist for this pull request

- [X] Check that the commit messages match our requested structure.
- [X] Name your pull request according to the [contribution guidelines](../docs/CONTRIBUTING.md).

### Description

Currently, this link points to the page it is already on, which doesn't help people learn how to upload and then deploy a container.