### PR TITLE
docs(k8s): remove deprecated version 1.21

### DIFF
--- a/containers/kubernetes/reference-content/version-support-policy.mdx
+++ b/containers/kubernetes/reference-content/version-support-policy.mdx
@@ -48,7 +48,6 @@ Before opening a support ticket related to cluster behavior or a Kubernetes comp
 | 1.24               | April 2022       | July 2023            | April 2022                   | April 2024       | May 15, 2024      |
 | 1.23               | December 8, 2021 | February 2023        | December 9, 2021             | December 2023    | February 15, 2024 |
 | 1.22               | August 4, 2021   | October 2022         | August 11, 2021              | August 2023      | October 15, 2023  |
-| 1.21               | April 8, 2021    | June 2022            | April 30, 2021               | April 2023       | June 15, 2023     |
 
 ## Version information
 For a complete changelog update, refer to the official [Kubernetes changelog](https://kubernetes.io/releases/).


### PR DESCRIPTION
### Description
Remove v1.21 from supported versions as it is deprecated
