### PR TITLE
feat(changelog): apple-silicon-changed-macos-ventura-13-now 2023-10-02

### DIFF
--- a/changelog/october2023/2023-10-02-apple-silicon-changed-macos-ventura-13-now.mdx
+++ b/changelog/october2023/2023-10-02-apple-silicon-changed-macos-ventura-13-now.mdx
@@ -1,5 +1,5 @@
 ---
-title: macOS Ventura 13 now available
+title: macOS Ventura 13 now available!
 status: changed
 author:
     fullname: 'Join the #apple-silicon channel on Slack.'

--- a/changelog/october2023/2023-10-02-apple-silicon-changed-macos-ventura-13-now.mdx
+++ b/changelog/october2023/2023-10-02-apple-silicon-changed-macos-ventura-13-now.mdx
@@ -1,0 +1,13 @@
+---
+title: macOS Ventura 13 now available
+status: changed
+author:
+    fullname: 'Join the #apple-silicon channel on Slack.'
+    url: 'https://slack.scaleway.com'
+date: 2023-10-02
+category: bare-metal
+product: apple-silicon
+---
+
+Mac mini M1 is now installed with **macOS Ventura 13** by default.
+


### PR DESCRIPTION
Reporter: Simon Grelet

This PR is a new changelog contribution. It has been created automatically.

Make sure to review it carefully before merging it.