### PR TITLE
feat(serverless-containers): add CPU and memory limits criteria

### DIFF
--- a/serverless/containers/reference-content/containers-limitations.mdx
+++ b/serverless/containers/reference-content/containers-limitations.mdx
@@ -26,6 +26,8 @@ This section contains usage limits that apply when using Serverless Containers.
 | Invocation rate                                   | Max Number  | 1000 per second  | Container                   |
 | Concurrency                                       | Max         | 80               | Container Instance          |
 | Scale (simultaneous Container Instances)          | Max         | 20               | Container                   |
+| CPU limit                                         | Max         | 2240 mvCPU       | Container                   |
+| CPU limit                                         | Min         | 70 mvCPU         | Container                   |
 | Environment Variables                             | Max Number  | 100              | Container + Namespace       |
 | Environment Variables                             | Max Size    | 1000 chars       | Environment Variable        |
 | Secret Environment Variables                      | Max Number  | 100              | Container + Namespace       |

--- a/serverless/containers/reference-content/containers-limitations.mdx
+++ b/serverless/containers/reference-content/containers-limitations.mdx
@@ -26,8 +26,7 @@ This section contains usage limits that apply when using Serverless Containers.
 | Invocation rate                                   | Max Number  | 1000 per second  | Container                   |
 | Concurrency                                       | Max         | 80               | Container Instance          |
 | Scale (simultaneous Container Instances)          | Max         | 20               | Container                   |
-| CPU limit                                         | Max         | 2240 mvCPU       | Container                   |
-| CPU limit                                         | Min         | 70 mvCPU         | Container                   |
+| CPU                                               | Min/max     | 70 to 2240 mvCPU | Container                   |
 | Environment Variables                             | Max Number  | 100              | Container + Namespace       |
 | Environment Variables                             | Max Size    | 1000 chars       | Environment Variable        |
 | Secret Environment Variables                      | Max Number  | 100              | Container + Namespace       |

--- a/serverless/containers/reference-content/containers-limitations.mdx
+++ b/serverless/containers/reference-content/containers-limitations.mdx
@@ -27,7 +27,7 @@ This section contains usage limits that apply when using Serverless Containers.
 | Concurrency                                       | Max            | 80               | Container Instance          |
 | Scale (simultaneous Container Instances)          | Max            | 20               | Container                   |
 | CPU                                               | Min/max        | 70 to 2240 mvCPU | Container                   |
