### PR TITLE
docs(vpc): Troubleshooting debian bullseye no default route int-add-vpc

### DIFF
--- a/network/vpc/troubleshooting/autoconfig-not-working.mdx
+++ b/network/vpc/troubleshooting/autoconfig-not-working.mdx
@@ -31,7 +31,7 @@ If your Instance does not get autoconfigured, it may be that you are using an ol
     apt list scaleway-ecosystem
     ```
 
-- On Debian distributions (Bookwork, Bullseye and Buster):
+- On Debian distributions (Bookworm, Bullseye and Buster):
 
     ```bash
     cat << EOF > /etc/apt/sources.list.d/scaleway-ubuntu-debian-stable-jammy.list

--- a/network/vpc/troubleshooting/private-dns-dhcp-not-working.mdx
+++ b/network/vpc/troubleshooting/private-dns-dhcp-not-working.mdx
@@ -31,3 +31,4 @@ DHCP should work out of the box for attached resources running any and all Linux
 
 In this case, if you are using `systemd-networkd` and do not have a route to our service IP address `169.254.169.254`, you should try updating and upgrading the packages on your system.
 
+There is also a known [bug](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=867625) affecting **Debian Bullseye** that prevents DHCP Client to apply correctly the default route. For this specific bug, we recommend to use another distribution like **Debian Bookworm**.

--- a/network/vpc/troubleshooting/private-dns-dhcp-not-working.mdx
+++ b/network/vpc/troubleshooting/private-dns-dhcp-not-working.mdx
@@ -31,4 +31,4 @@ DHCP should work out of the box for attached resources running any and all Linux
 
 In this case, if you are using `systemd-networkd` and do not have a route to our service IP address `169.254.169.254`, you should try updating and upgrading the packages on your system.
 
-There is also a known [bug](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=867625) affecting **Debian Bullseye** that prevents DHCP Client to apply correctly the default route. For this specific bug, we recommend to use another distribution like **Debian Bookworm**.
+There is also a known [bug](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=867625) affecting **Debian Bullseye**, that prevents DHCP clients  from correctly applying the default route. For this specific bug, we recommend using another distribution, such as **Debian Bookworm**.

--- a/network/vpc/troubleshooting/private-dns-dhcp-not-working.mdx
+++ b/network/vpc/troubleshooting/private-dns-dhcp-not-working.mdx
@@ -31,4 +31,4 @@ DHCP should work out of the box for attached resources running any and all Linux
 
 In this case, if you are using `systemd-networkd` and do not have a route to our service IP address `169.254.169.254`, you should try updating and upgrading the packages on your system.
 
-There is also a known [bug](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=867625) affecting **Debian Bullseye**, that prevents DHCP clients  from correctly applying the default route. For this specific bug, we recommend using another distribution, such as **Debian Bookworm**.
+There is also a known [bug](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=867625) affecting **Debian Bullseye**, that prevents DHCP clients from correctly applying the default route. For this specific bug, we recommend using another distribution, such as **Debian Bookworm**.


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

Add Troubleshooting information for when debian bullseye instance has no no default route
