### PR TITLE
docs(storage): Address potential boot failure on Debian caused by FSTAB command

### DIFF
--- a/storage/block/how-to/mount-and-use-volume.mdx
+++ b/storage/block/how-to/mount-and-use-volume.mdx
@@ -118,7 +118,7 @@ With the current configuration, the block device will not be mounted automatical
 Add this line to the `/etc/fstab` file of your instance:
 
 ```
-echo '/dev/sda /mnt/block-volume ext4 defaults 0 0' >> /etc/fstab
+echo "UUID=$(blkid --output value /dev/sda | head -n1) /mnt/block-volume ext4 defaults 0 0" >> /etc/fstab
 ```
 
 ## How to transfer data from your local machine to the remote block volume


### PR DESCRIPTION
### Your checklist for this pull request

- [X] Check that the commit messages match our requested structure.
- [X] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description
Fix boot failure issue on Debian with kernel >= 5.3 caused by the fellowing command : 

`echo '/dev/sda /mnt/block-volume ext4 defaults 0 0' >> /etc/fstab`

The boot process on Debian with Kernel >= 5.3 can experience failures due to random volume naming, resulting in intermittent boot issues.

Introduce UID assignment in FSTAB line to ensure consistent volume naming at boot with this command : 

`echo "UUID=$(blkid --output value /dev/sda | head -n1) /mnt/block-volume ext4 defaults 0 0" >> /etc/fstab`