-| Memory                                            | Tier values    | [tiers table](#tiers-table-for-container-memory)     | Container                   |
+| Memory                                            | Min/Max        | 128 to 4096 MiB  | Container                   |
 | Environment Variables                             | Max Number     | 100              | Container + Namespace       |
 | Environment Variables                             | Max Size       | 1000 chars       | Environment Variable        |
 | Secret Environment Variables                      | Max Number     | 100              | Container + Namespace       |
@@ -42,20 +42,6 @@ This section contains usage limits that apply when using Serverless Containers.
 \** Total container memory is the sum of the memory allocated to all your containers at their maximum Scale.
 
 These limits are enforced as [Account quotas](/console/my-account/reference-content/account-quotas/#serverless-containers).
-
-## Tiers table for container memory
-
-When creating a container, please use one of these memory tiers:
-
-| Memory  |
-|---------|
-| 128 MB  |
-| 256 MB  |
-| 512 MB  |
-| 1024 MB |
-| 2048 MB |
-| 3072 MB |
-| 4096 MB |
 
 ## Configuration Restrictions
 

--- a/serverless/containers/reference-content/containers-limitations.mdx
+++ b/serverless/containers/reference-content/containers-limitations.mdx
@@ -15,32 +15,47 @@ categories:
 
 This section contains usage limits that apply when using Serverless Containers.
 
-| Resources                                         | Criteria    | Limits           | Scope                       |
-|---------------------------------------------------|-------------|------------------|-----------------------------|
-| Namespaces                                        | Max Number  | 100*             | Project                     |
-| Containers                                        | Max Number  | 1000*            | Organization                |
-| Total container memory\**                         | Max Size    | 600 GiB          | Organization                |
-| Image size compressed                             | Max size    | 250 MiB          | Container                   |
-| Image size uncompressed                           | Max size    | 1 GiB            | Container                   |
-| Temporary disk size                               | Max size    | 512 MiB          | Container                   |
-| Invocation rate                                   | Max Number  | 1000 per second  | Container                   |
-| Concurrency                                       | Max         | 80               | Container Instance          |
-| Scale (simultaneous Container Instances)          | Max         | 20               | Container                   |
-| CPU                                               | Min/max     | 70 to 2240 mvCPU | Container                   |
-| Environment Variables                             | Max Number  | 100              | Container + Namespace       |
-| Environment Variables                             | Max Size    | 1000 chars       | Environment Variable        |
-| Secret Environment Variables                      | Max Number  | 100              | Container + Namespace       |
-| Secret Environment Variables                      | Max Size    | 65536 bytes      | Secret Environment Variable |
-| Time before scale to zero                         | Time        | 15 minutes       | Instance                    |
-| Time before scale down                            | Time        | 30 seconds       | Instance                    |
-| Timeout                                           | Max         | 15 minutes       | Request                     |
-| Logs                                              | Logs        | 30000 per minute | Project                     |
+| Resources                                         | Criteria       | Limits           | Scope                       |
+|---------------------------------------------------|-------------   |------------------|-----------------------------|
+| Namespaces                                        | Max Number     | 100*             | Project                     |
+| Containers                                        | Max Number     | 1000*            | Organization                |
+| Total container memory\**                         | Max Size       | 600 GiB          | Organization                |
+| Image size compressed                             | Max size       | 250 MiB          | Container                   |
+| Image size uncompressed                           | Max size       | 1 GiB            | Container                   |
+| Temporary disk size                               | Max size       | 512 MiB          | Container                   |
+| Invocation rate                                   | Max Number     | 1000 per second  | Container                   |
+| Concurrency                                       | Max            | 80               | Container Instance          |
+| Scale (simultaneous Container Instances)          | Max            | 20               | Container                   |
+| CPU                                               | Min/max        | 70 to 2240 mvCPU | Container                   |
+| Memory                                            | Tier values    | [tiers table](#tiers-table-for-container-memory)     | Container                   |
+| Environment Variables                             | Max Number     | 100              | Container + Namespace       |
+| Environment Variables                             | Max Size       | 1000 chars       | Environment Variable        |
+| Secret Environment Variables                      | Max Number     | 100              | Container + Namespace       |
+| Secret Environment Variables                      | Max Size       | 65536 bytes      | Secret Environment Variable |
+| Time before scale to zero                         | Time           | 15 minutes       | Instance                    |
+| Time before scale down                            | Time           | 30 seconds       | Instance                    |
+| Timeout                                           | Max            | 15 minutes       | Request                     |
+| Logs                                              | Logs           | 30000 per minute | Project                     |
 
 \* Lower limits may apply before account verification. Please contact our support team if you have any questions.
 
 \** Total container memory is the sum of the memory allocated to all your containers at their maximum Scale.
 
 These limits are enforced as [Account quotas](/console/my-account/reference-content/account-quotas/#serverless-containers).
+
+## Tiers table for container memory
+
+When creating a container, please use one of these memory tiers:
+
+| Memory  |
+|---------|
+| 128 MB  |
+| 256 MB  |
+| 512 MB  |
+| 1024 MB |
+| 2048 MB |
+| 3072 MB |
+| 4096 MB |
 
 ## Configuration Restrictions
 


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Check that the commit messages match our requested structure.
- [x] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

With the new feature of flexible resources for containers, users will be able to choose memory and CPU limits separately. A criteria on CPU and memory limits is added.

