### PR TITLE
feat(changelog): kubernetes-removed-kubernetes-122-is-no-longer-supporte 2023-10-26

### DIFF
--- a/changelog/october2023/2023-10-26-kubernetes-removed-kubernetes-122-is-no-longer-supporte.mdx
+++ b/changelog/october2023/2023-10-26-kubernetes-removed-kubernetes-122-is-no-longer-supporte.mdx
@@ -1,5 +1,5 @@
 ---
-title: Kubernetes 1.22 is no longer supported on our Kubernetes products
+title: Scaleway Kubernetes products no longer support Kubernetes 1.22
 status: removed
 author:
     fullname: 'Join the #k8s channel on Slack.'
@@ -9,5 +9,5 @@ category: containers
 product: kubernetes
 ---
 
-Clusters using this specific version will be automatically upgraded to 1.23 on October 16th, 2023. Find more details in [our version support policy](https://www.scaleway.com/en/docs/containers/kubernetes/reference-content/version-support-policy/#scaleway-kubernetes-kapsule-and-kosmos-release-calendar).
+Clusters using the Kubernetes 1.22 version will be automatically upgraded to the Kubernetes 1.23 version on October 16th, 2023. Find more details in [our version support policy](/containers/kubernetes/reference-content/version-support-policy/#scaleway-kubernetes-kapsule-and-kosmos-release-calendar).
 

--- a/changelog/october2023/2023-10-26-kubernetes-removed-kubernetes-122-is-no-longer-supporte.mdx
+++ b/changelog/october2023/2023-10-26-kubernetes-removed-kubernetes-122-is-no-longer-supporte.mdx
@@ -1,0 +1,13 @@
+---
+title: Kubernetes 1.22 is no longer supported on our Kubernetes products
+status: removed
+author:
+    fullname: 'Join the #k8s channel on Slack.'
+    url: 'https://slack.scaleway.com'
+date: 2023-10-26
+category: containers
+product: kubernetes
+---
+
+Clusters using this specific version will be automatically upgraded to 1.23 on October 16th, 2023. Find more details in [our version support policy](https://www.scaleway.com/en/docs/containers/kubernetes/reference-content/version-support-policy/#scaleway-kubernetes-kapsule-and-kosmos-release-calendar).
+


### PR DESCRIPTION
Reporter: tgenaitay

This PR is a new changelog contribution. It has been created automatically.

Make sure to review it carefully before merging it.