### PR TITLE
docs(instances): fix cloud-init on debian 12

### DIFF
--- a/compute/instances/troubleshooting/fix-cloud-init-debian12.mdx
+++ b/compute/instances/troubleshooting/fix-cloud-init-debian12.mdx
@@ -13,7 +13,7 @@ categories:
   - compute
 ---
 
-Debian 12 (Bookworm) Instances created before June 2nd, 2023 were delivered with a version of `cloud-init` preinstalled that came with a wrong user configuration made by the custom-built upstream `cloud-init 23.2`.<br />
+Debian 12 (Bookworm) Instances created before June 2nd, 2023 were delivered with a preinstalled version of `cloud-init` that came with a wrong user configuration made by the custom-built upstream `cloud-init 23.2`.<br />
 
 The issue has been fixed for Instances created  after June 2nd, 2023. The Debian 12 image now uses the official Debian Unstable `cloud-init` package.<br />
 

--- a/compute/instances/troubleshooting/fix-cloud-init-debian12.mdx
+++ b/compute/instances/troubleshooting/fix-cloud-init-debian12.mdx
@@ -17,8 +17,7 @@ Debian 12 (Bookworm) Instances created prior to 2023-06-22 were delivered with a
 
 The issue has been fixed for Instances created past the above mentioned date. The Debian 12 image now uses the official Debian Unstable cloud-init package.<br />
 
-To fix the issue on a Instance affected by this bug, run the following steps to fix the issue:
-
+Run the following commands to fix the issue on an Instance affected by this bug:
 ```
 wget http://ftp.fr.debian.org/debian/pool/main/c/cloud-init/cloud-init_23.2-1_all.deb -O /tmp/cloud-init_23.2-1_all.deb
 

--- a/compute/instances/troubleshooting/fix-cloud-init-debian12.mdx
+++ b/compute/instances/troubleshooting/fix-cloud-init-debian12.mdx
@@ -13,10 +13,11 @@ categories:
   - compute
 ---
 
-Debian 12 (Bookworm) Instances created prior to 2023-06-22 were delivered with a version of `cloud-init` preinstalled that came with a wrong user configuration made by the custom-built upstream cloud-init 23.2.
-The problem has been fixed for Instances created past the above mentioned date. The Debian 12 image now uses the official Debian Unstable cloud-init package.
+Debian 12 (Bookworm) Instances created prior to 2023-06-22 were delivered with a version of `cloud-init` preinstalled that came with a wrong user configuration made by the custom-built upstream `cloud-init 23.2`.<br />
 
-To fix the problem on a Instance affected by this bug, run the following steps to fix the issue:
+The issue has been fixed for Instances created past the above mentioned date. The Debian 12 image now uses the official Debian Unstable cloud-init package.<br />
+
+To fix the issue on a Instance affected by this bug, run the following steps to fix the issue:
 
 ```
 wget http://ftp.fr.debian.org/debian/pool/main/c/cloud-init/cloud-init_23.2-1_all.deb -O /tmp/cloud-init_23.2-1_all.deb

--- a/compute/instances/troubleshooting/fix-cloud-init-debian12.mdx
+++ b/compute/instances/troubleshooting/fix-cloud-init-debian12.mdx
@@ -15,7 +15,7 @@ categories:
 
 Debian 12 (Bookworm) Instances created prior to 2023-06-22 were delivered with a version of `cloud-init` preinstalled that came with a wrong user configuration made by the custom-built upstream `cloud-init 23.2`.<br />
 
