### PR TITLE
fix(messaging): aws cli crendentials profile format

### DIFF
--- a/serverless/messaging/api-cli/connect-aws-cli.mdx
+++ b/serverless/messaging/api-cli/connect-aws-cli.mdx
@@ -90,7 +90,7 @@ Now you have installed the AWS-CLI, you need to configure it for use with your S
 
     If you have other profiles, you can add a block to indicate their credentials too:
     ```
-    [profile aws]
+    [aws]
     aws_access_key_id=<ACCESS_KEY>
     aws_secret_access_key=<SECRET_KEY>
     ```


### PR DESCRIPTION
### Your checklist for this pull request

- [ ] Check that the commit messages match our requested structure.
- [ ] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description
The example credentials use the wrong format for profile name.
Lookup [format of the files](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html#cli-configure-files-format) for reference. Blocks in credentials file do not have `profile` in it, only the profile name.

