### PR TITLE
docs(loadbalancer-annotations): wrong default timeout value

### DIFF
--- a/containers/kubernetes/api-cli/using-load-balancer-annotations.mdx
+++ b/containers/kubernetes/api-cli/using-load-balancer-annotations.mdx
@@ -233,7 +233,7 @@ The Availability Zone in which the Load Balancer will be created.
 ## service.beta.kubernetes.io/scw-loadbalancer-timeout-server
 
 This is the annotation to set the maximum server connection inactivity time.
-The default value is `10m`. The duration is measured by Golang. Duration (ex: `1s`, `2m`, `4h`, ...).
+The default value is `10s`. The duration is measured by Golang. Duration (ex: `1s`, `2m`, `4h`, ...).
 
 </Concept>
 
@@ -242,7 +242,7 @@ The default value is `10m`. The duration is measured by Golang. Duration (ex: `1
 ## service.beta.kubernetes.io/scw-loadbalancer-timeout-connect
 
 This is the annotation to set the maximum initial server connection establishment time.
-The default value is `10m`. The duration are go's time. Duration (ex: `1s`, `2m`, `4h`, ...).
+The default value is `10s`. The duration are go's time. Duration (ex: `1s`, `2m`, `4h`, ...).
 
 </Concept>
 
@@ -251,7 +251,7 @@ The default value is `10m`. The duration are go's time. Duration (ex: `1s`, `2m`
 ## service.beta.kubernetes.io/scw-loadbalancer-timeout-tunnel
 
 This is the annotation to set the maximum tunnel inactivity time.
-The default value is `10m`. The duration are go's time. Duration (ex: `1s`, `2m`, `4h`, ...).
+The default value is `10s`. The duration are go's time. Duration (ex: `1s`, `2m`, `4h`, ...).
 
 </Concept>
 


### PR DESCRIPTION
### Your checklist for this pull request

- [X] Check that the commit messages match our requested structure.
- [X] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description
Discovered while searching why a request timeout after 10s with a 504 on browser and a 499 on an nginx-ingress. Found that there is `10m` in the documentation but after modifying the value in the annotations of my LB with more than `10s` (60s), no timeout (my request take 28seconds).
Can't get this information in the Console nor with the scw client, that stay a deduction, please check with your teams.
If it's true, everything is ready in the PR.

Thank you, have a good day !
