### PR TITLE
fix(docs): helm values indentation

### DIFF
--- a/tutorials/proxy-protocol-v2-load-balancer/index.mdx
+++ b/tutorials/proxy-protocol-v2-load-balancer/index.mdx
@@ -243,15 +243,15 @@ If you're using the [`ingress-nginx`](https://kubernetes.github.io/ingress-nginx
 1. Create the file below (e.g. `ingress-nginx-scw.yaml`) using a text editor.
     ```yaml
     controller:
-    kind: DaemonSet
-    service:
+      kind: DaemonSet
+      service:
         # Your LB IP here if you want (optional)
         loadBalancerIP: "X.X.X.X"
         externalTrafficPolicy: "Local"
         annotations:
         service.beta.kubernetes.io/scw-loadbalancer-proxy-protocol-v2: "true"
         service.beta.kubernetes.io/scw-loadbalancer-use-hostname: "true"
-    config:
+      config:
         use-forwarded-headers: "true"
         compute-full-forwarded-for: "true"
         use-proxy-protocol: "true"
@@ -263,7 +263,7 @@ If you're using the [`ingress-nginx`](https://kubernetes.github.io/ingress-nginx
     # Once the above file is created, you can run the below
     # https://kubernetes.github.io/ingress-nginx/deploy/#quick-start
     helm upgrade --install ingress-nginx ingress-nginx \
-    --repo https://kubernetes.github.io/ingress-nginx \
-    --namespace ingress-nginx --create-namespace \
-    -f ingress-nginx-scw.yaml
+      --repo https://kubernetes.github.io/ingress-nginx \
+      --namespace ingress-nginx --create-namespace \
+      -f ingress-nginx-scw.yaml
     ```


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Check that the commit messages match our requested structure.
- [x] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

Refers to https://github.com/scaleway/docs-content/pull/1232.

Just noticed that the indentation isn't correct for the `ingress-nginx` `values.yaml` file ([docs](https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml))

