### PR TITLE
feat(changelog): functions-deprecated-node19-runtime-deprecated 2023-04-27

### DIFF
--- a/changelog/april2023/2023-04-27-functions-deprecated-node19-runtime-deprecated.mdx
+++ b/changelog/april2023/2023-04-27-functions-deprecated-node19-runtime-deprecated.mdx
@@ -1,0 +1,14 @@
+---
+title: Node19 runtime deprecated
+status: deprecated
+author:
+    fullname: 'Join the #serverless-functions on Slack.'
+    url: 'https://slack.scaleway.com'
+date: 2023-04-27
+category: serverless
+product: functions
+---
+
+Node19 is now deprecated as it is no longer maintained by the nodeJs team.
+
+


### PR DESCRIPTION
Reporter: Benedikt Rollik

This PR is a new changelog contribution. It has been created automatically.

Make sure to review it carefully before merging it.