### PR TITLE
docs(kapsule): no more advanced options on cluster create page int-fix-k8s

### DIFF
--- a/containers/kubernetes/how-to/create-cluster.mdx
+++ b/containers/kubernetes/how-to/create-cluster.mdx
@@ -39,7 +39,7 @@ This document concerns the creation and management of a **Kubernetes Kapsule** c
       * **Kubernetes Kosmos** allows you to attach an Instance or dedicated server from any Cloud provider to a Scaleway Kubernetes control plane.
     * The geographical **region** of the cluster.
     * The Kubernetes **version** for the cluster.
-    * The **name** for the cluster and optionally a description, tags, which can help you to organize your cluster. Keep the default settings if you don't know what these values mean
+    * The **name** for the cluster and optionally a description, and tags, which can help you to organize your cluster. Keep the default settings if you don't know what these values mean.
 4. Click **Next**. The second page of the cluster creation wizard displays. 
 5. This page concerns the settings for your pool. Enter the following information:
     * The **availability zone** in which all your pool's nodes will be created

--- a/containers/kubernetes/how-to/create-cluster.mdx
+++ b/containers/kubernetes/how-to/create-cluster.mdx
@@ -38,9 +38,8 @@ This document concerns the creation and management of a **Kubernetes Kapsule** c
       * **Kubernetes Kapsule** allows you to create clusters exclusively of Scaleway Instances, and includes features such as node auto-healing and pool auto-scaling.
       * **Kubernetes Kosmos** allows you to attach an Instance or dedicated server from any Cloud provider to a Scaleway Kubernetes control plane.
     * The geographical **region** of the cluster.
-    * The Kubernetes **version** for the cluster
-    * The **name** for the cluster and optionally a description
-    * If required, configure **advanced options**, including the container network interface, the ingress controller and cluster tags, which can help you to organize your cluster. Keep the default settings if you don't know what these values mean
+    * The Kubernetes **version** for the cluster.
+    * The **name** for the cluster and optionally a description, tags, which can help you to organize your cluster. Keep the default settings if you don't know what these values mean
 4. Click **Next**. The second page of the cluster creation wizard displays. 
 5. This page concerns the settings for your pool. Enter the following information:
     * The **availability zone** in which all your pool's nodes will be created

--- a/containers/kubernetes/quickstart.mdx
+++ b/containers/kubernetes/quickstart.mdx
@@ -31,8 +31,7 @@ Scaleway [Kubernetes Kapsule and Kosmos](/containers/kubernetes/concepts/#kubern
       * **Kubernetes Kosmos** cluster. Kubernetes Kosmos is the first managed Kubernetes engine that allows you to attach an Instance or dedicated server from any Cloud provider to a Scaleway Kubernetes control plane.
     * The geographical **region** of the cluster.
     * The Kubernetes **version** for the cluster.
-    * The **name** for the cluster and optionally a description.
-    * On **Kubernetes Kapsule** clusters, you can, if required, configure **advanced options**. These include the container network interface, the ingress controller, and cluster tags, which can help you to organize your cluster. Keep the default settings if you do not know what these values mean.
+    * The **name** for the cluster and optionally a description, tags, which can help you to organize your cluster. 
 4. * If you are creating a **Kubernetes Kapsule** cluster, click **Next**. The second page of the cluster creation wizard displays.
    * If you are creating a **Kubernetes Kosmos** cluster, click **Create a cluster** to create cluster without any pools. You can add them to the cluster later. Otherwise, click **Add and configure a Pool** to configure a node pool for your cluster.
 5.  This page concerns the settings for your pool if you create a **Kubernetes Kapsule** cluster or if you want to use Scaleway nodes for your cluster with **Kubernetes Kosmos**. Enter the following information:


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Check that the commit messages match our requested structure.
- [X] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description
Kubernetes console do not offer an "advanced options" button anymore, tags and description have moved under name step.
