### PR TITLE
fix(lb): improve bucket website doc

### DIFF
--- a/network/load-balancer/how-to/create-load-balancer.mdx
+++ b/network/load-balancer/how-to/create-load-balancer.mdx
@@ -43,7 +43,7 @@ categories:
         - Proxy: select a [proxy protocol](/network/load-balancer/concepts/#proxy-protocol) option from the list. Depending on the type of health check you choose, you are prompted for additional information, for example HTTP healthchecks require a method (GET, PUT or POST, a URI and a response code).
         - Server IPs: enter the IP addresses of each of your backend servers.
     - Configure **advanced settings** if required:
-      - **S3 failover**: activate the feature and enter a Scaleway Object Storage [Bucket Website](/storage/object/concepts/#bucket-website) URL. If none of your backend servers are available, users will be redirected to this page. 
+      - **S3 failover**: activate the feature and enter a Scaleway Object Storage [Bucket Website](/storage/object/concepts/#bucket-website) URL (e.g. `https://my-bucket.s3-website.nl-ams.scw.cloud`). If none of your backend servers are available, users will be redirected to this page. 
 
       <Message type="note">
         The S3 failover feature is only available for Load Balancers using the HTTP protocol on their backend. Find out more about setting up a static website with Object Storage in our [dedicated documentation](/storage/object/how-to/use-bucket-website/).

--- a/network/load-balancer/how-to/set-up-s3-failover.mdx
+++ b/network/load-balancer/how-to/set-up-s3-failover.mdx
@@ -25,10 +25,9 @@ The **S3 failover** feature allows you to redirect users to a static website hos
 1. Follow the instructions for [creating a Load Balancer](/network/load-balancer/how-to/create-load-balancer/).
 2. Click the  **+Advanced Settings** button after step 5 of the creation wizard.
     <Lightbox src="scaleway-s3-failover.webp" alt="" />
-3. Slide the <Icon name="toggle" /> toggle to activate S3 failover, and enter a Scaleway Object Storage [Bucket Website](/storage/object/concepts/#bucket-website) URL in the **S3 link** box.
+3. Slide the <Icon name="toggle" /> toggle to activate S3 failover, and enter a Scaleway Object Storage [Bucket Website](/storage/object/concepts/#bucket-website) URL in the **S3 link** box. Note that the URL of the bucket endpoint is not sufficient, the bucket website URL is specifically required (e.g.`https://my-bucket.s3-website.nl-ams.scw.cloud`).
     <Message type="note">
       The S3 failover feature is only available for Load Balancers using the HTTP protocol on their backend.
-
     </Message>
 4. Click **Create a Load Balancer** to finish.
 
@@ -44,7 +43,7 @@ The **S3 failover** feature allows you to redirect users to a static website hos
     <Message type="note">
       The S3 failover feature is only available for Load Balancers using the HTTP protocol on their backend.
     </Message>
-7. Enter a Scaleway Object Storage [Bucket Website](/storage/object/concepts/#bucket-website) URL in the **S3 link** box, if activating the feature.
+7. Enter a Scaleway Object Storage [Bucket Website](/storage/object/concepts/#bucket-website) URL in the **S3 link** box, if activating the feature. Note that the URL of the bucket endpoint is not sufficient, the bucket website URL is specifically required (e.g.`https://my-bucket.s3-website.nl-ams.scw.cloud`).
 8. Click **Edit backend** to finish.
 
 ## How to create a static website for S3 failover

--- a/network/load-balancer/how-to/setup-ssl-offloading.mdx
+++ b/network/load-balancer/how-to/setup-ssl-offloading.mdx
@@ -102,7 +102,7 @@ You should now create or edit your frontend and backend with your SSL Certificat
     - **Health Check**: Configure a `HTTP` health check to detect if the backend application is available.
     - **Server IP(s)**: Enter the IP address of the server(s) running the backend application.
       - Configure **advanced settings** if required:
-        - **S3 failover**: activate the feature and enter a Scaleway Object Storage URL. If none of your backend servers are available, users will be redirected to this page.
+        - **S3 failover**: activate the feature and enter a Scaleway Object Storage bucket website URL. If none of your backend servers are available, users will be redirected to this page.
         - **[Sticky session](/network/load-balancer/concepts/#sticky-session)**: activate the feature and enter the name for a cookie that will bind users' sessions to specific backend servers. 
 8. Click the **Edit** or **Create** button as applicable to finish the process.
 9. Open a web browser and point it to https://common_name. Make sure to replace `common_name` with the main domain configured in the SSL certificate. The connection is now encrypted with SSL.

--- a/network/load-balancer/quickstart.mdx
+++ b/network/load-balancer/quickstart.mdx
@@ -43,7 +43,7 @@ categories:
         - Proxy: select a [proxy protocol](/network/load-balancer/concepts/#proxy-protocol) option from the list. Depending on the type of health check you choose, you are prompted for additional information, for example HTTP healthchecks require a method (GET, PUT or POST, a URI and a response code).
         - Server IPs: enter the IP addresses of each of your backend servers.
     - Configure **advanced settings** if required:
-      - **S3 failover**: activate the feature and enter a Scaleway Object Storage [Bucket Website](/storage/object/concepts/#bucket-website) URL. If none of your backend servers are available, users will be redirected to this page. 
+      - **S3 failover**: activate the feature and enter a Scaleway Object Storage [Bucket Website](/storage/object/concepts/#bucket-website) URL (e.g. `https://my-bucket.s3-website.nl-ams.scw.cloud`). If none of your backend servers are available, users will be redirected to this page. 
 
       <Message type="note">
         The S3 failover feature is only available for Load Balancers using the HTTP protocol on their backend. Find out more about setting up a static website with Object Storage in our [dedicated documentation](/storage/object/how-to/use-bucket-website/).


### PR DESCRIPTION
### Description
Make it clearer that the S3 failover link for Load Balancer has to be the bucket website URL, not the bucket endpoint
