### PR TITLE
docs(ObjectStorage): addANoteAboutAwsEndpointUrlError main

### DIFF
--- a/storage/object/api-cli/object-storage-aws-cli.mdx
+++ b/storage/object/api-cli/object-storage-aws-cli.mdx
@@ -90,6 +90,11 @@ To interact with Object Storage, `aws-cli` and `awscli-plugin-endpoint` need to 
 
     <Message type="note">
       Set the `endpoint_url` and `region` corresponding to the geographical region of your bucket. It can either be `fr-par` (Paris, France), `nl-ams` (Amsterdam, The Netherlands) or `pl-waw` (Warsaw, Poland).
+
+      If you are facing to an error like : Could not connect to the endpoint URL: "https://s3.fr-par.amazonaws.com/"
+      You can use the following cli option : `--endpoint-url=https://s3.fr-par.scw.cloud`
+
+
     </Message>
 4. Generate a credentials file using the command:
     ```


### PR DESCRIPTION
when using macOS AWS-CLI the Scaleway endpoint are ignored when using [scaleway doc](https://www.scaleway.com/en/docs/storage/object/api-cli/object-storage-aws-cli/) .  This behavior can be fixed temporary with --endpoint-url

### Your checklist for this pull request

- [ ] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

Please describe what you added or changed.

I have added a comment about an error when using AWS-CLI on Mac : Could not connect to the endpoint URL: "https://s3.fr-par.amazonaws.com/"
You can bypass it with --endpoint-url


