### PR TITLE
feat(changelog): load-balancers-removed-sni-routes-to-http 2023-06-01

### DIFF
--- a/changelog/june2023/2023-06-01-load-balancers-removed-sni-routes-to-http.mdx
+++ b/changelog/june2023/2023-06-01-load-balancers-removed-sni-routes-to-http.mdx
@@ -3,7 +3,7 @@ title: SNI routes to HTTP backends are no longer supported
 status: removed
 author:
     fullname: 'Join the #load-balancer channel on Slack.'
-    url: 'https://scaleway-community.slack.com/archives/load-balancer'
+    url: 'https://slack.scaleway.com/'
 date: 2023-06-01
 category: network
 product: load-balancers
@@ -13,5 +13,5 @@ Following our deprecation notice, it is no longer possible to create and use SNI
 
 All Load Balancers that were still using SNI routes with HTTP backends on June 1st have now been automatically updated to use the HTTP Host header route instead.
 
-For more information please refer to our documentation: https://www.scaleway.com/en/docs/network/load-balancer/reference-content/sni-route-deprecation/
+For more information please refer to our [product documentation](https://www.scaleway.com/en/docs/network/load-balancer/reference-content/sni-route-deprecation/).
 

--- a/changelog/june2023/2023-06-01-load-balancers-removed-sni-routes-to-http.mdx
+++ b/changelog/june2023/2023-06-01-load-balancers-removed-sni-routes-to-http.mdx
@@ -1,0 +1,17 @@
+---
+title: SNI routes to HTTP backends are no longer supported
+status: removed
+author:
+    fullname: 'Join the #load-balancer channel on Slack.'
+    url: 'https://scaleway-community.slack.com/archives/load-balancer'
+date: 2023-06-01
+category: network
+product: load-balancers
+---
+
+Following our deprecation notice, it is no longer possible to create and use SNI routes with HTTP backends in Scaleway Load Balancer. The HTTP Host header route type must now be used instead.
+
+All Load Balancers that were still using SNI routes with HTTP backends on June 1st have now been automatically updated to use the HTTP Host header route instead.
+
+For more information please refer to our documentation: https://www.scaleway.com/en/docs/network/load-balancer/reference-content/sni-route-deprecation/
+


### PR DESCRIPTION
Reporter: David TENCER

This PR is a new changelog contribution. It has been created automatically.

Make sure to review it carefully before merging it.