### PR TITLE
fix(apple): add instructions for Remmina

### DIFF
--- a/compute/apple-silicon/how-to/connect-to-mac-mini-m1.mdx
+++ b/compute/apple-silicon/how-to/connect-to-mac-mini-m1.mdx
@@ -43,6 +43,32 @@ You are now logged in and can launch applications just as if you were using your
 
 <Lightbox src="scaleway-m1-remote-desktop.webp" alt="" />
 
+## How to connect with Remmina on Linux OS
+
+If you are using Linux and you experience problems using the [VNC button](how-to-connect-via-vnc) to connect to your Mac mini M1, you can connect directly from a VNC client. In the example below, we use Remmina.
+
+1. [Download and install Remmina](https://remmina.org/how-to-install-remmina/), if necessary. Note that Remmina is included in most Linux distributions as standard, however.
+
+2. Open Remmina and click the square **+** icon in the top left of the screen to create a new quick connection.
+
+3. Enter the following parameters:
+    - **Protocol**: Remmina VNC Plugin
+    - **Server**: The Public IP address of your Mac mini M1, displayed on its **Overview** page in the Scaleway console.
+    - **Username**: `m1`
+    - **User password**: The VNC password of your Mac mini M1, displayed on its **Overview** page in the Scaleway console.
+    - **Color depth**: High color (16 bpp) or better, otherwise the connection will fail.
+
+4. Click **Save and connect** to save these settings for the future, and launch a connection to your Mac mini M1.
+
+You can now log in the graphical environment of macOS using the default user m1 and the VNC password.
+
+    <Message type="note">
+      macOS may ask you for your password once logged into the VNC session. Change the keyboard layout of macOS to your computer's local keyboard layout before entering the password. Click on U.S. keyboard in the top right corner, to display a list of all available keyboard layouts
+
+      <Lightbox src="scaleway-vnc-lang.webp" alt="" />
+    </Message>
+
+
 ## How to connect via SSH
 
 You can also connect directly to the terminal of your Mac mini M1 using the SSH protocol and your [SSH key](/console/my-account/concepts/#ssh-key). 


### PR DESCRIPTION
### Description
Add instructions for connecting to Mac mini via Remmina