-The issue has been fixed for Instances created past the above mentioned date. The Debian 12 image now uses the official Debian Unstable cloud-init package.<br />
+The issue has been fixed for Instances created past the above mentioned date. The Debian 12 image now uses the official Debian Unstable `cloud-init` package.<br />
 
 Run the following commands to fix the issue on an Instance affected by this bug:
 ```

--- a/compute/instances/troubleshooting/fix-cloud-init-debian12.mdx
+++ b/compute/instances/troubleshooting/fix-cloud-init-debian12.mdx
@@ -1,10 +1,10 @@
 ---
 meta:
   title: Fix the wrong user configuration of cloud-init on Debian 12 (Bookworm)
-  description: This page helps you to fix the wrong user configuration of cloud-init on Debian 12 (Bookworm)
+  description: This page helps you fix the wrong user configuration of cloud-init on Debian 12 (Bookworm)
 content:
   h1: Fix the wrong user configuration of cloud-init on Debian 12 (Bookworm)
-  paragraph: This page helps you to fix the wrong user configuration of cloud-init on Debian 12 (Bookworm)
+  paragraph: This page helps you fix the wrong user configuration of cloud-init on Debian 12 (Bookworm)
 tags: debian12 debian bookworm cloud-init
 dates:
   validation: 2023-06-16
@@ -13,9 +13,9 @@ categories:
   - compute
 ---
 
-Debian 12 (Bookworm) Instances created prior to 2023-06-22 were delivered with a version of `cloud-init` preinstalled that came with a wrong user configuration made by the custom-built upstream `cloud-init 23.2`.<br />
+Debian 12 (Bookworm) Instances created before June 2nd, 2023 were delivered with a version of `cloud-init` preinstalled that came with a wrong user configuration made by the custom-built upstream `cloud-init 23.2`.<br />
 
-The issue has been fixed for Instances created past the above mentioned date. The Debian 12 image now uses the official Debian Unstable `cloud-init` package.<br />
+The issue has been fixed for Instances created  after June 2nd, 2023. The Debian 12 image now uses the official Debian Unstable `cloud-init` package.<br />
 
 Run the following commands to fix the issue on an Instance affected by this bug:
 ```

--- a/compute/instances/troubleshooting/fix-cloud-init-debian12.mdx
+++ b/compute/instances/troubleshooting/fix-cloud-init-debian12.mdx
@@ -1,0 +1,30 @@
+---
+meta:
+  title: Fix the wrong user configuration of cloud-init on Debian 12 (Bookworm)
+  description: This page helps you to fix the wrong user configuration of cloud-init on Debian 12 (Bookworm)
+content:
+  h1: Fix the wrong user configuration of cloud-init on Debian 12 (Bookworm)
+  paragraph: This page helps you to fix the wrong user configuration of cloud-init on Debian 12 (Bookworm)
+tags: debian12 debian bookworm cloud-init
+dates:
+  validation: 2023-06-16
+  posted: 2023-05-04
+categories:
+  - compute
+---
+
+Debian 12 (Bookworm) Instances created prior to 2023-06-22 were delivered with a version of `cloud-init` preinstalled that came with a wrong user configuration made by the custom-built upstream cloud-init 23.2.
+The problem has been fixed for Instances created past the above mentioned date. The Debian 12 image now uses the official Debian Unstable cloud-init package.
+
+To fix the problem on a Instance affected by this bug, run the following steps to fix the issue:
+
+```
+wget http://ftp.fr.debian.org/debian/pool/main/c/cloud-init/cloud-init_23.2-1_all.deb -O /tmp/cloud-init_23.2-1_all.deb
+
+dpkg -i /tmp/cloud-init_23.2-1_all.deb
+
+for FILE in /etc/group /etc/gshadow /etc/passwd /etc/shadow /etc/subgid /etc/subuid /etc/sudoers.d/90-cloud-init-users;
+do
+sed -i -e 's/Ubuntu/Debian/g' -e 's/ubuntu/debian/g' $FILE
+done
+```

--- a/menu/navigation.json
+++ b/menu/navigation.json
@@ -529,6 +529,10 @@
                     "slug": "bootscript-eol"
                   },
                   {
+                    "label": "Fixing the user configuration of cloud-init on Debian 12",
+                    "slug": "fix-cloud-init-debian12"
+                  },
+                  {
                     "label": "Changing the rescue mode of Instances",
                     "slug": "change-rescue-mode"
                   }


### PR DESCRIPTION

### Description
Steps to fix the wrong user configuration of cloud-init for Debian 12 
