### PR TITLE
feat(header): add link

### DIFF
--- a/blocks/header.json
+++ b/blocks/header.json
@@ -15,6 +15,11 @@
     "package": "developers"
   },
   {
+    "to": "/",
+    "label": "Scaleway Learning",
+    "package": "learning"
+  },
+  {
     "to": "/changelog/",
     "label": "Changelog",
     "package": "docs"


### PR DESCRIPTION
## Why 
- Testing add new link for Scaleway Learning 

## Testing
- Just check the link target `/en/learning/`