### PR TITLE
docs(tutorials): add k8s categories fluentbit tuto

### DIFF
--- a/tutorials/k8s-fluentbit-observability/index.mdx
+++ b/tutorials/k8s-fluentbit-observability/index.mdx
@@ -9,6 +9,8 @@ tags: fluentbit grafana kubernetes metrics logs
 categories:
   - observability
   - cockpit
+  - containers
+  - kubernetes
 dates:
   validation: 2023-06-01
   posted: 2023-06-01


### PR DESCRIPTION
### Description
Add Kubernetes category to Fluent Bit tutorial
