### PR TITLE
feat(changelog): kubernetes-changed-bumped-images-to-ubuntu 2023-09-01

### DIFF
--- a/changelog/september2023/2023-09-01-kubernetes-changed-bumped-images-to-ubuntu.mdx
+++ b/changelog/september2023/2023-09-01-kubernetes-changed-bumped-images-to-ubuntu.mdx
@@ -1,0 +1,14 @@
+---
+title: Bumped images to Ubuntu 22.04 and 6.2 kernel
+status: changed
+author:
+    fullname: 'Join the #k8s channel on Slack.'
+    url: 'https://slack.scaleway.com'
+date: 2023-09-01
+category: containers
+product: kubernetes
+---
+
+Starting from Kubernetes version `1.28.0`, worker nodes are now using Ubuntu 22.04 and 6.2 kernel.
+
+


### PR DESCRIPTION
Reporter: tgenaitay

This PR is a new changelog contribution. It has been created automatically.

Make sure to review it carefully before merging it.