### PR TITLE
fix(doc): copy paste problem with ILO part

### DIFF
--- a/dedibox/kvm-over-ip/quickstart.mdx
+++ b/dedibox/kvm-over-ip/quickstart.mdx
@@ -56,13 +56,13 @@ IPMI is a standard specification for a remote management subsystem. On a Dell se
     - The **iDDRAC** tabs show you information about the iDRAC itself.
     - Click the other relevant links on the left sidebar to see information about **Batteries**, **Temperatures**, **Voltages**, etc. as required.
 
-## How to use IPMI via HP iLO
+## How to use IPMI via HPE iLO
 
-IPMI is a standard specification for a remote management subsystem. On a Dell server, IPMI is realized through the ILO: the **i**ntegrated **L**ights **O**ut processor.
+IPMI is a standard specification for a remote management subsystem. On a HPE server, IPMI is realized through the ILO: the **i**ntegrated **L**ights **O**ut processor.
 
 1. From the console, click **Server** > **Server list**. A list of your servers displays.
 2. Click **Manage** next to the relevant server.
-3. Click the **IDRAC** button on the right. A disclaimer displays.
+3. Click the **ILO** button on the right. A disclaimer displays.
 4. Click **I Accept** to agree with the terms of the disclaimer.
 5. Enter the authorized IPv4 address for the iDRAC connection. The IP address of your Internet connection is already pre-filled in the form. Then click **Create** to generate your credentials.
     <Message type="note">


### PR DESCRIPTION
1 - rename HP by HPE
2 - see a copy/paste problem between IDRAC and ILO I just renamed HPE instead of DELL in the HPE part and I corrected IDRAC to ILO

### Your checklist for this pull request

- [ ] Check that the commit messages match our requested structure.
- [ ] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description
Please describe your pull request.

