### PR TITLE
docs(TEM): add important block on supported auth method main

### DIFF
--- a/managed-services/transactional-email/how-to/generate-api-keys-for-api-and-smtp-sending.mdx
+++ b/managed-services/transactional-email/how-to/generate-api-keys-for-api-and-smtp-sending.mdx
@@ -96,6 +96,10 @@ To send your emails using SMTP, a valid API key and your Project ID are required
 2. Authenticate yourself to the server using your Project ID as username.
 3. Use your secret key as password and start sending emails.
 
+<Message type="important">
+ - Only the PLAIN authentication method is supported by smtp servers.
+</Message>
+
 <Navigation title="See Also">
   <PreviousButton to="/managed-services/transactional-email/how-to/manage-email-activity/">How to manage your email activity</PreviousButton>
   <NextButton to="/managed-services/transactional-email/how-to/generate-api-keys-for-tem-with-iam/">How to generate API keys for API and SMTP sending with IAM</NextButton>

--- a/managed-services/transactional-email/how-to/generate-api-keys-for-api-and-smtp-sending.mdx
+++ b/managed-services/transactional-email/how-to/generate-api-keys-for-api-and-smtp-sending.mdx
@@ -97,7 +97,7 @@ To send your emails using SMTP, a valid API key and your Project ID are required
 3. Use your secret key as password and start sending emails.
 
 <Message type="important">
- - Only the PLAIN authentication method is supported by smtp servers.
+You can only use the `PLAIN` authentication method for now, as other methods are not supported.
 </Message>
 
 <Navigation title="See Also">

--- a/managed-services/transactional-email/how-to/generate-api-keys-for-tem-with-iam.mdx
+++ b/managed-services/transactional-email/how-to/generate-api-keys-for-tem-with-iam.mdx
@@ -86,7 +86,7 @@ To send your emails using SMTP, a valid API key and your Project ID are required
 3. Use your secret key as password and start sending emails.
 
 <Message type="important">
- - Only the PLAIN authentication method is supported by smtp servers.
+ You can only use the `PLAIN` authentication method for now, as other methods are not supported.
 </Message>
 
 <Navigation title="See Also">

--- a/managed-services/transactional-email/how-to/generate-api-keys-for-tem-with-iam.mdx
+++ b/managed-services/transactional-email/how-to/generate-api-keys-for-tem-with-iam.mdx
@@ -85,6 +85,10 @@ To send your emails using SMTP, a valid API key and your Project ID are required
 2. Authenticate yourself to the server using your Project ID as username.
 3. Use your secret key as password and start sending emails.
 
+<Message type="important">
+ - Only the PLAIN authentication method is supported by smtp servers.
+</Message>
+
 <Navigation title="See Also">
   <PreviousButton to="/managed-services/transactional-email/how-to/generate-api-keys-for-api-and-smtp-sending/">How to generate API keys for API and SMTP sending</PreviousButton>
   <NextButton to="/managed-services/transactional-email/how-to/delete-tem-domain/">How to delete your Transactional Email domain</NextButton>


### PR DESCRIPTION
Hello,

At this time the only Authentification method supported by the smtp server are AUTH PLAIN.
Confirmed by an answer on scaleway community slack,(https://scaleway-community.slack.com/archives/C0358JE0XEK/p1675681143135959?thread_ts=1675618137.698359&cid=C0358JE0XEK)

Regards,