### PR TITLE
fix(docs): added specifications on account quotas

### DIFF
--- a/console/my-account/reference-content/account-quotas.mdx
+++ b/console/my-account/reference-content/account-quotas.mdx
@@ -29,9 +29,9 @@ At Scaleway, quotas are applicable per [Organization](/identity-and-access-manag
 
 [Identity and Access Management (IAM)](/identity-and-access-management/iam/concepts/) allows you to share access to the management of your Scaleway resources, in a controlled and secure manner.
 
-|             | [Payment method validated](/console/my-account/how-to/manage-billing-information/#how-to-add-a-credit-card) | [Identity validated](/console/my-account/how-to/verify-identity/)|
+|             | [Payment method validated](/console/my-account/how-to/manage-billing-information/#how-to-add-a-credit-card)| Payment method and [identity validated](/console/my-account/how-to/verify-identity/)|
 |-------------|:----------------------------------------------------------------------------------------------------------:|:-----------------------------------------------------------------:|
-| API keys| 50                                                                                                         | 50                                                                |
+| API keys    | 50                                                                                                         | 50                                                                |
 | Applications| 50                                                                                                         | 50                                                                |
 | Groups      | 50                                                                                                         | 50                                                                |
 | Policies    | 50                                                                                                         | 50                                                                |
@@ -45,7 +45,7 @@ At Scaleway, quotas are applicable per [Organization](/identity-and-access-manag
 
 <Macro id="console-projects" />
 
-|                          | [Payment method validated](/console/my-account/how-to/manage-billing-information/#how-to-add-a-credit-card) | [Identity validated](/console/my-account/how-to/verify-identity/) |
+|                          | [Payment method validated](/console/my-account/how-to/manage-billing-information/#how-to-add-a-credit-card) | Payment method and [identity validated](/console/my-account/how-to/verify-identity/) |
 |--------------------------|:----------------------------------------------------------------------------------------------------------:|:-------------------------------------------------------------:|
 | Maximum number of Projects in an Organization       | 25                                                                                                   | 25                                                                |
 
@@ -58,7 +58,7 @@ At Scaleway, quotas are applicable per [Organization](/identity-and-access-manag
 
 <Macro id="console-ssh-keys" />
 
-|                          | [Payment method validated](/console/my-account/how-to/manage-billing-information/#how-to-add-a-credit-card) | [Identity validated](/console/my-account/how-to/verify-identity/) |
+|                          | [Payment method validated](/console/my-account/how-to/manage-billing-information/#how-to-add-a-credit-card) | Payment method and [identity validated](/console/my-account/how-to/verify-identity/) |
 |--------------------------|:----------------------------------------------------------------------------------------------------------:|:-------------------------------------------------------------:|
 | SSH keys allowed         | 50                                                                                                   | 50                                                                |
 
@@ -66,7 +66,7 @@ At Scaleway, quotas are applicable per [Organization](/identity-and-access-manag
 
 <Macro id="console-smtp" />
 
-|                          | [Payment method validated](/console/my-account/how-to/manage-billing-information/#how-to-add-a-credit-card) | [Identity validated](/console/my-account/how-to/verify-identity/) |
+|                          | [Payment method validated](/console/my-account/how-to/manage-billing-information/#how-to-add-a-credit-card) | Payment method and [identity validated](/console/my-account/how-to/verify-identity/) |
 |--------------------------|:----------------------------------------------------------------------------------------------------------:|:-------------------------------------------------------------:|
 | SMTP allowed             | [Validate your identity](/console/my-account/how-to/verify-identity/)                                                                               | Yes                                         |
 
@@ -78,7 +78,7 @@ At Scaleway, quotas are applicable per [Organization](/identity-and-access-manag
   Quotas are applied manually for Enterprise (ENT) range Instances to Organizations that have their [identity validated](/console/my-account/how-to/verify-identity/). [Contact our support team.](https://console.scaleway.com/support/create)
 </Message>
 
-|             | [Payment method validated](/console/my-account/how-to/manage-billing-information/#how-to-add-a-credit-card) | [Identity validated](/console/my-account/how-to/verify-identity/)|
+|             | [Payment method validated](/console/my-account/how-to/manage-billing-information/#how-to-add-a-credit-card) | Payment method and [identity validated](/console/my-account/how-to/verify-identity/)|
 |-------------|:----------------------------------------------------------------------------------------------------------:|:-----------------------------------------------------------------:|
 | AMP2-C1     | 1                                                                                                          | 5                                                                 |
 | AMP2-C2     | 1                                                                                                          | 4                                                                 |
@@ -140,7 +140,7 @@ At Scaleway, quotas are applicable per [Organization](/identity-and-access-manag
   [Contact our support team](https://console.scaleway.com/support/create) if you want to increase your quotas to more than 1.
 </Message>
 
-|               | [Payment method validated](/console/my-account/how-to/manage-billing-information#how-to-add-a-credit-card) | [Identity validated](/console/my-account/how-to/verify-identity/) |
+|               | [Payment method validated](/console/my-account/how-to/manage-billing-information#how-to-add-a-credit-card) | Payment method and [identity validated](/console/my-account/how-to/verify-identity/) |
 |-------------|:----------------------------------------------------------------------------------------------------------:|:-------------------------------------------------------------:|
 | RENDER-S    | To use this product, you must [validate your identity](/console/my-account/how-to/verify-identity/). | 1                                                                 |
 | GPU 3070 - S| To use this product, you must [validate your identity](/console/my-account/how-to/verify-identity/). | 1                                                                 |
@@ -149,7 +149,7 @@ At Scaleway, quotas are applicable per [Organization](/identity-and-access-manag
 
 <Macro id="compute-apple-silicon-m1" />
 
-|               | [Payment method validated](/console/my-account/how-to/manage-billing-information#how-to-add-a-credit-card) | [Identity validated](/console/my-account/how-to/verify-identity/) |
+|               | [Payment method validated](/console/my-account/how-to/manage-billing-information#how-to-add-a-credit-card) | Payment method and [identity validated](/console/my-account/how-to/verify-identity/) |
 |-------------|:----------------------------------------------------------------------------------------------------------:|:-------------------------------------------------------------:|
 | Apple silicon | 1 per [Availability Zone](/compute/instances/concepts/#availability-zone) | 1 per [Availability Zone](/compute/instances/concepts/#availability-zone)                                                                 |
 
@@ -158,7 +158,7 @@ At Scaleway, quotas are applicable per [Organization](/identity-and-access-manag
 
 <Macro id="compute-elastic-metal" />
 
-|                 | [Payment method validated](/console/my-account/how-to/manage-billing-information#how-to-add-a-credit-card) | [Identity validated](/console/my-account/how-to/verify-identity/)                                      |
+|                 | [Payment method validated](/console/my-account/how-to/manage-billing-information#how-to-add-a-credit-card) | Payment method and [identity validated](/console/my-account/how-to/verify-identity/)                                      |
 |-----------------|:----------------------------------------------------------------------------------------------------------:|:------------------------------------------------------------------------------------------------------:|
 | A210R SATA      | 1                                                                                                          | 3                                                                                                      |
 | A310X SSD       | 1                                                                                                          | 3                                                                                                      |
@@ -183,7 +183,7 @@ At Scaleway, quotas are applicable per [Organization](/identity-and-access-manag
 
 After you order a server from the list of Elastic Metal servers compatible with Microsoft Windows Server, you can choose a version of Windows Server to install directly from our console.
 
-|                 | [Payment method validated](/console/my-account/how-to/manage-billing-information#how-to-add-a-credit-card) | [Identity validated](/console/my-account/how-to/verify-identity/)                                      |
+|                 | [Payment method validated](/console/my-account/how-to/manage-billing-information#how-to-add-a-credit-card) | Payment method and [identity validated](/console/my-account/how-to/verify-identity/)                                      |
 |-----------------|:----------------------------------------------------------------------------------------------------------:|:------------------------------------------------------------------------------------------------------:|
 | Windows License | Not available                                                                                              | Available                                                                                              |
 
@@ -191,7 +191,7 @@ After you order a server from the list of Elastic Metal servers compatible with 
 
 <Macro id="compute-kubernetes" />
 
-|                          | [Payment method validated](/console/my-account/how-to/manage-billing-information/#how-to-add-a-credit-card) | [Identity validated](/console/my-account/how-to/verify-identity/) |
+|                          | [Payment method validated](/console/my-account/how-to/manage-billing-information/#how-to-add-a-credit-card) | Payment method and [identity validated](/console/my-account/how-to/verify-identity/) |
 |--------------------------|:----------------------------------------------------------------------------------------------------------:|:-------------------------------------------------------------:|
 | Kubernetes               | 500                                                                                                  | 500                                                               |
 
@@ -199,7 +199,7 @@ After you order a server from the list of Elastic Metal servers compatible with 
 
 <Macro id="compute-container-registry" />
 
-|                          | [Payment method validated](/console/my-account/how-to/manage-billing-information/#how-to-add-a-credit-card) | [Identity validated](/console/my-account/how-to/verify-identity/) |
+|                          | [Payment method validated](/console/my-account/how-to/manage-billing-information/#how-to-add-a-credit-card) | Payment method and [identity validated](/console/my-account/how-to/verify-identity/) |
 |--------------------------|:----------------------------------------------------------------------------------------------------------:|:-------------------------------------------------------------:|
 | Registry namespaces      | 99 999                                                                                               | 99 999                                                            |
 | Registry images          | 99 999                                                                                               | 99 999                                                            |
@@ -211,14 +211,14 @@ After you order a server from the list of Elastic Metal servers compatible with 
 
 #### Resources quotas
 
-|                          | [Payment method validated](/console/my-account/how-to/manage-billing-information/#how-to-add-a-credit-card) | [Identity validated](/console/my-account/how-to/verify-identity/) |
+|                          | [Payment method validated](/console/my-account/how-to/manage-billing-information/#how-to-add-a-credit-card) | Payment method and [identity validated](/console/my-account/how-to/verify-identity/) |
 |--------------------------|:----------------------------------------------------------------------------------------------------------:|:-------------------------------------------------------------:|
 | Container namespaces     | 25                                                                                                         | 25                                                           |
 | Number of containers     | 25                                                                                                         | 25                                                            |
 
 #### RAM quotas
 
-|                          | [Payment method validated](/console/my-account/how-to/manage-billing-information/#how-to-add-a-credit-card) | [Identity validated](/console/my-account/how-to/verify-identity/) |
+|                          | [Payment method validated](/console/my-account/how-to/manage-billing-information/#how-to-add-a-credit-card) | Payment method and [identity validated](/console/my-account/how-to/verify-identity/) |
 |--------------------------|:----------------------------------------------------------------------------------------------------------:|:-------------------------------------------------------------:|
 | Maximum RAM              | 25 GB                                                                                                      | 100 GB                                                        |
 
@@ -239,9 +239,9 @@ For example, if you choose to create a container with 512 MB of memory and a max
 
 #### RAM quotas
 
-|                          | [Payment method validated](/console/my-account/how-to/manage-billing-information/#how-to-add-a-credit-card) | [Identity validated](/console/my-account/how-to/verify-identity/) |
-|--------------------------|:----------------------------------------------------------------------------------------------------------:|:-------------------------------------------------------------:|
-| Maximum RAM              | 25 GB                                                                                                      | 100 GB                                                        |
+|                          | [Payment method validated](/console/my-account/how-to/manage-billing-information/#how-to-add-a-credit-card) | Payment method and [identity validated](/console/my-account/how-to/verify-identity/) |
+|--------------------------|:----------------------------------------------------------------------------------------------------------: |:------------------------------------------------------------------------------------:|
+| Maximum RAM              | 25 GB                                                                                                       | 100 GB                                                                               |
 
 The maximum RAM quota is obtained by multiplying the maximum scale factor of your container by the selected RAM quantity.
 For example, if you choose to create a container with 512 MB of memory and a max scale of 20, you will have 10 GB RAM.
@@ -257,13 +257,13 @@ Local and Block Storage options are available with our compute offers.
     - The maximum local storage for a DEV Instance depends on the DEV Instance type. For example, for the DEV1-XL the maximum local storage is 120GB.
 </Message>
 
-|                                                | [Payment method validated](/console/my-account/how-to/manage-billing-information/#how-to-add-a-credit-card ) | [Identity validated](/console/my-account/how-to/verify-identity/) |
-|------------------------------------------------|:----------------------------------------------------------------------------------------------------------:|:-------------------------------------------------------------:|
-| Block Storage total size in GB | 500                                                                                                  | 5 000                                                               |
-| Local Storage total size in GB | 1 000                                                                                                | 5 000                                                             |
-| Snapshots                                      | 99 999                                                                                               | 99 999                                                            |
-| Images                                         | 99 999                                                                                               | 99 999                                                            |
-| Volumes                                        | 200                                                                                                  | 5 000                                                             |
+|                                                | [Payment method validated](/console/my-account/how-to/manage-billing-information/#how-to-add-a-credit-card ) | Payment method and [identity validated](/console/my-account/how-to/verify-identity/)   |
+|------------------------------------------------|:------------------------------------------------------------------------------------------------------------:|:--------------------------------------------------------------------------------------:|
+| Block Storage total size in GB                 | 500                                                                                                          | 5 000                                                                                  |
+| Local Storage total size in GB                 | 1 000                                                                                                        | 5 000                                                                                  |
+| Snapshots                                      | 99 999                                                                                                       | 99 999                                                                                 |
+| Images                                         | 99 999                                                                                                       | 99 999                                                                                 |
+| Volumes                                        | 200                                                                                                          | 5 000                                                                                  |
 
 
 
@@ -271,45 +271,45 @@ Local and Block Storage options are available with our compute offers.
 
 <Macro id="storage-object-storage" />
 
-|                           | [Payment method validated](/console/my-account/how-to/manage-billing-information/#how-to-add-a-credit-card) | [Identity validated](/console/my-account/how-to/verify-identity/) |
-|---------------------------|:----------------------------------------------------------------------------------------------------------:|:-------------------------------------------------------------:|
-| Object Storage buckets    | 100                                                                                               | 100                                                            |
+|                           | [Payment method validated](/console/my-account/how-to/manage-billing-information/#how-to-add-a-credit-card) | Payment method and [identity validated](/console/my-account/how-to/verify-identity/) |
+|---------------------------|:-----------------------------------------------------------------------------------------------------------:|:------------------------------------------------------------------------------------:|
+| Object Storage buckets    | 100                                                                                                         | 100                                                                                  |
 
 ## Database Instances
 
 <Macro id="storage-managed-databases" />
 
-|                           | [Payment method validated](/console/my-account/how-to/manage-billing-information/#how-to-add-a-credit-card ) | [Identity validated](/console/my-account/how-to/verify-identity/) |
-|---------------------------|:----------------------------------------------------------------------------------------------------------:|:-------------------------------------------------------------:|
-| Database Instances        | 5                                                                                                    | 10                                                                |
-| Backups per Instance      | 40 000                                                                                               | 40 000                                                            |
-| Database backups          | 5 000                                                                                                | 5 000                                                             |
-| ACLs per Instance         | 50                                                                                                   | 50                                                                |
-| Snapshots per Instance    | 50                                                                                                   | 50                                                                |
-| Total Block Storage in GB | 5 000                                                                                                | 5 000                                                             |
-| Database Snapshots        | 100                                                                                                  | 100                                                               |
+|                           | [Payment method validated](/console/my-account/how-to/manage-billing-information/#how-to-add-a-credit-card ) | Payment method and [identity validated](/console/my-account/how-to/verify-identity/) |
+|---------------------------|:------------------------------------------------------------------------------------------------------------:|:------------------------------------------------------------------------------------:|
+| Database Instances        | 5                                                                                                            | 10                                                                                   |
+| Backups per Instance      | 40 000                                                                                                       | 40 000                                                                               |
+| Database backups          | 5 000                                                                                                        | 5 000                                                                                |
+| ACLs per Instance         | 50                                                                                                           | 50                                                                                   |
+| Snapshots per Instance    | 50                                                                                                           | 50                                                                                   |
+| Total Block Storage in GB | 5 000                                                                                                        | 5 000                                                                                |
+| Database Snapshots        | 100                                                                                                          | 100                                                                                  |
 
 ## Network
 
 Additional IP addresses and placement groups are available with our compute offers.
 
-|                           | [Payment method validated](/console/my-account/how-to/manage-billing-information/#how-to-add-a-credit-card) | [Identity validated](/console/my-account/how-to/verify-identity/) |
-|---------------------------|:----------------------------------------------------------------------------------------------------------:|:-------------------------------------------------------------:|
-| Elastic Metal Flexible IP | 64                                                                                                   | 64                                                                |
-| Private Networks          | 255                                                                                                  | 255                                                               |
-| Private NICs              | 255                                                                                                  | 255                                                               |
-| Instances IPs             | 20                                                                                                   | 50                                                                |
-| Security Groups           | 99 999                                                                                               | 99 999                                                            |
-| Security Rules            | 500                                                                                                  | 500                                                               |
-| Placement Groups          | 100                                                                                                  | 100                                                               |
-| Compute Clusters          | 100                                                                                                  | 100                                                               |
+|                           | [Payment method validated](/console/my-account/how-to/manage-billing-information/#how-to-add-a-credit-card) | Payment method and [identity validated](/console/my-account/how-to/verify-identity/)|
+|---------------------------|:-----------------------------------------------------------------------------------------------------------:|:-----------------------------------------------------------------------------------:|
+| Elastic Metal Flexible IP | 64                                                                                                          | 64                                                                                  |
+| Private Networks          | 255                                                                                                         | 255                                                                                 |
+| Private NICs              | 255                                                                                                         | 255                                                                                 |
+| Instances IPs             | 20                                                                                                          | 50                                                                                  |
+| Security Groups           | 99 999                                                                                                      | 99 999                                                                              |
+| Security Rules            | 500                                                                                                         | 500                                                                                 |
+| Placement Groups          | 100                                                                                                         | 100                                                                                 |
+| Compute Clusters          | 100                                                                                                         | 100                                                                                 |
 
 ## Public Gateways
 
 <Macro id="network-public-gateways" />
 
-|                          | [Payment method validated](/console/my-account/how-to/manage-billing-information/#how-to-add-a-credit-card) | [Identity validated](/console/my-account/how-to/verify-identity/) |
-|--------------------------|:----------------------------------------------------------------------------------------------------------:|:-------------------------------------------------------------:|
+|                          | [Payment method validated](/console/my-account/how-to/manage-billing-information/#how-to-add-a-credit-card) | Payment method and [identity validated](/console/my-account/how-to/verify-identity/) |
+|--------------------------|:-----------------------------------------------------------------------------------------------------------:|:-------------------------------------------------------------:|
 | Public Gateway DHCP reservations    | 1024                                                                                                 | 1024                                                              |
 | Public Gateway DHCP servers         | 255                                                                                                  | 255                                                               |
 | Private Networks attached to Public Gateways     | 10                                                                                                   | 10                                                                |
@@ -321,7 +321,7 @@ Additional IP addresses and placement groups are available with our compute offe
 
 <Macro id="network-load-balancer" />
 
-|                           | [Payment method validated](/console/my-account/how-to/manage-billing-information/#how-to-add-a-credit-card) | [Identity validated](/console/my-account/how-to/verify-identity/) |
+|                           | [Payment method validated](/console/my-account/how-to/manage-billing-information/#how-to-add-a-credit-card) | Payment method and [identity validated](/console/my-account/how-to/verify-identity/) |
 |---------------------------|:----------------------------------------------------------------------------------------------------------:|:-------------------------------------------------------------:|
 | Load Balancers            | 50                                                                                                   | 50                                                                |
 
@@ -329,7 +329,7 @@ Additional IP addresses and placement groups are available with our compute offe
 
 <Macro id="network-dns-cloud" />
 
-|                          | [Payment method validated](/console/my-account/how-to/manage-billing-information/#how-to-add-a-credit-card) | [Identity validated](/console/my-account/how-to/verify-identity/) |
+|                          | [Payment method validated](/console/my-account/how-to/manage-billing-information/#how-to-add-a-credit-card) | Payment method and [identity validated](/console/my-account/how-to/verify-identity/) |
 |--------------------------|:----------------------------------------------------------------------------------------------------------:|:-------------------------------------------------------------:|
 | Domain zones             | 100                                                                                                  | 100                                                               |
 | Domain user records      | 10 000                                                                                               | 10 000                                                            |
@@ -341,7 +341,7 @@ Additional IP addresses and placement groups are available with our compute offe
 
 <Macro id="iot-hub-iot" />
 
-|                           | [Payment method validated](/console/my-account/how-to/manage-billing-information/#how-to-add-a-credit-card) | [Identity validated](/console/my-account/how-to/verify-identity/) |
+|                           | [Payment method validated](/console/my-account/how-to/manage-billing-information/#how-to-add-a-credit-card) | Payment method and [identity validated](/console/my-account/how-to/verify-identity/) |
 |---------------------------|:----------------------------------------------------------------------------------------------------------:|:-------------------------------------------------------------:|
 | IoT Hubs Shared           | 5                                                                                                    | 5                                                                 |
 | IoT Hubs Dedicated        | 50                                                                                                   | 50                                                                |
@@ -364,7 +364,7 @@ Transactional Email is a platform that allows Scaleway clients to send [transact
  Additional quotas can be added on a case-by-case basis. If you have already validated your payment method and your identity and want to increase your quota beyond the values shown on this page, [contact our support team](https://console.scaleway.com/support/create).
 </Message>
 
-|                                     | [Payment method validated](/console/my-account/how-to/manage-billing-information/#how-to-add-a-credit-card) | [Identity validated](/console/my-account/how-to/verify-identity) |
+|                                     | [Payment method validated](/console/my-account/how-to/manage-billing-information/#how-to-add-a-credit-card) | Payment method and [identity validated](/console/my-account/how-to/verify-identity) |
 |-------------------------------------|-------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------|
 | Max. of recipients                  | 3                                                                                                           | 3                                                                |
 | Domains per Organization            | 2                                                                                                           | 5                                                                |
@@ -382,7 +382,7 @@ Transactional Email is a platform that allows Scaleway clients to send [transact
 
 Scaleway’s [Secret Manager](/identity-and-access-management/secret-manager/concepts/#secret-manager/) allows you to conveniently store, access and share sensitive data such as passwords, API keys and certificates.
 
-| Name                                   | [Payment method validated](https://www.scaleway.com/en/docs/console/my-account/how-to/manage-billing-information/#how-to-add-a-credit-card) | [Identity validated](https://www.scaleway.com/en/docs/console/my-account/how-to/verify-identity/) |
+| Name                                   | [Payment method validated](https://www.scaleway.com/en/docs/console/my-account/how-to/manage-billing-information/#how-to-add-a-credit-card) | Payment method and [identity validated](https://www.scaleway.com/en/docs/console/my-account/how-to/verify-identity/) |
 |----------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------|
 | Secrets                                | 100                                                                                                                                         | 250                                                                                               |
 | Versions per secret                    | 20                                                                                                                                          | 20                                                                                                |
@@ -395,6 +395,6 @@ Web Hosting is a service that allows individuals and organizations to make their
 
 Scaleway provides several [Web Hosting plans](https://www.scaleway.com/en/web-hosting/) for individuals, professionals, and everyone in between.
 
-|              | [Payment method validated](https://www.scaleway.com/en/docs/console/my-account/how-to/manage-billing-information/#how-to-add-a-credit-card) | [Identity validated](https://www.scaleway.com/en/docs/console/my-account/how-to/verify-identity/) |
+|              | [Payment method validated](https://www.scaleway.com/en/docs/console/my-account/how-to/manage-billing-information/#how-to-add-a-credit-card) | Payment method and [identity validated](https://www.scaleway.com/en/docs/console/my-account/how-to/verify-identity/) |
 |--------------|---------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------|
 | Web Hostings | 1                                                                                                                                           | 2                                                                                                 |


### PR DESCRIPTION
Replaced "Identity validated" with "Payment and identity validated" to clear confusion