### PR TITLE
docs: Fixing markdown link in create instance docs

### DIFF
--- a/compute/instances/how-to/create-an-instance.mdx
+++ b/compute/instances/how-to/create-an-instance.mdx
@@ -17,7 +17,7 @@ categories:
   - compute
 ---
 
-This page shows how to create your first Scaleway Instance. An [Instance](/compute/instances/concepts/#instance) is a virtual machine in the cloud. Just like a physical machine, it has resources - virtualized CPU, RAM, storage etc. - which vary depending on the [Instance type]/compute/instances/reference-content/choosing-instance-type/) you choose. After you have created your Instance you can [connect](/compute/instances/how-to/connect-to-instance/) to it and use it for a wide range of computing use cases depending on the Instance type you chose, from running small scale tests and personal projects, to hosting applications and development environments, to setting up a production server.
+This page shows how to create your first Scaleway Instance. An [Instance](/compute/instances/concepts/#instance) is a virtual machine in the cloud. Just like a physical machine, it has resources - virtualized CPU, RAM, storage etc. - which vary depending on the [Instance type](/compute/instances/reference-content/choosing-instance-type/) you choose. After you have created your Instance you can [connect](/compute/instances/how-to/connect-to-instance/) to it and use it for a wide range of computing use cases depending on the Instance type you chose, from running small scale tests and personal projects, to hosting applications and development environments, to setting up a production server.
 
 <Macro id="iam-requirements" />
 


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Check that the commit messages match our requested structure.
- [x] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description
Fixed a missing `(` in markdown, resulting in wrongly parsed link.

![image](https://user-images.githubusercontent.com/283419/230407320-fadda0c3-8194-4eab-9f49-8ad9bd6740c5.png)


