### PR TITLE
docs(k8s): add exposed service type information

### DIFF
--- a/containers/kubernetes/api-cli/exposing-services.mdx
+++ b/containers/kubernetes/api-cli/exposing-services.mdx
@@ -18,6 +18,7 @@ categories:
 <Message type="requirement">
   - You have an account and are logged into the [Scaleway console](https://console.scaleway.com)
   - You have [created](/containers/kubernetes/how-to/create-cluster/) a Scaleway Kubernetes cluster
+  - The service you want to expose is a `TCP` or `HTTP` one
 </Message>
 
 ## Creating a Load Balancer service


### PR DESCRIPTION
Load Balancer only handle TCP and HTTP service, trying to expose another type of service is not possible using this method.

### Your checklist for this pull request

- [x] Check that the commit messages match our requested structure.
- [x] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description
Please describe your pull request.

