### PR TITLE
feat(changelog): kubernetes-deprecated-kapsule-clusters-with-only-public 2023-10-18

### DIFF
--- a/changelog/october2023/2023-10-18-kubernetes-deprecated-kapsule-clusters-with-only-public.mdx
+++ b/changelog/october2023/2023-10-18-kubernetes-deprecated-kapsule-clusters-with-only-public.mdx
@@ -1,0 +1,21 @@
+---
+title: Kapsule clusters with only public IPs
+status: deprecated
+author:
+    fullname: 'Join the #k8s channel on Slack.'
+    url: 'https://slack.scaleway.com'
+date: 2023-10-18
+category: containers
+product: kubernetes
+---
+
+Hardening security is a top priority. 
+
+Effective now, every new Kapsule cluster is required a (free) Private Network attached.
+
+Starting this deprecation cycle, existing Kapsule clusters must be connected to a Private Network. 
+
+The default worker nodes isolation configuration will keep public IPs for nodes to access the Internet, and add private endpoints for resources to communicate securely. Security groups aren't overridden at migration and RR wildcard DNS still point to public IPs.
+
+More information on the migration steps provided in [our reference documentation](https://www.scaleway.com/en/docs/containers/kubernetes/reference-content/secure-cluster-with-private-network/).
+

--- a/changelog/october2023/2023-10-18-kubernetes-deprecated-kapsule-clusters-with-only-public.mdx
+++ b/changelog/october2023/2023-10-18-kubernetes-deprecated-kapsule-clusters-with-only-public.mdx
@@ -11,11 +11,11 @@ product: kubernetes
 
 Hardening security is a top priority. 
 
-Effective now, every new Kapsule cluster is required a (free) Private Network attached.
+Effective now, every new Kapsule cluster is required to have a (free) Private Network attached.
 
 Starting this deprecation cycle, existing Kapsule clusters must be connected to a Private Network. 
 
-The default worker nodes isolation configuration will keep public IPs for nodes to access the Internet, and add private endpoints for resources to communicate securely. Security groups aren't overridden at migration and RR wildcard DNS still point to public IPs.
+The default worker nodes' isolation configuration will keep public IPs for nodes to access the Internet, and add private endpoints for resources to communicate securely. Security groups aren't overridden at migration and RR wildcard DNS still point to public IPs.
 
-More information on the migration steps provided in [our reference documentation](https://www.scaleway.com/en/docs/containers/kubernetes/reference-content/secure-cluster-with-private-network/).
+More information on the migration steps is provided in [our reference documentation](https://www.scaleway.com/en/docs/containers/kubernetes/reference-content/secure-cluster-with-private-network/).
 


### PR DESCRIPTION
Reporter: tgenaitay

This PR is a new changelog contribution. It has been created automatically.

Make sure to review it carefully before merging it.