### PR TITLE
docs(kubernetes): update cafe-ingress yaml file url

### DIFF
--- a/compute/kubernetes/api-cli/exposing-services.mdx
+++ b/compute/kubernetes/api-cli/exposing-services.mdx
@@ -73,7 +73,7 @@ By default, on Kubernetes Kapsule, a wildcard round-robin DNS record is created,
     ```
 2. Use a test application called `cafe-ingress`, to test the way it works. The application serves different web pages depending on the URL you type. Deploy it with the following command: 
     ```sh
-    $ kubectl create -f https://raw.githubusercontent.com/nginxinc/kubernetes-ingress/master/examples/complete-example/cafe.yaml
+    $ kubectl create -f https://raw.githubusercontent.com/nginxinc/kubernetes-ingress/main/examples/complete-example/cafe.yaml
     ```
 3. Create the ingress object with this YAML manifest, called `cafe-ingress.yml`. Please note that we use our DNS wildcard on the host stanza of this YAML file.
     ```yml


### PR DESCRIPTION
nginxinc/kubernetes-ingress master branch has been renamed to main: updating `kubectl create [...]` command.