### PR TITLE
docs(k8s): k8s moved from compute to containers in console Int-fix-k8s

### DIFF
--- a/containers/kubernetes/how-to/create-cluster.mdx
+++ b/containers/kubernetes/how-to/create-cluster.mdx
@@ -29,7 +29,7 @@ To administrate your Kubernetes Cluster easily, Scaleway provides a `.kubeconfig
 
 This document concerns the creation and management of a **Kubernetes Kapsule** cluster. To create a Kubernetes Kosmos Cluster, refer to the [alternative documentation](/containers/kubernetes/how-to/create-kosmos-cluster)
 
-1. Click **Kubernetes** in the **Compute** section of the [Scaleway Console](https://console.scaleway.com) side menu. The Kubernetes Kapsule dashboard displays.
+1. Click **Kubernetes** in the **Containers** section of the [Scaleway Console](https://console.scaleway.com) side menu. The Kubernetes Kapsule dashboard displays.
 2. Click **Create a cluster**. The first page of the cluster creation wizard displays. This concerns the configuration of your cluster.
 3. Complete the following steps of the wizard:
     <Lightbox src="scaleway-choose-cluster-type.webp" alt="" />    

--- a/containers/kubernetes/how-to/create-kosmos-cluster.mdx
+++ b/containers/kubernetes/how-to/create-kosmos-cluster.mdx
@@ -26,7 +26,7 @@ Kubernetes Kosmos provides an alternative to a classic [Kubernetes Kapsule](/con
   Be aware that auto scaling and auto healing features are not available on external providers' nodes within Kosmos clusters. Since Scaleway does not have access to your other providers' accounts, it is not possible to carry out actions such as automatic deletion, creation,and reboot of external nodes.
 </Message>
 
-1. Click **Kubernetes** in the **Compute** section of the [Scaleway Console](https://console.scaleway.com) side menu. The Kubernetes dashboard displays.
+1. Click **Kubernetes** in the **Containers** section of the [Scaleway Console](https://console.scaleway.com) side menu. The Kubernetes dashboard displays.
 2. Click **Create a cluster**. The first page of the cluster creation wizard displays. This concerns the configuration of your cluster.
 3. Complete the following steps of the wizard:
     <Lightbox src="scaleway-choose-cluster-type.webp" alt="" />    

--- a/containers/kubernetes/how-to/delete-cluster.mdx
+++ b/containers/kubernetes/how-to/delete-cluster.mdx
@@ -20,7 +20,7 @@ categories:
   - You have [created](/containers/kubernetes/how-to/create-cluster) a Kubernetes Kapsule cluster
 </Message>
 
-1. Click **Kubernetes** in the **Compute** section of the [Scaleway Console](https://console.scaleway.com) side menu. The Kubernetes Kapsule dashboard displays.
+1. Click **Kubernetes** in the **Containers** section of the [Scaleway Console](https://console.scaleway.com) side menu. The Kubernetes Kapsule dashboard displays.
 2. Click <Icon name="more" /> next to the cluster you wish to delete, then click **Delete** on the drop-down menu. A cluster deletion pop-up displays. 
     <Lightbox src="scaleway-kapsule_cluster_menu.webp" alt="" />
 3. Type **DELETE** to confirm the deletion of your cluster. Tick the checkbox to automatically delete all volumes (including those with volume type “retain”) and Load Balancers whose names start with cluster ID. Validate your choice by clicking **Delete this cluster**. 

--- a/containers/kubernetes/how-to/deploy-ingress-controller.mdx
+++ b/containers/kubernetes/how-to/deploy-ingress-controller.mdx
@@ -22,7 +22,7 @@ An [Ingress Controller](/containers/kubernetes/concepts/#ingress-controller) is 
   - You have [created](/containers/kubernetes/how-to/create-cluster/) a Kubernetes Kapsule cluster
 </Message>
 
-1. Click **Kubernetes** in the **Compute** section of the [Scaleway Console](https://console.scaleway.com) side menu. The Kubernetes Kapsule dashboard displays.
+1. Click **Kubernetes** in the **Containers** section of the [Scaleway Console](https://console.scaleway.com) side menu. The Kubernetes Kapsule dashboard displays.
 2. Click the name of the cluster you want to edit. The cluster dashboard displays.
 3. Click the **Easy Deploy** tab to display the Easy Deploy feature. Then click **Deploy an application**.
     <Lightbox src="scaleway-kubernetes-easy-deploy-feature.webp" alt="" />

--- a/containers/kubernetes/how-to/edit-cluster.mdx
+++ b/containers/kubernetes/how-to/edit-cluster.mdx
@@ -24,7 +24,7 @@ You can manage and edit the parameters of your cluster from the [Scaleway Consol
 
 ## How to manage a Kubernetes Kapsule cluster
 
-1. Click **Kubernetes** in the **Compute** section of the [Scaleway Console](https://console.scaleway.com) side menu. The Kubernetes Kapsule dashboard displays.
+1. Click **Kubernetes** in the **Containers** section of the [Scaleway Console](https://console.scaleway.com) side menu. The Kubernetes Kapsule dashboard displays.
 2. Click <Icon name="more" /> next to the cluster you want to edit to display the options menu:
     <Lightbox src="scaleway-kapsule_cluster_menu.webp" alt="" />
 

--- a/containers/kubernetes/how-to/edit-kosmos-cluster.mdx
+++ b/containers/kubernetes/how-to/edit-kosmos-cluster.mdx
@@ -34,7 +34,7 @@ You can add nodes and pools to your Kosmos cluster from the [Scaleway Console](h
 
 A multi-cloud pool allows you to attach external Instances and servers to your cluster. Instances added to the same pool do not need to share the same configuration, nor do they have to be managed by the same Cloud provider. 
 
-1. Click **Kubernetes** in the Compute section of the side menu. The Kubernetes creation page displays.
+1. Click **Kubernetes** in the Containers section of the side menu. The Kubernetes creation page displays.
 2. Click the cluster you want to add a pool to.
 3. Click the **Pools** tab.
 4. Click the **+ Add a new pool** button. The pool creation wizard displays.

--- a/containers/kubernetes/how-to/enable-easy-deploy.mdx
+++ b/containers/kubernetes/how-to/enable-easy-deploy.mdx
@@ -33,7 +33,7 @@ The Easy Deploy feature allows you to pull images directly from [Scaleway Contai
   To deploy a container from an image stored within Container Registry, you must be logged in to the [Scaleway Console](https://console.scaleway.com/).
 </Message>
 
-1. Click **Kubernetes** in the **Compute** section of the [Scaleway Console](https://console.scaleway.com) side menu. The Kubernetes Kapsule dashboard displays.
+1. Click **Kubernetes** in the **Containers** section of the [Scaleway Console](https://console.scaleway.com) side menu. The Kubernetes Kapsule dashboard displays.
     <Lightbox src="scaleway-kubernetes-clusters-list.webp" alt="" />
 2. Click the name of the cluster you wish to deploy your image on. The Cluster Information tab displays.
     <Lightbox src="scaleway-kubernetes-cluster-information.webp" alt="" />

--- a/containers/kubernetes/how-to/monitor-cluster.mdx
+++ b/containers/kubernetes/how-to/monitor-cluster.mdx
@@ -22,7 +22,7 @@ categories:
 
 ## How to access the Kubernetes dashboard
 
-1. Click **Kubernetes** in the **Compute** section of the [Scaleway Console](https://console.scaleway.com) side menu. The Kubernetes Kapsule dashboard displays.
+1. Click **Kubernetes** in the **Containers** section of the [Scaleway Console](https://console.scaleway.com) side menu. The Kubernetes Kapsule dashboard displays.
 2. Click the name of the cluster you want to monitor. The cluster overview page displays.  This page provides several pieces of information about your cluster:
     * Cluster information
     * Add-ons

--- a/containers/kubernetes/how-to/upgrade-kubernetes-version.mdx
+++ b/containers/kubernetes/how-to/upgrade-kubernetes-version.mdx
@@ -20,7 +20,7 @@ categories:
   - You have [created](/containers/kubernetes/how-to/create-cluster) a Kubernetes Kapsule cluster running on a Kubernetes version older than the latest release
 </Message>
 
-1. Click **Kubernetes** under **Compute** on the side menu. A list of your Kubernetes Kapsule clusters displays.
+1. Click **Kubernetes** under **Containers** on the side menu. A list of your Kubernetes Kapsule clusters displays.
 2. Click the cluster name you wish to upgrade the Kubernetes version for. The cluster information page displays.
     <Message type="tip">
       Alternatively you can click <Icon name="more" /> > **More info** to display the cluster information page.


### PR DESCRIPTION
### Your checklist for this pull request

- [X] Check that the commit messages match our requested structure.
- [X] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description
Our tutorials still mentionned COMPUTE, but k8s moved under CONTAINERS not so long ago.
