### PR TITLE
feat(serverless): call private functions and containers from triggers

### DIFF
--- a/serverless/containers/how-to/add-trigger-to-a-container.mdx
+++ b/serverless/containers/how-to/add-trigger-to-a-container.mdx
@@ -31,11 +31,8 @@ The trigger is configured during the container deployment, and it determines how
 </Message>
 
 <Message type="important">
-  This feature is currently in beta.
-</Message>
-
-<Message type="important">
-  It is possible to create triggers on private functions. But, if you want to **update** the privacy of a function from public to private, you will need to recreate the existing **SQS** and **NATS** triggers after the privacy change. We are actively working to make this operation as seamless as possible, but for now, you will need to recreate the triggers.
+  - This feature is currently in beta.
+  - You can create triggers on private functions, but to update the privacy of a function from **public** to **private**, you must recreate the existing **SQS** and **NATS** triggers after the privacy change. We are actively working to make this operation as seamless as possible.
 </Message>
 
 <Message type="note">

--- a/serverless/containers/how-to/add-trigger-to-a-container.mdx
+++ b/serverless/containers/how-to/add-trigger-to-a-container.mdx
@@ -31,7 +31,11 @@ The trigger is configured during the container deployment, and it determines how
 </Message>
 
 <Message type="important">
-  This feature is currently in beta and does not support calling private containers yet.
+  This feature is currently in beta.
+</Message>
+
+<Message type="important">
+  It is possible to create triggers on private functions. But, if you want to **update** the privacy of a function from public to private, you will need to recreate the existing **SQS** and **NATS** triggers after the privacy change. We are actively working to make this operation as seamless as possible, but for now, you will need to recreate the triggers.
 </Message>
 
 <Message type="note">

--- a/serverless/functions/how-to/add-trigger-to-a-function.mdx
+++ b/serverless/functions/how-to/add-trigger-to-a-function.mdx
@@ -26,7 +26,15 @@ This page shows you how to configure triggers for your functions. Triggers are c
 </Message>
 
 <Message type="important">
-  This feature is currently in beta and does not support calling private functions yet.
+  This feature is currently in beta.
+</Message>
+
+<Message type="important">
+  It is possible to create triggers on private functions. But, if you want to **update** the privacy of a function from public to private, you will need to recreate the existing **SQS** and **NATS** triggers after the privacy change. We are actively working to make this operation as seamless as possible, but for now, you will need to recreate the triggers.
+</Message>
+
+<Message type="note">
+  Triggers send messages through a `POST` request with the message body in the request body.
 </Message>
 
 ## SQS triggers

--- a/serverless/functions/how-to/add-trigger-to-a-function.mdx
+++ b/serverless/functions/how-to/add-trigger-to-a-function.mdx
@@ -26,11 +26,8 @@ This page shows you how to configure triggers for your functions. Triggers are c
 </Message>
 
 <Message type="important">
-  This feature is currently in beta.
-</Message>
-
-<Message type="important">
-  It is possible to create triggers on private functions. But, if you want to **update** the privacy of a function from public to private, you will need to recreate the existing **SQS** and **NATS** triggers after the privacy change. We are actively working to make this operation as seamless as possible, but for now, you will need to recreate the triggers.
+  - This feature is currently in beta.
+  - You can create triggers on private functions, but to update the privacy of a function from **public** to **private**, you must recreate the existing **SQS** and **NATS** triggers after the privacy change. We are actively working to make this operation as seamless as possible.
 </Message>
 
 <Message type="note">


### PR DESCRIPTION
### Your checklist for this pull request

- [X] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

It is now possible to call private functions and containers from SQS and NATS triggers!

I've also added the "note" in the functions page (it was already in the containers page); and it's valid for both products.

Thanks!