### PR TITLE
docs(how-to): fix typo quanta kvm

### DIFF
--- a/dedibox/kvm-over-ip/how-to/quanta-computer.mdx
+++ b/dedibox/kvm-over-ip/how-to/quanta-computer.mdx
@@ -7,14 +7,14 @@ content:
   paragraph: This page explains how to use the KVM device of Quanta Computer servers
 tags: kvm quanta 
 dates:
-  validation: 2022-08-01
+  validation: 2022-12-01
   posted: 2021-07-16
 categories:
   - dedibox-servers
 ---
 
 
-This page shows you how to use [KVM](/dedibox/kvm-over-ip/concepts/#kvm-over-ip) on a Dedibox with HP KVM.
+This page shows you how to use [KVM](/dedibox/kvm-over-ip/concepts/#kvm-over-ip) on a Dedibox with Quanta Computer KVM.
 
 <Message type="requirement">
   - You have an account and are logged into the [Dedibox Console](https://console.online.net) 
@@ -39,7 +39,7 @@ The connection URL and your credentials display. Click on the link to access the
 ## Accessing the KVM-over-IP device 
 
 1. Open the connection URL of your KVM in your web browser, then log in using the credentials displayed during access creation. 
-2. Click **Remote Control** > **Console Redirection** in the menu. Download and exectute the Java applet.
+2. Click **Remote Control** > **Console Redirection** in the menu. Download and run the Java applet.
     <Lightbox src="scaleway_qct_console_redir.webp" alt="" />
 3. Click **Media** > **Virtual Media** in the KVM window.
     <Lightbox src="scaleway_qct_virtual_media.webp" alt="" />


### PR DESCRIPTION
### Description
Fixed a typo in the how-to for Quanta Computer KVM-over-IP devices
