### PR TITLE
docs(serverless function): homogenise punctuation and fix indentation

### DIFF
--- a/serverless/functions/api-cli/fun-uploading-with-serverless-framework.mdx
+++ b/serverless/functions/api-cli/fun-uploading-with-serverless-framework.mdx
@@ -54,10 +54,11 @@ The `serverless.yml` file contains the configuration of a namespace containing o
 
 The different parameters are:
 - `service`: your namespace name.
-- `provider.runtime`: the runtime of your functions ([check the supported runtimes](/serverless/functions/reference-content/functions-lifecycle/)).
-- `provider.env`: the environment variables attached to your namespace are injected into all your namespace containers.
-- `scwToken`: the Scaleway **token** you got in prerequisites.
-- `scwProject`: the Scaleway **Project ID**.
+- `provider`: settings related to Scaleway, your cloud provider.
+  - `runtime`: the runtime of your functions ([check the supported runtimes](/serverless/functions/reference-content/functions-lifecycle/)).
+  - `env`: the environment variables attached to your namespace are injected into all your namespace containers.
+  - `scwToken`: the Scaleway **token** you got in prerequisites.
+  - `scwProject`: the Scaleway **Project ID**.
 - `package.patterns`: usually, this parameter does not need to be configured. It allows you to include or exclude directories from the deployment.
 - `functions`: Configuration of your functions. It is a `yml` dictionary, with the key being the functions' name.
   - `handler` (Required): file or function which will be executed.

--- a/serverless/functions/api-cli/fun-uploading-with-serverless-framework.mdx
+++ b/serverless/functions/api-cli/fun-uploading-with-serverless-framework.mdx
@@ -53,18 +53,18 @@ Serverless Framework enables you to create a project using a specific template.
 The `serverless.yml` file contains the configuration of a namespace containing one or more functions with the same runtime. In the following example, we use one function and a `python3` runtime. 
 
 The different parameters are:
-- `service`: your namespace name
-- `provider.runtime`: the runtime of your functions ([check the supported runtimes](/serverless/functions/reference-content/functions-lifecycle/))
-- `provider.env`: the environment variables attached to your namespace are injected into all your namespace containers
-- `scwToken`: the Scaleway **token** you got in prerequisites
-- `scwProject`: the Scaleway **Project ID** 
-- `package.patterns`: usually, this parameter does not need to be configured. It allows you to include or exclude directories from the deployment
-- `functions`: Configuration of your functions. It is a `yml` dictionary, with the key being the functions' name
-  - `handler` (Required): file or function which will be executed. 
-  - `env` (Optional): environment variables specifics for the current function
-  - `minScale` (Optional): how many function instances we keep running (default: 0)
-  - `maxScale` (Optional): maximum number of instances this function can scale to (default: 20)
-  - `memoryLimit`: RAM allocated to the function instances. 
+- `service`: your namespace name.
+- `provider.runtime`: the runtime of your functions ([check the supported runtimes](/serverless/functions/reference-content/functions-lifecycle/)).
+- `provider.env`: the environment variables attached to your namespace are injected into all your namespace containers.
+- `scwToken`: the Scaleway **token** you got in prerequisites.
+- `scwProject`: the Scaleway **Project ID**.
+- `package.patterns`: usually, this parameter does not need to be configured. It allows you to include or exclude directories from the deployment.
+- `functions`: Configuration of your functions. It is a `yml` dictionary, with the key being the functions' name.
+  - `handler` (Required): file or function which will be executed.
+  - `env` (Optional): environment variables specifics for the current function.
+  - `minScale` (Optional): how many function instances we keep running (default: 0).
+  - `maxScale` (Optional): maximum number of instances this function can scale to (default: 20).
+  - `memoryLimit`: RAM allocated to the function instances.
   - `runtime`: (Optional) runtime of the function. Can be used when you need to deploy multiple functions with different runtimes in your Serverless Project. If absent, `provider.runtime` will be used.
   - `events` (Optional): List of events that trigger your functions (e.g, trigger a function based on a schedule with `CRONJobs`). 
 
@@ -259,9 +259,9 @@ With `events`, you may link your containers to specific triggers. For the moment
 
 Below is a list of supported triggers for Scaleway Serverless, and the configuration parameters required to deploy them:
 
-- **schedule**: Triggers your container based on CRON schedules
-  - `rate`: the CRON Schedule (UNIX Format) on which your functions will be executed
-  - `input`: key-value mapping to define arguments that will be passed to your function's event object during execution
+- **schedule**: Triggers your container based on CRON schedules.
+  - `rate`: the CRON Schedule (UNIX Format) on which your functions will be executed.
+  - `input`: key-value mapping to define arguments that will be passed to your function's event object during execution.
 
 To link a Trigger to your function, you can define an `events` key in your function:
 


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Check that the commit messages match our requested structure.
- [x] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description
Some part of the documentation are still inconsistent in punctuation. Examples can be found in this PR. Also, some indentation in collections related to `yml` collections is not correct and causes the user with no experience to an issue while running the commands.

About the commit message, for the first one I tried a shorter version. Please confirm which is better, `docs(func)` or `docs(serverless function)` which is perhaps more explicit, but longer (and I do want to keep 50 chars max for the short description!).