### PR TITLE
doc(kapsule): docker now deprecated from 1.20

### DIFF
--- a/containers/kubernetes/reference-content/version-support-policy.mdx
+++ b/containers/kubernetes/reference-content/version-support-policy.mdx
@@ -128,7 +128,7 @@ Starting from Kubernetes version 1.25 launch, **containerd** is the only runtime
 
 | Runtime | Deprecation | Obsolete    |
 |---------|-------------|-------------|
-| Docker  | from v1.23  | from v1.24  |
+| Docker  | from v1.20  | from v1.21  |
 | Cri-o   | from v1.24  | from v1.25 |
 
 * Migration policies:


### PR DESCRIPTION
### Your checklist for this pull request

- [X] Check that the commit messages match our requested structure.
- [X] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description
Due to an incompatibility of Docker + Cilium, we noticed many clusters with this setup do not work properly on versions 1.21+. That's not something we can patch.
We thus have deprecated Docker from 1.20. 
Clusters on Docker won't be able to migrate to 1.21 any further.
