### PR TITLE
fix(concepts): updated concepts instances

### DIFF
--- a/compute/instances/api-cli/migrating-gp-to-pro.mdx
+++ b/compute/instances/api-cli/migrating-gp-to-pro.mdx
@@ -18,8 +18,8 @@ This page explains how to migrate from a DEV1/GP1 Instance with local storage to
 </Message>
 
 To migrate from a source Instance with local storage to a destination Instance with Block Storage we will:
-  - create a [backup](/compute/instances/concepts/#backup) of the source Instance, including unified [snapshots](/compute/instances/concepts/#snapshot) of all the source Instance's volumes,
-  - create the destination Instance from the backup image
+  - create an [image](/compute/instances/concepts/#image) of the source Instance, including unified [snapshots](/compute/instances/concepts/#snapshot) of all the source Instance's volumes,
+  - create the destination Instance from the image
 
 Local and block snapshots have different formats. To support the migration from one to the other, we use unified snapshots. Unified snapshots can be created from either a local or block volume and, in turn, used to create either a local or block volume.
 

--- a/compute/instances/concepts.mdx
+++ b/compute/instances/concepts.mdx
@@ -36,14 +36,6 @@ An Availability Zone refers to the geographical location in which your instance 
 
 <Concept opened>
 
-## Backup
-
-The backup feature allows you to create an [image](#image) of your Instance, which contains all its volumes. You can use this image not only to restore your Instance and its data but also to create a series of Instances with a predefined configuration. See our dedicated how-to on [how to create a backup of your Instance](/compute/instances/how-to/create-a-backup).
-
-</Concept>
-
-<Concept opened>
-
 ## Block Volumes
 
 Block volumes provide network-attached storage that can be plugged in/out of Instances like a virtual hard drive. From a user's point of view, block volumes behave like regular disks, and can be used to increase the storage of an Instance.
@@ -122,7 +114,7 @@ Flexible IP addresses are public IP addresses that you can hold independently of
 
 ## Image
 
-An image is a template for creating new Instances. It can be created from a [backup](#backup), which is a complete copy of an Instance containing all of its volumes, or a [snapshot](#snapshot), which is a copy of one specific volume.
+Creating an image allows you to make a complete backup of your Instance. One image will contain all of the [volumes](#volumes) of your Instance, and can be used to restore your Instance and its data. You can also use it to create a series of Instances with a predefined configuration. To copy not all but only one specific volume of an Instance, you can use the [snapshot](#snapshot) feature instead.
 
 </Concept>
 


### PR DESCRIPTION
Removing the definition of Backup, and updating the Image definition to match recent changes in the console.

