### PR TITLE
docs(pgw): shell export cmd typo

### DIFF
--- a/network/vpc/api-cli/standalone-pgw-rpn.mdx
+++ b/network/vpc/api-cli/standalone-pgw-rpn.mdx
@@ -55,7 +55,7 @@ This solution intended for testing purposes, given that VPC and regional Private
     # The IPv4 subnet of your regional PN is: 172.16.12.0/22
     # The IP of your Public Gateway will be: 172.16.12.1/22
     
-    e$ xport PGW_ADDR="172.16.12.1"
+    $ export PGW_ADDR="172.16.12.1"
     $ export PGW_NET_ADDR="$PGW_ADDR/22"
     ```
 


### PR DESCRIPTION
### Description

Fix typo in shell export command in PGW / RPN howto.

