### PR TITLE
docs(cockpit): Increase scrape_timeout to 60s

### DIFF
--- a/observability/cockpit/api-cli/configuring-grafana-agent.mdx
+++ b/observability/cockpit/api-cli/configuring-grafana-agent.mdx
@@ -43,7 +43,7 @@ This page explains how to configure the Grafana agent to push your logs and metr
     metrics:
       wal_directory: /tmp/agent
       global:
-        scrape_interval: 15s
+        scrape_interval: 60s
         remote_write:
         - url: <your metrics push url>
           headers:
@@ -77,7 +77,7 @@ This page explains how to configure the Grafana agent to push your logs and metr
     metrics:
       wal_directory: /tmp/agent
       global:
-        scrape_interval: 15s
+        scrape_interval: 60s
         remote_write:
         - url: https://metrics.cockpit.fr-par.scw.cloud/api/v1/push
           headers:
@@ -138,10 +138,10 @@ This page explains how to configure the Grafana agent to push your logs and metr
 8. Run the following command to bring the Grafana Agent container up:
 
     ```
-    docker-compose up
+    docker compose up
     ```
     <Message type="important">
-     Run `sudo docker-compose up` if you are using Linux.
+     Run `sudo docker compose up` if you are using Linux and your user is not in docker group.
     </Message>
 
 ## Visualizing metrics on Grafana

--- a/observability/cockpit/api-cli/configuring-grafana-agent.mdx
+++ b/observability/cockpit/api-cli/configuring-grafana-agent.mdx
@@ -141,7 +141,7 @@ This page explains how to configure the Grafana agent to push your logs and metr
     docker compose up
     ```
     <Message type="important">
-     Run `sudo docker compose up` if you are using Linux and your user is not in docker group.
+     Run `sudo docker compose up` if you are using Linux and your user is not in the docker group.
     </Message>
 
 ## Visualizing metrics on Grafana


### PR DESCRIPTION
The idea is to scrape every minute instead of every 15s to reduce cost of using this example.

### Your checklist for this pull request

- [ ] Check that the commit messages match our requested structure.
- [ ] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description
Please describe your pull request.

