### PR TITLE
docs(Kapsule): URL of cafe example for traefik have changed ext-fix-kapsule

### DIFF
--- a/tutorials/traefik-v2-cert-manager/index.mdx
+++ b/tutorials/traefik-v2-cert-manager/index.mdx
@@ -120,7 +120,7 @@ In this step, we deploy a test application called "tea coffee" which is only pri
 
 1. Use `kubectl` to create the application
     ```
-    $ kubectl create -f https://raw.githubusercontent.com/nginxinc/kubernetes-ingress/master/examples/complete-example/cafe.yaml
+    $ kubectl create -f https://raw.githubusercontent.com/nginxinc/kubernetes-ingress/main/examples/ingress-resources/complete-example/cafe.yaml
     ```
 2. Create an associated ingress object pointing to teacoffee.mytest.com by creating and editing the file `ingress-teacoffee.yml` in your favorite text editor:
     ```yaml


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Check that the commit messages match our requested structure.
- [x] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description
The URL for the cafe example service in the traefik2 tutorial have changed, this is the new url

