### PR TITLE
fix(instances): wrong URL to backup an instance

### DIFF
--- a/compute/instances/api-cli/creating-backups.mdx
+++ b/compute/instances/api-cli/creating-backups.mdx
@@ -24,7 +24,7 @@ The Backup feature is used to back up your Instance data. It creates an image of
 
 A backup is created using the command:
 ```
-POST https://api.scaleway.com/instance/v1/zones/<region>/<uid>/action
+POST https://api.scaleway.com/instance/v1/zones/<region>/servers/<uid>/action
 {"action":"backup"}
 ```
 


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Check that the commit messages match our requested structure.
- [x] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description
The URL to backup an instance was missing the `/servers` part, cf. the API documentation: https://developers.scaleway.com/en/products/instance/api/#post-049a5b

