### PR TITLE
feat(changelog): kubernetes-removed-kubernetes-1.20-is-no 2023-01-25

### DIFF
--- a/changelog/january2023/2023-01-25-kubernetes-removed-kubernetes-1.20-is-no.mdx
+++ b/changelog/january2023/2023-01-25-kubernetes-removed-kubernetes-1.20-is-no.mdx
@@ -1,0 +1,13 @@
+---
+title: Kubernetes 1.20 is no longer supported on our Kubernetes products starting January 15th
+status: removed
+author:
+    fullname: 'Join the #k8s channel on Slack.'
+    url: 'https://slack.scaleway.com'
+date: 2023-01-25
+category: compute
+product: kubernetes
+---
+
+Kubernetes 1.20 is no longer supported on our [Kubernetes products](https://www.scaleway.com/en/docs/containers/kubernetes/quickstart) starting January 15th. Clusters in this specific version will automatically be upgraded to 1.21 on February 15th, 2023.
+


### PR DESCRIPTION
Reporter: Thibault Genaitay

This PR is a new changelog contribution. It has been created automatically.

Make sure to review it carefully before merging it.