### PR TITLE
fix(how-tos): Repair inconsistencies in k8s tutorial part 1

### DIFF
--- a/tutorials/get-started-containers-docker/index.mdx
+++ b/tutorials/get-started-containers-docker/index.mdx
@@ -218,11 +218,11 @@ To finish, we push the Docker images we have created to a container registry. Co
     </Message>
 4. Tag the image you want to push with the address of your Container Registry namespace:
     ```bash
-    sudo docker tag mytestapp <address-of-your-namespace>/mytestapp
+    sudo docker tag testwhoami <address-of-your-namespace>/whoami
     ```
 5. Push the tagged image to the Container Registry namespace:
     ```bash
-    sudo docker push <address-of-your-namespace>/mytestapp
+    sudo docker push <address-of-your-namespace>/whoami
     ```
 6. Refresh your Container Registry namespace in the browser to ensure your image has been successfully pushed.
 

--- a/tutorials/get-started-containers-docker/index.mdx
+++ b/tutorials/get-started-containers-docker/index.mdx
@@ -184,16 +184,8 @@ In this example, we look at a pre-built application called **whoami**, an HTTP s
     You should see the `testwhoami` image in the output, showing that the container is running.
 7. Open up a browser and go to the application's endpoint, which is the IP address of your local machine with the port 8000:
     ```
-    http://<your-ip-address>:8000
+    http://localhost:8000
     ```
-
-    <Message type="tip">
-      If you don't know your local IP address, use the following command to find out:
-
-      ```
-      hostname --all-ip-addresses | awk '{print $1}'
-      ```
-    </Message>
 
     You should see that the container image is printing out its container ID at the endpoint, with an output similar to the following:
 

--- a/tutorials/get-started-containers-docker/index.mdx
+++ b/tutorials/get-started-containers-docker/index.mdx
@@ -123,12 +123,12 @@ We start by creating a simple, one-line Python application that prints "Hello Wo
 5. Copy and paste the following code into the Dockerfile, then save and exit:
     ```
     FROM python:3
-    ADD myapp.py /
+    COPY myapp.py /
     CMD ["python", "./myapp.py"]
     ```
 
     * **FROM**: this instruction specifies the base image for the container. In our case, we take care of our python requirement.
-    * **ADD**: this instruction adds files from our local machine (`myapp.py`) to the container image.
+    * **COPY**: this instruction adds files from our local machine (`myapp.py`) to the container image.
     * **CMD**: this instruction contains the command to be executed by default when the container is launched. In this case, we tell it to use python to run the `myapp.py` application.
 6. Run the following command to build a Docker image for the application, using the Dockerfile just created:
     ```

--- a/tutorials/get-started-containers-docker/index.mdx
+++ b/tutorials/get-started-containers-docker/index.mdx
@@ -168,6 +168,10 @@ In this example, we look at a pre-built application called **whoami**, an HTTP s
     ```bash
     sudo docker build -t testwhoami .
     ```
+
+    <Message type="tip">
+      If you are using a Mac with an Apple Silicon chip, you need to add the `--platform linux/amd64` argument to the above command. This is because the **whoami** application is not yet compatible with the ARM architecture.
+    </Message>
 5. Run the container image with the following command. Note that the `-d` argument tells Docker to run the contianer in the background (**d**etached mode), and the `-p` argument exposes the necessary ports for the application:
     ```bash
     sudo docker run -d -p 8000:8000 -t testwhoami


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Check that the commit messages match our requested structure.
- [x] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description
There are several inconsistencies between kubernetes Part 1 and Part 2:

- Part 2 references a whoami-image, which does not yet exist after part 1 (we push the testapp, but not the whoami app to the registry)
- Hint for Apple Silicons seems to be necessary, since an old whoami-image is used as a base, which does not support arm-architectures
- Use COPY instead of ADD, because ADD can have side effects, which is not intended in this case
- Local-bound docker ports can be accessed via `localhost` instead of the computer's IP-address (which does not give more information at this point in this tutorial, just more confusion)


