### PR TITLE
nit: appropriate naming for operator

### DIFF
--- a/containers/kubernetes/how-to/use-nvidia-gpu-operator.mdx
+++ b/containers/kubernetes/how-to/use-nvidia-gpu-operator.mdx
@@ -1,11 +1,11 @@
 ---
 meta:
-  title: How to use the Kubernetes GPU operator on Kapsule and Kosmos with GPU Instances
-  description: This page explains how to use the Kubernetes GPU operator on Kapsule and Kosmos with GPU Instances
+  title: How to use the NVIDIA GPU operator on Kapsule and Kosmos with GPU Instances
+  description: This page explains how to use the NVIDIA GPU operator on Kapsule and Kosmos with GPU Instances
 content:
-  h1: How to use the Kubernetes GPU operator on Kapsule and Kosmos with GPU Instances
-  paragraph: This page explains how to use the Kubernetes GPU operator on Kapsule and Kosmos with GPU Instances
-tags: kubernetes kubernetes-kapsule kapsule cluster gpu-operator
+  h1: How to use the NVIDIA GPU operator on Kapsule and Kosmos with GPU Instances
+  paragraph: This page explains how to use the NVIDIA GPU operator on Kapsule and Kosmos with GPU Instances
+tags: kubernetes kubernetes-kapsule kapsule cluster gpu-operator nvidia gpu
 dates:
   validation: 2023-07-18
   posted: 2023-07-18


### PR DESCRIPTION
changed 'Kubernetes' to 'NVIDIA' where appropriate