### PR TITLE
fix(storage): Disk name was incorrect when increasing object partition

### DIFF
--- a/storage/block/how-to/increase-block-volume.mdx
+++ b/storage/block/how-to/increase-block-volume.mdx
@@ -58,7 +58,7 @@ With Block Storage it is possible to expand the volume size of an Instance.
     └─sda15   8:15   0   106M  0 part /boot/efi
     ```
 
-3. Use `growpart` to increase the partition size of your block storage volume (here `/dev/sdb1`):
+3. Use `growpart` to increase the partition size of your block storage volume (here `/dev/sda1`):
     ```
     growpart /dev/sdX 1
     ```


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Check that the commit messages match our requested structure.
- [x] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description
The partition in the example was `sda1` not `sdb1` (simple typo fix)

