### PR TITLE
docs(add): review docs , Configure RPNv2 for Rocky Linux 9 with nmcli

### DIFF
--- a/dedibox-network/rpn/how-to/configure-rpnv2.mdx
+++ b/dedibox-network/rpn/how-to/configure-rpnv2.mdx
@@ -106,7 +106,7 @@ nmcli connection modify vlan-VLAN2001 ipv4.addresses 192.168.10.101/24 ipv4.meth
 nmcli connection up vlan-VLAN2001
 ```
 
-Assign an IP address to VLAN `2001` (your vlan id) on `serv2` and change ipv4.method to use manual method
+Assign an IP address to VLAN `2001` (your VLAN) on `serv2` and change `ipv4.method` to use the manual method
 
 ```
 nmcli connection modify vlan-VLAN2001 ipv4.addresses 192.168.10.100/24 ipv4.method manual ipv4.addresses

--- a/dedibox-network/rpn/how-to/configure-rpnv2.mdx
+++ b/dedibox-network/rpn/how-to/configure-rpnv2.mdx
@@ -99,7 +99,7 @@ vlan-VLAN2001  116121e0-4dca-4fb7-82ac-6e3888f7d277  vlan      VLAN2001
 
 Configure the second server to enable reachability from the group members.
 
-Assign an IP address to VLAN `2001` (your vlan id) on `serv1` and change ipv4.method to use manual method
+Assign an IP address to VLAN `2001` (your VLAN ID) on `serv1` and change `ipv4.method` to use the manual method
 
 ```
 nmcli connection modify vlan-VLAN2001 ipv4.addresses 192.168.10.101/24 ipv4.method manual ipv4.addresses

--- a/dedibox-network/rpn/how-to/configure-rpnv2.mdx
+++ b/dedibox-network/rpn/how-to/configure-rpnv2.mdx
@@ -80,7 +80,7 @@ In the following 'how to' we assume your RPN NIC is `eth1`.
     ```
 ## How to configure RPNv2 on Rocky Linux 9
 
-In the following 'how-to' guide, we will assume that your RPN NIC is `eth1`, the VLAN ID is `2001` and the new connection name is `VLAN2001`. 
+For the purpose of this how to, we assume that your RPN NIC is `eth1`, the VLAN ID is `2001` and the new connection name is `VLAN2001`. 
 
 To add a new VLAN connection using the nmcli command, follow the steps below:
 

--- a/dedibox-network/rpn/how-to/configure-rpnv2.mdx
+++ b/dedibox-network/rpn/how-to/configure-rpnv2.mdx
@@ -113,7 +113,7 @@ nmcli connection modify vlan-VLAN2001 ipv4.addresses 192.168.10.100/24 ipv4.meth
 nmcli connection up vlan-VLAN2001
 ```
 
-Test via ping
+Test your configuration via `ping`:
 
 From 192.168.0.100 to 192.168.0.101
 

--- a/dedibox-network/rpn/how-to/configure-rpnv2.mdx
+++ b/dedibox-network/rpn/how-to/configure-rpnv2.mdx
@@ -78,6 +78,62 @@ In the following 'how to' we assume your RPN NIC is `eth1`.
     NETWORK=my.private.address.0
     VLAN=YES
     ```
+## How to configure RPNv2 on Rocky Linux 9
+
+In the following 'how-to' guide, we will assume that your RPN NIC is `eth1`, the VLAN ID is `2001` and the new connection name is `VLAN2001`. 
+
+To add a new VLAN connection using the nmcli command, follow the steps below:
+
+```
+[root@srv1 ~]# nmcli connection add type vlan ifname VLAN2001 dev eth1 id 2001
+Connection 'vlan-VLAN2001' (116121e0-4dca-4fb7-82ac-6e38b0f7d277) successfully added.d
+```
+
+Show the updated VLAN connection :
+
+```
+[root@srv1 ~]# nmcli connection show 
+NAME           UUID                                  TYPE      DEVICE   
+vlan-VLAN2001  116121e0-4dca-4fb7-82ac-6e3888f7d277  vlan      VLAN2001
+```
+
+Configure the second server to enable reachability from the group members.
+
+Assign an IP address to VLAN `2001` (your vlan id) on `serv1` and change ipv4.method to use manual method
+
+```
+nmcli connection modify vlan-VLAN2001 ipv4.addresses 192.168.10.101/24 ipv4.method manual ipv4.addresses
+nmcli connection up vlan-VLAN2001
+```
+
+Assign an IP address to VLAN `2001` (your vlan id) on `serv2` and change ipv4.method to use manual method
+
+```
+nmcli connection modify vlan-VLAN2001 ipv4.addresses 192.168.10.100/24 ipv4.method manual ipv4.addresses
+nmcli connection up vlan-VLAN2001
+```
+
+Test via ping
+
+From 192.168.0.100 to 192.168.0.101
+
+```
+[root@srv1 ~]# ping 192.168.0.101
+PING 192.168.0.101 (192.168.0.101) 56(84) bytes of data.
+64 bytes from 192.168.0.101: icmp_seq=1 ttl=64 time=12.9 ms
+64 bytes from 192.168.0.101: icmp_seq=2 ttl=64 time=12.9 ms
+64 bytes from 192.168.0.101: icmp_seq=3 ttl=64 time=13.1 ms
+```
+
+From 192.168.0.100 to 192.168.0.100
+
+```
+[root@frontend-srv ~]# ping 192.168.0.100
+PING 192.168.0.100 (192.168.0.100) 56(84) bytes of data.
+64 bytes from 192.168.0.100: icmp_seq=1 ttl=64 time=13.2 ms
+64 bytes from 192.168.0.100: icmp_seq=2 ttl=64 time=13.1 ms
+64 bytes from 192.168.0.100: icmp_seq=3 ttl=64 time=13.1 ms
+```
 
 ## How to configure RPNv2 on FreeBSD
 


### PR DESCRIPTION
Configure RPNv2 for Rocky Linux 9 with nmcli

### Your checklist for this pull request

- [x] Check that the commit messages match our requested structure.
- [x] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description
Is a : How to configure Rocky Linux 9 with nmcli to use RPNv2 ?

I have tested the server configuration on both servers.

