### PR TITLE
fix(bin): add node_modules check

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,3 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
-
 bash bin/check-pre-commit

--- a/bin/check-pre-commit
+++ b/bin/check-pre-commit
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 [[ $(bin/count-invalid-slugs) == "0" ]] && \
-[ ! -d node_modules/ ] && echo "⚠️ You need to install node_modules first"; exit 1; \
+[ ! -d node_modules/ ] && echo "⚠️ You need to install node_modules first" && exit 1; \
 yarn lint-staged || \
 (echo "💔 Slug error(s):" && bin/list-invalid-slugs \ 
 echo "⚠️ You must fix slugs in 'menu/navigation.json' before commit"; exit 1)

--- a/bin/check-pre-commit
+++ b/bin/check-pre-commit
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 [[ $(bin/count-invalid-slugs) == "0" ]] && \
+[ ! -d node_modules/ ] && echo "⚠️ You need to install node_modules first"; exit 1; \
 yarn lint-staged || \
 (echo "💔 Slug error(s):" && bin/list-invalid-slugs \ 
 echo "⚠️ You must fix slugs in 'menu/navigation.json' before commit"; exit 1)

--- a/observability/index.mdx
+++ b/observability/index.mdx
@@ -3,6 +3,6 @@ meta:
   title: Discover Observability
   description: Discover Observability
 content:
-  h1: Discover Observability
+  h1: Discover Odfgbservability
   paragraph: Discover Observability
 ---

--- a/observability/index.mdx
+++ b/observability/index.mdx
@@ -3,6 +3,6 @@ meta:
   title: Discover Observability
   description: Discover Observability
 content:
-  h1: Discover Odfgbservability
+  h1: Discover Observability
   paragraph: Discover Observability
 ---


### PR DESCRIPTION
## Why
- When commit, if no node_modules installed => it will print "⚠️ You must fix slugs in 'menu/navigation.json' before commit"

## Test
- First delete your content/node_modules directory
- Delete randomly some stuff in the `menu/navigation.json` (to create error), and try to commit ==> it should tell you to install node-modules
- Install it : `yarn`
- Retry to commit ==> > it should tell you you have to fix you menu/navigation.json
- Fix it and do other modification
- Try to commit ==> should be good