### PR TITLE
feat(changelog): kubernetes-removed-container-runtimes-docker-and 2023-02-07

### DIFF
--- a/changelog/february2023/2023-02-07-kubernetes-removed-container-runtimes-docker-and.mdx
+++ b/changelog/february2023/2023-02-07-kubernetes-removed-container-runtimes-docker-and.mdx
@@ -1,0 +1,15 @@
+---
+title: Container Runtimes Docker and CRI-O are not supported anymore
+status: removed
+author:
+    fullname: 'Join the #k8s channel on Slack.'
+    url: 'https://slack.scaleway.com'
+date: 2023-02-07
+category: compute
+product: kubernetes
+---
+
+All new pools created in Scaleway Kubernetes clusters now use `Containerd` as their default runtime. 
+
+Scaleway recommends [to migrate node pools](https://www.scaleway.com/en/docs/containers/kubernetes/how-to/change-container-runtime-interface/) to a supported CRI. Please find more details on [our migration policies here](https://www.scaleway.com/en/docs/containers/kubernetes/reference-content/version-support-policy/).
+

--- a/changelog/february2023/2023-02-07-kubernetes-removed-container-runtimes-docker-and.mdx
+++ b/changelog/february2023/2023-02-07-kubernetes-removed-container-runtimes-docker-and.mdx
@@ -11,5 +11,5 @@ product: kubernetes
 
 All new pools created in Scaleway Kubernetes clusters now use `Containerd` as their default runtime. 
 
-Scaleway recommends [to migrate node pools](https://www.scaleway.com/en/docs/containers/kubernetes/how-to/change-container-runtime-interface/) to a supported CRI. Find more details on [our migration policies here](https://www.scaleway.com/en/docs/containers/kubernetes/reference-content/version-support-policy/).
+We recommend you [migrate node pools](https://www.scaleway.com/en/docs/containers/kubernetes/how-to/change-container-runtime-interface/) to a supported CRI. You can find more details about migration policies in our [version support policy page](https://www.scaleway.com/en/docs/containers/kubernetes/reference-content/version-support-policy/).
 

--- a/changelog/february2023/2023-02-07-kubernetes-removed-container-runtimes-docker-and.mdx
+++ b/changelog/february2023/2023-02-07-kubernetes-removed-container-runtimes-docker-and.mdx
@@ -11,5 +11,5 @@ product: kubernetes
 
 All new pools created in Scaleway Kubernetes clusters now use `Containerd` as their default runtime. 
 
-Scaleway recommends [to migrate node pools](https://www.scaleway.com/en/docs/containers/kubernetes/how-to/change-container-runtime-interface/) to a supported CRI. Please find more details on [our migration policies here](https://www.scaleway.com/en/docs/containers/kubernetes/reference-content/version-support-policy/).
+Scaleway recommends [to migrate node pools](https://www.scaleway.com/en/docs/containers/kubernetes/how-to/change-container-runtime-interface/) to a supported CRI. Find more details on [our migration policies here](https://www.scaleway.com/en/docs/containers/kubernetes/reference-content/version-support-policy/).
 


### PR DESCRIPTION
Reporter: Thibault Genaitay

This PR is a new changelog contribution. It has been created automatically.

Make sure to review it carefully before merging it.