### PR TITLE
fix(s3): update object-storage-aws-cli

### DIFF
--- a/storage/object/api-cli/object-storage-aws-cli.mdx
+++ b/storage/object/api-cli/object-storage-aws-cli.mdx
@@ -55,7 +55,10 @@ To interact with Object Storage, `aws-cli` and `awscli-plugin-endpoint` need to 
       max_concurrent_requests = 100
       max_queue_size = 1000
       multipart_threshold = 50MB
-      # Edit the multipart_chunksize value according to the file sizes that you want to upload. The present configuration allows to upload files up to 10 GB (1000 requests * 10MB). For example setting it to 5GB allows you to upload files up to 5TB.
+      # Edit the multipart_chunksize value according to the file sizes that you
+      # want to upload. The present configuration allows to upload files up to
+      # 10 GB (1000 requests * 10MB). For example setting it to 5GB allows you
+      # to upload files up to 5TB.
       multipart_chunksize = 10MB
     s3api =
       endpoint_url = https://s3.nl-ams.scw.cloud


### PR DESCRIPTION
show comment in ~/.aws/config on several lines

### Your checklist for this pull request

- [x] Check that the commit messages match our requested structure.
- [x] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description
Currently the comment is hidden, it requires to scroll horizontally, which is not convenient:

> ![image](https://github.com/scaleway/docs-content/assets/2071331/b90125b6-9cda-408e-93f6-3f2c4bfacaa5)


