### PR TITLE
docs(fix): fixed broken slack community link

### DIFF
--- a/index.mdx
+++ b/index.mdx
@@ -56,7 +56,7 @@ The goal of this document is to provide clients with information about every res
   <GeneralLinksItem
     icon="community"
     title="Slack Community"
-    href="https://scaleway-community.slack.com/join/shared_invite/zt-19uuwgo5h-bofWNwE~jijt70lQkziQxg#/shared-invite/email/"
+    href="https://slack.scaleway.com/"
   />
   <GeneralLinksItem
     icon="status"


### PR DESCRIPTION
### Description
Fixed broken slack community link on docs landing page
