### PR TITLE
docs(instances): fixed style typo in command line

### DIFF
--- a/compute/instances/troubleshooting/reboot-from-faulty-kernel.mdx
+++ b/compute/instances/troubleshooting/reboot-from-faulty-kernel.mdx
@@ -23,8 +23,8 @@ categories:
 
 1. Switch the Instance's `boot-type` to `rescue` and reboot your Instance into rescue mode using the CLI-Tools: 
     ```
-    # scw instance server update {Instance_ID} boot-type=rescue
-    # scw instance server reboot {Instance_ID}
+    scw instance server update {Instance_ID} boot-type=rescue
+    scw instance server reboot {Instance_ID}
     ```
     <Message type="note">
         Replace `{Instance_ID}` with the unique ID of your Instance, e.g. `0500ebd2-d70d-49af-a969-3ac09b6f7fff`.

--- a/compute/instances/troubleshooting/reboot-from-faulty-kernel.mdx
+++ b/compute/instances/troubleshooting/reboot-from-faulty-kernel.mdx
@@ -31,18 +31,21 @@ categories:
     </Message>
 2. Once the Instance is rebooted, log into your Instance using [SSH](/compute/instances/how-to/connect-to-instance/) and setup the environment to be able to chroot into it:
     ```sh
-    # cat /proc/partitions
+    cat /proc/partitions
     major minor #blocks name
 
     8 0 9765625 sda
     8 1 9634536 sda1
     8 14 3072 sda14
     8 15 126976 sda15
-    # mount /dev/sda1 /mnt
-    # mount /dev/sda15 /mnt/boot/efi
-    # mount -o bind /sys /mnt/sys
-    # mount -o bind /proc /mnt/proc
-    # mount -o bind /dev /mnt/dev
+    ```
+    Then mount the partitions:
+    ```
+    mount /dev/sda1 /mnt
+    mount /dev/sda15 /mnt/boot/efi
+    mount -o bind /sys /mnt/sys
+    mount -o bind /proc /mnt/proc
+    mount -o bind /dev /mnt/dev
     ```
 3. Once mounted, use the `chroot` command to get into your Instances' root filesystem. You can then change the `GRUB_DEFAULT` value to boot using the previous kernel:
     ```sh

--- a/compute/instances/troubleshooting/reboot-from-faulty-kernel.mdx
+++ b/compute/instances/troubleshooting/reboot-from-faulty-kernel.mdx
@@ -62,7 +62,7 @@ categories:
     # /boot/grub/grub.cfg.
     # For full documentation of the options in this file, see:
     #   info -f grub -n 'Simple configuration'
-    
+
     GRUB_DEFAULT="1>2"
     GRUB_TIMEOUT=5
     GRUB_DISTRIBUTOR=`lsb_release -i -s 2> /dev/null || echo Debian`
@@ -91,7 +91,7 @@ categories:
 
  ### Examples of failed boots
 
-* In the followin example, the Instance may only boot with the root filesystem in `read-only` mode:
+* In the following example, the Instance may only boot with the root filesystem in `read-only` mode:
     ```sh
     [  OK  ] Finished Remove Stale Onli…ext4 Metadata Check Snapshots.
     [    4.219158] cloud-init[542]: Traceback (most recent call last):


### PR DESCRIPTION
### Description
Fixed small display error in command line style formatting
