### PR TITLE
docs(messaging): fix indents for AWS config file

### DIFF
--- a/serverless/messaging/api-cli/connect-aws-cli.mdx
+++ b/serverless/messaging/api-cli/connect-aws-cli.mdx
@@ -54,9 +54,9 @@ Now you have installed the AWS-CLI, you need to configure it for use with your S
     endpoint = awscli_plugin_endpoint
     [default]
     sns =
-    endpoint_url = https://sqs-sns.mnq.fr-par.scw.cloud
+      endpoint_url = https://sqs-sns.mnq.fr-par.scw.cloud
     sqs =
-    endpoint_url = https://sqs-sns.mnq.fr-par.scw.cloud 
+      endpoint_url = https://sqs-sns.mnq.fr-par.scw.cloud 
     ```
 
     Optionally, you can also configure additional profiles by adding new blocks under `[default]`. For example, you can add a second profile, `[profile aws]`, to connect to AWS SNS/SQS service if you want:
@@ -66,9 +66,9 @@ Now you have installed the AWS-CLI, you need to configure it for use with your S
     endpoint = awscli_plugin_endpoint
     [default]
     sns =
-    endpoint_url = https://sqs-sns.mnq.fr-par.scw.cloud
+      endpoint_url = https://sqs-sns.mnq.fr-par.scw.cloud
     sqs =
-    endpoint_url = https://sqs-sns.mnq.fr-par.scw.cloud
+      endpoint_url = https://sqs-sns.mnq.fr-par.scw.cloud
     [profile aws]
     region=eu-west-3
     output=json


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Check that the commit messages match our requested structure.
- [x] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description
Files needs to have proper indentation, otherwise CLI gives error `Unable to parse config file`

