### PR TITLE
docs(instances): updated information about cloud-init and marked bootscripts as deprecated 

### DIFF
--- a/compute/instances/how-to/use-boot-modes.mdx
+++ b/compute/instances/how-to/use-boot-modes.mdx
@@ -57,6 +57,10 @@ Rescue mode restarts your Instance via the network on a minimal operating system
 
 ## How to use a bootscript
 
+<Message type="importat">
+  This feature is deprecated and may be removed in the future. It is not recommended to use it any longer for production Instances.
+<Message>
+
 A bootscript allows you to choose a pre-built configuration script to boot your Instance. 
 
 1. Click **Instances** in the **Compute** section of the side menu. The Instances page displays.
@@ -73,22 +77,14 @@ A bootscript allows you to choose a pre-built configuration script to boot your 
 
 The cloud-init program that is available on recent distributions (Ubuntu, Fedora, Debian) is able to consume and execute data from the user-data field of the Scaleway Console. The process then behaves differently depending on the format of the information it finds. One of the most popular formats for scripts within user-data is the cloud-config file format. Cloud-config files are special scripts designed to be run by the cloud-init process. These are generally used for initial configuration on the very first boot of a server.
 
-Cloud-init is enabled for the following image versions:
-
-|  OS               |  Versions             |
-|-------------------|-----------------------|
-|  **Ubuntu**       |  Xenial / Bionic      |
-|  **Debian**       |  Stretch              |
-|  **Fedora**       |  32                   |
-|  **Centos**       |  8                    |
-|  **Rocky Linux**  |  8                    |
+Cloud-init is enabled for all Scaleway Instances OS images.
 
 Follow the instructions below to reboot an existing Instance using cloud-init. 
 
 1. Click **Instances** in the **Compute** section of the side menu. The Instances page displays.
-2. Click the Instance you wish to use a bootscript with.
+2. Click the Instance you wish to use with cloud-init.
 3. Click the **Advanced Settings** tab.
-4. In the **Cloud-init** section, use the <Icon name="toggle" /> toggle to to select **Use cloud init**
+4. In the **Cloud-init** section, use the <Icon name="toggle" /> toggle to activate **Use cloud init**.
     <Lightbox src="scaleway-cloud-init.webp" alt=""/>
 5. Enter your **user-data**. User data is the mechanism by which a user can pass information contained in a local file to an Instance at launch time. The typical use case is to pass something like a shell script or a configuration file as user data.
 

--- a/compute/instances/how-to/use-boot-modes.mdx
+++ b/compute/instances/how-to/use-boot-modes.mdx
@@ -57,9 +57,9 @@ Rescue mode restarts your Instance via the network on a minimal operating system
 
 ## How to use a bootscript
 
-<Message type="importat">
-  This feature is deprecated and may be removed in the future. It is not recommended to use it any longer for production Instances.
-<Message>
+<Message type="important">
+  This feature is **deprecated** and may be removed in the future. It is not recommended to use it any longer for production Instances.
+</Message>
 
 A bootscript allows you to choose a pre-built configuration script to boot your Instance. 
 
@@ -75,9 +75,8 @@ A bootscript allows you to choose a pre-built configuration script to boot your 
 
 [Cloud-init](/compute/instances/concepts/#cloud-init) enables automatic configuration of an Instance as it boots into the cloud, turning it from a generic Ubuntu image into a configured server in a few seconds. 
 
-The cloud-init program that is available on recent distributions (Ubuntu, Fedora, Debian) is able to consume and execute data from the user-data field of the Scaleway Console. The process then behaves differently depending on the format of the information it finds. One of the most popular formats for scripts within user-data is the cloud-config file format. Cloud-config files are special scripts designed to be run by the cloud-init process. These are generally used for initial configuration on the very first boot of a server.
-
-Cloud-init is enabled for all Scaleway Instances OS images.
+The cloud-init program that is able to consume and execute data from the user-data field of the Scaleway Console. The process then behaves differently depending on the format of the information it finds. One of the most popular formats for scripts within user-data is the cloud-config file format. Cloud-config files are special scripts designed to be run by the cloud-init process.
+These are generally used for initial configuration on the very first boot of a server. **Cloud-init is available for all Scaleway Instances OS images.**
 
 Follow the instructions below to reboot an existing Instance using cloud-init. 
 


### PR DESCRIPTION
### Description
updated information about cloud-init and marked bootscripts as deprecated 
