### PR TITLE
provide correct information for encryption per volume

### DIFF
--- a/compute/kubernetes/api-cli/managing-storage.mdx
+++ b/compute/kubernetes/api-cli/managing-storage.mdx
@@ -183,8 +183,28 @@ parameters:
 
 all the PVC created with the StorageClass `scw-bssd-enc` will be encrypted at rest with the passphrase `myawesomepassphrase`.
 
-The [Per Volume Secret](https://kubernetes-csi.github.io/docs/secrets-and-credentials-storage-class.html#per-volume-secrets) can also be used to avoid having one passphrase per StorageClass.
+#### Per Volume Secret
 
+You can have a different encryption key per volume by defining such StorageClass
+
+```yaml
+allowVolumeExpansion: false # not yet supported
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: "scw-bssd-enc-per-vol"
+provisioner: csi.scaleway.com
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+parameters:
+  encrypted: "true"
+  csi.storage.k8s.io/node-publish-secret-namespace: ${pvc.namespace}
+  csi.storage.k8s.io/node-publish-secret-name: ${pvc.annotations['team.example.com/key']}
+```
+
+With this StorageClass, the encryptionkey is stored in one secret located in the same namespace than the PVC, the name of the secret being provided in the annotation `team.example.com/key` on this PVC.
+
+You can see different configurations on the [Official CSI Documentation](https://kubernetes-csi.github.io/docs/secrets-and-credentials-storage-class.html#per-volume-secrets) can also be used to avoid having one passphrase per StorageClass.
 
 <Navigation title="See Also">
   <PreviousButton to="/compute/kubernetes/api-cli/using-load-balancer-annotations/">Using Load Balancer annotations</PreviousButton>


### PR DESCRIPTION
In the documentation linked, it tells to use the following
```
  csi.storage.k8s.io/node-publish-secret-name: ${pvc.annotations['team.example.com/key']}
  csi.storage.k8s.io/node-publish-secret-namespace: ${pvc.namespace}
```
which does not work ( I opened a case with scw  because I was unable to have this working).

(tbh I don't know what means all these parameters)

### Your checklist for this pull request

- [ ] Check that the commit messages match our requested structure.
- [ ] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description
Please describe your pull request.

