### PR TITLE
fix(messaging): add supported actions tables

### DIFF
--- a/compute/messaging/reference-content/sns-support.mdx
+++ b/compute/messaging/reference-content/sns-support.mdx
@@ -1,0 +1,226 @@
+---
+meta:
+  title: SNS - Supported Actions
+  description: Discover which SNS AWS API actions are supported by Scaleway Messaging and Queuing
+content:
+  h1: SNS - Supported Actions
+  paragraph: Discover which SNS AWS API actions are supported by Scaleway Messaging and Queuing
+tags: messaging
+categories: 
+  - messaging
+---
+
+This page lists all actions described in the AWS SNS documentation, and states whether they are supported by Scaleway Messaging and Queuing.
+
+- **Y** means the parameter is fully supported
+- **N** means the parameter is not supported
+- **P** means the parameter is partially supported (see associated comments for more details)
+
+## CreateTopic
+
+CreateTopic requires the `CanManage` permission.
+
+### CreateTopic Request
+
+| Parameters            |  Support  | Comments                                                                                          |
+|:----------------------|:---------:|:--------------------------------------------------------------------------------------------------|
+| Attributes (map)      |   **P**   | See supported attributes in the [SNS Topic Attributes](#sns-api-support-topic-attributes) section |
+| Name                  |   **Y**   |                                                                                                   |
+| Tags.member.N (array) |   **N**   |                                                                                                   |
+
+### CreateTopic Response
+
+| Elements   |  Support  | Comments   |
+|:-----------|:---------:|:-----------|
+| TopicArn   |   **Y**   |            |
+
+## DeleteTopic
+
+DeleteTopic requires the `CanManage` permission.
+
+### DeleteTopic Request
+
+| Parameters   |  Support  | Comments   |
+|:-------------|:---------:|:-----------|
+| TopicArn     |   **Y**   |            |
+
+## ListTopics
+
+ListTopics requires the `CanManage` permission.
+
+### ListTopics Request
+
+| Parameters   |  Support  | Comments   |
+|:-------------|:---------:|:-----------|
+| NextToken    |   **N**   |            |
+
+### ListTopics Response
+
+| Elements                |  Support  | Comments   |
+|:------------------------|:---------:|:-----------|
+| NextToken               |   **N**   |            |
+| Topics.member.N (array) |   **Y**   |            |
+
+## ListSubscriptions
+
+ListSubscriptions requires the `CanManage` permission.
+
+### ListSubscriptions Request
+
+| Parameters   |  Support  | Comments   |
+|:-------------|:---------:|:-----------|
+| NextToken    |   **N**   |            |
+
+### ListSubscriptions Response
+
+| Elements                       |  Support  | Comments   |
+|:-------------------------------|:---------:|:-----------|
+| NextToken                      |   **N**   |            |
+| Subscriptions.member.N (array) |   **Y**   |            |
+
+## ListSubscriptionsByTopic
+
+ListSubscriptionsByTopic requires the `CanManage` permission.
+
+### ListSubscriptionsByTopic Request
+
+| Parameters   |  Support  | Comments   |
+|:-------------|:---------:|:-----------|
+| NextToken    |   **N**   |            |
+| TopicArn     |   **Y**   |            |
+
+### ListSubscriptionsByTopic Response
+
+| Elements                       |  Support  | Comments   |
+|:-------------------------------|:---------:|:-----------|
+| NextToken                      |   **N**   |            |
+| Subscriptions.member.N (array) |   **Y**   |            |
+
+## Publish
+
+Publish requires the `CanPublish` permission.
+
+### Publish Request
+
+| Parameters             |  Support  | Comments   |
+|:-----------------------|:---------:|:-----------|
+| Message                |   **Y**   |            |
+| MessageAttributes      |   **N**   |            |
+| MessageDeduplicationId |   **Y**   |            |
+| MessageGroupId         |   **N**   |            |
+| MessageStructure       |   **N**   |            |
+| PhoneNumber            |   **N**   |            |
+| Subject                |   **Y**   |            |
+| TargetArn              |   **N**   |            |
+| TopicArn               |   **Y**   |            |
+
+### Publish Response
+
+| Elements       |  Support  | Comments   |
+|:---------------|:---------:|:-----------|
+| MessageId      |   **Y**   |            |
+| SequenceNumber |   **N**   |            |
+
+## Subscribe
+
+Subscribe requires the `CanReceive` permission.
+
+### Subscribe Request
+
+| Parameters            |  Support  | Comments                                                                                                        |
+|:----------------------|:---------:|:----------------------------------------------------------------------------------------------------------------|
+| Attributes (map)      |   **P**   | See supported attributes in the [SNS Subscription Attributes](#sns-api-support-subscription-attributes) section |
+| Endpoint              |   **Y**   | Note that for lambda, the endpoint must be the Scaleway Serverless Function public URL                             |
+| Protocol              |   **P**   | Only http, sqs and lambda protocols are supported                                                               |
+| ReturnSubscriptionArn |   **N**   | The subscription arn is always returned (even for pending subscriptions)                                        |
+| TopicArn              |   **Y**   |                                                                                                                 |
+
+### Subscribe Response
+
+| Elements        |  Support  | Comments   |
+|:----------------|:---------:|:-----------|
+| SubscriptionArn |   **Y**   |            |
+
+## Unsubscribe
+
+Unsubscribe requires the `CanReceive or CanManage` permission.
+
+### Unsubscribe Request
+
+| Parameters      |  Support  | Comments   |
+|:----------------|:---------:|:-----------|
+| SubscriptionArn |   **Y**   |            |
+
+## GetTopicAttributes
+
+GetTopicAttributes requires the `CanManage` permission.
+
+### GetTopicAttributes Request
+
+| Parameters   |  Support  | Comments   |
+|:-------------|:---------:|:-----------|
+| TopicArn     |   **Y**   |            |
+
+### GetTopicAttributes Response
+
+| Elements         |  Support  | Comments                                                                                          |
+|:-----------------|:---------:|:--------------------------------------------------------------------------------------------------|
+| Attributes (map) |   **P**   | See supported attributes in the [SNS Topic Attributes](#sns-api-support-topic-attributes) section |
+
+## SetTopicAttributes
+
+SetTopicAttributes requires the `CanManage` permission.
+
+### SetTopicAttributes Request
+
+| Parameters     |  Support  | Comments                                                                                          |
+|:---------------|:---------:|:--------------------------------------------------------------------------------------------------|
+| AttributeName  |   **P**   | See supported attributes in the [SNS Topic Attributes](#sns-api-support-topic-attributes) section |
+| AttributeValue |   **Y**   |                                                                                                   |
+| TopicArn       |   **Y**   |                                                                                                   |
+
+## ConfirmSubscription
+
+ConfirmSubscription requires the `None` permission.
+
+### ConfirmSubscription Request
+
+| Parameters                |  Support  | Comments   |
+|:--------------------------|:---------:|:-----------|
+| AuthenticateOnUnsubscribe |   **N**   |            |
+| Token                     |   **Y**   |            |
+| TopicArn                  |   **Y**   |            |
+
+### ConfirmSubscription Response
+
+| Elements        |  Support  | Comments   |
+|:----------------|:---------:|:-----------|
+| SubscriptionArn |   **Y**   |            |
+
+### SNS API support - Topic attributes
+
+| Attribute Name            |  Support  | Comments                                              |
+|:--------------------------|:---------:|:------------------------------------------------------|
+| ContentBasedDeduplication |   **Y**   |                                                       |
+| DeliveryPolicy            |   **N**   |                                                       |
+| DisplayName               |   **N**   |                                                       |
+| EffectiveDeliveryPolicy   |   **N**   |                                                       |
+| FifoTopic                 |   **Y**   |                                                       |
+| KmsMasterKeyId            |   **N**   |                                                       |
+| Owner                     |   **Y**   |                                                       |
+| Policy                    |   **N**   |                                                       |
+| SignatureVersion          |   **N**   | Version 1 is always used, version 2 is not supported. |
+| SubscriptionsConfirmed    |   **Y**   |                                                       |
+| SubscriptionsDeleted      |   **Y**   |                                                       |
+| SubscriptionsPending      |   **Y**   |                                                       |
+| TopicArn                  |   **Y**   |                                                       |
+
+### SNS API support - Subscription attributes
+
+| Attribute Name      |  Support  | Comments   |
+|:--------------------|:---------:|:-----------|
+| DeliveryPolicy      |   **N**   |            |
+| FilterPolicy        |   **N**   |            |
+| RawMessageDelivery  |   **N**   |            |
+| RedrivePolicy       |   **Y**   |            |
+| SubscriptionRoleArn |   **N**   |            |

--- a/compute/messaging/reference-content/sqs-support.mdx
+++ b/compute/messaging/reference-content/sqs-support.mdx
@@ -1,0 +1,284 @@
+---
+meta:
+  title: SQS - Supported Actions
+  description: Discover which SQS AWS API actions are supported by Scaleway Messaging and Queuing
+content:
+  h1: SQS - Supported Actions
+  paragraph: Discover which SQS AWS API actions are supported by Scaleway Messaging and Queuing
+tags: messaging
+categories: 
+  - messaging
+---
+
+This page lists all actions described in the AWS SQS documentation, and states whether they are supported by Scaleway Messaging and Queuing.
+
+- **Y** means the parameter is fully supported
+- **N** means the parameter is not supported
+- **P** means the parameter is partially supported (see associated comments for more details)
+
+## CreateQueue
+
+CreateQueue requires the `CanManage` permission.
+
+### CreateQueue Request
+
+| Parameters      |  Support  | Comments                                                                                          |
+|:----------------|:---------:|:--------------------------------------------------------------------------------------------------|
+| Attribute (map) |   **P**   | See supported attributes in the [SQS Queue Attributes](#sqs-api-support-queue-attributes) section |
+| QueueName       |   **Y**   | See AWS documentation for naming conventions (FIFO queues are supported)                          |
+| Tag             |   **N**   |                                                                                                   |
+
+### CreateQueue Response
+
+| Elements   |  Support  | Comments   |
+|:-----------|:---------:|:-----------|
+| QueueUrl   |   **Y**   |            |
+
+## ReceiveMessage
+
+ReceiveMessage requires the `CanReceive` permission.
+
+### ReceiveMessage Request
+
+| Parameters              |  Support  | Comments                                                                                              |
+|:------------------------|:---------:|:------------------------------------------------------------------------------------------------------|
+| AttributeName.N (array) |   **P**   | See supported attributes in the [SQS Message Attributes](#sqs-api-support-message-attributes) section |
+| MaxNumberOfMessages     |   **Y**   |                                                                                                       |
+| MessageAttributeName.N  |   **N**   |                                                                                                       |
+| QueueUrl                |   **Y**   |                                                                                                       |
+| ReceiveRequestAttemptId |   **N**   |                                                                                                       |
+| VisibilityTimeout       |   **N**   |                                                                                                       |
+| WaitTimeSeconds         |   **N**   |                                                                                                       |
+
+### ReceiveMessage Response
+
+| Elements                         |  Support  | Comments                                                                                              |
+|:---------------------------------|:---------:|:------------------------------------------------------------------------------------------------------|
+| Message.N.Attribute              |   **P**   | See supported attributes in the [SQS Message Attributes](#sqs-api-support-message-attributes) section |
+| Message.N.Body                   |   **Y**   |                                                                                                       |
+| Message.N.MD5OfBody              |   **Y**   |                                                                                                       |
+| Message.N.MD5OfMessageAttributes |   **Y**   |                                                                                                       |
+| Message.N.MessageAttribute       |   **Y**   |                                                                                                       |
+| Message.N.MessageId              |   **Y**   |                                                                                                       |
+| Message.N.ReceiptHandle          |   **Y**   |                                                                                                       |
+
+## SendMessage
+
+SendMessage requires the `CanPublish` permission.
+
+### SendMessage Request
+
+| Parameters             |  Support  | Comments   |
+|:-----------------------|:---------:|:-----------|
+| DelaySeconds           |   **N**   |            |
+| MessageAttribute (map) |   **Y**   |            |
+| MessageBody            |   **Y**   |            |
+| MessageDeduplicationId |   **Y**   |            |
+| MessageGroupId         |   **N**   |            |
+| MessageSystemAttribute |   **N**   |            |
+| QueueUrl               |   **Y**   |            |
+
+### SendMessage Response
+
+| Elements                     |  Support  | Comments   |
+|:-----------------------------|:---------:|:-----------|
+| MD5OfMessageAttributes       |   **Y**   |            |
+| MD5OfMessageBody             |   **Y**   |            |
+| MD5OfMessageSystemAttributes |   **N**   |            |
+| MessageId                    |   **Y**   |            |
+| SequenceNumber               |   **Y**   |            |
+
+## SendMessageBatch
+
+SendMessageBatch requires the `CanPublish` permission.
+
+### SendMessageBatch Request
+
+| Parameters                             |  Support  | Comments                                                                                                            |
+|:---------------------------------------|:---------:|:--------------------------------------------------------------------------------------------------------------------|
+| QueueUrl                               |   **Y**   |                                                                                                                     |
+| SendMessageBatchRequestEntry.N (array) |   **P**   | As with the SendMessage action, the DelaySeconds, MessageGroupId and MessageSystemAttribute parameters are not supported |
+
+### SendMessageBatch Response
+
+| Elements                              |  Support  | Comments                                       |
+|:--------------------------------------|:---------:|:-----------------------------------------------|
+| BatchResultErrorEntry.N (array)       |   **Y**   |                                                |
+| SendMessageBatchResultEntry.N (array) |   **P**   | All fields are supported except MD5OfMessageSystemAttributes |
+
+## ListQueues
+
+ListQueues requires the `CanManage` permission.
+
+### ListQueues Request
+
+| Parameters      |  Support  | Comments   |
+|:----------------|:---------:|:-----------|
+| MaxResults      |   **N**   |            |
+| NextToken       |   **N**   |            |
+| QueueNamePrefix |   **Y**   |            |
+
+### ListQueues Response
+
+| Elements           |  Support  | Comments   |
+|:-------------------|:---------:|:-----------|
+| NextToken          |   **N**   |            |
+| QueueUrl.N (array) |   **Y**   |            |
+
+## DeleteMessage
+
+DeleteMessage requires the `CanReceive` permission.
+
+### DeleteMessage Request
+
+| Parameters    |  Support  | Comments   |
+|:--------------|:---------:|:-----------|
+| QueueUrl      |   **Y**   |            |
+| ReceiptHandle |   **Y**   |            |
+
+## DeleteMessageBatch
+
+DeleteMessageBatch requires the `CanReceive` permission.
+
+### DeleteMessageBatch Request
+
+| Parameters                               |  Support  | Comments   |
+|:-----------------------------------------|:---------:|:-----------|
+| DeleteMessageBatchRequestEntry.N (array) |   **Y**   |            |
+| QueueUrl                                 |   **Y**   |            |
+
+### DeleteMessageBatch Response
+
+| Elements                                |  Support  | Comments   |
+|:----------------------------------------|:---------:|:-----------|
+| BatchResultErrorEntry.N (array)         |   **Y**   |            |
+| DeleteMessageBatchResultEntry.N (array) |   **Y**   |            |
+
+## DeleteQueue
+
+DeleteQueue requires the `CanManage` permission.
+
+### DeleteQueue Request
+
+| Parameters   |  Support  | Comments   |
+|:-------------|:---------:|:-----------|
+| QueueUrl     |   **Y**   |            |
+
+## GetQueueUrl
+
+GetQueueUrl requires the `CanManage` permission.
+
+### GetQueueUrl Request
+
+| Parameters             |  Support  | Comments   |
+|:-----------------------|:---------:|:-----------|
+| QueueName              |   **Y**   |            |
+| QueueOwnerAWSAccountId |   **Y**   |            |
+
+### GetQueueUrl Response
+
+| Elements   |  Support  | Comments   |
+|:-----------|:---------:|:-----------|
+| QueueUrl   |   **Y**   |            |
+
+## GetQueueAttributes
+
+GetQueueAttributes requires the `CanManage` permission.
+
+### GetQueueAttributes Request
+
+| Parameters              |  Support  | Comments                                                                                          |
+|:------------------------|:---------:|:--------------------------------------------------------------------------------------------------|
+| AttributeName.N (array) |   **P**   | See supported attributes in the [SQS Queue Attributes](#sqs-api-support-queue-attributes) section |
+| QueueUrl                |   **Y**   |                                                                                                   |
+
+### GetQueueAttributes Response
+
+| Elements        |  Support  | Comments                                                                                          |
+|:----------------|:---------:|:--------------------------------------------------------------------------------------------------|
+| Attribute (map) |   **P**   | See supported attributes in the [SQS Queue Attributes](#sqs-api-support-queue-attributes) section |
+
+## SetQueueAttributes
+
+SetQueueAttributes requires the `CanManage` permission.
+
+### SetQueueAttributes Request
+
+| Parameters      |  Support  | Comments                                                                                          |
+|:----------------|:---------:|:--------------------------------------------------------------------------------------------------|
+| Attribute (map) |   **P**   | See supported attributes in the [SQS Queue Attributes](#sqs-api-support-queue-attributes) section |
+| QueueUrl        |   **Y**   |                                                                                                   |
+
+## ChangeMessageVisibility
+
+ChangeMessageVisibility requires the `CanManage` permission.
+
+### ChangeMessageVisibility Request
+
+| Parameters        |  Support  | Comments                                                        |
+|:------------------|:---------:|:----------------------------------------------------------------|
+| QueueUrl          |   **Y**   |                                                                 |
+| ReceiptHandle     |   **Y**   |                                                                 |
+| VisibilityTimeout |   **P**   | Only '0' and the current queue visibility timeout are supported |
+
+## ChangeMessageVisibilityBatch
+
+ChangeMessageVisibilityBatch requires the `CanManage` permission.
+
+### ChangeMessageVisibilityBatch Request
+
+| Parameters                                        |  Support  | Comments                                                                            |
+|:--------------------------------------------------|:---------:|:------------------------------------------------------------------------------------|
+| QueueUrl                                          |   **Y**   |                                                                                     |
+| ChangeMessageVisibilityBatchResultEntry.N (array) |   **P**   | The same VisibilityTimeout values are supported as for [ChangeMessageVisibility](#changemessagevisibility) |
+
+## PurgeQueue
+
+PurgeQueue requires the `CanManage` permission.
+
+### PurgeQueue Request
+
+| Parameters   |  Support  | Comments   |
+|:-------------|:---------:|:-----------|
+| QueueUrl     |   **Y**   |            |
+
+### SQS API support - Queue attributes
+
+| Attribute Name                        |  Support  | Comments   |
+|:--------------------------------------|:---------:|:-----------|
+| All                                   |   **Y**   |            |
+| ApproximateNumberOfMessages           |   **Y**   |            |
+| ApproximateNumberOfMessagesDelayed    |   **N**   |            |
+| ApproximateNumberOfMessagesNotVisible |   **Y**   |            |
+| ContentBasedDeduplication             |   **Y**   |            |
+| CreatedTimestamp                      |   **Y**   |            |
+| DeduplicationScope                    |   **N**   |            |
+| DelaySeconds                          |   **N**   |            |
+| FifoQueue                             |   **Y**   |            |
+| FifoThroughputLimit                   |   **N**   |            |
+| KmsDataKeyReusePeriodSeconds          |   **N**   |            |
+| KmsMasterKeyId                        |   **N**   |            |
+| LastModifiedTimestamp                 |   **N**   |            |
+| MaximumMessageSize                    |   **Y**   |            |
+| MessageRetentionPeriod                |   **Y**   |            |
+| Policy                                |   **N**   |            |
+| QueueArn                              |   **Y**   |            |
+| ReceiveMessageWaitTimeSeconds         |   **N**   |            |
+| RedriveAllowPolicy                    |   **N**   |            |
+| RedrivePolicy                         |   **N**   |            |
+| SqsManagedSseEnabled                  |   **N**   |            |
+| VisibilityTimeout                     |   **Y**   |            |
+
+### SQS API support - Message attributes
+
+| Attribute Name                   |  Support  | Comments   |
+|:---------------------------------|:---------:|:-----------|
+| All                              |   **Y**   |            |
+| ApproximateFirstReceiveTimestamp |   **N**   |            |
+| ApproximateReceiveCount          |   **Y**   |            |
+| AWSTraceHeader                   |   **N**   |            |
+| MessageDeduplicationId           |   **Y**   |            |
+| MessageGroupId                   |   **N**   |            |
+| SequenceNumber                   |   **Y**   |            |
+| SenderId                         |   **Y**   |            |
+| SentTimestamp                    |   **Y**   |            |


### PR DESCRIPTION
### Description
Add the tables of which actions are supported by SCW Messaging and Queuing. (Currently/previously hosted on the developers doc)
