### PR TITLE
fix(vpc): wrong number for IP range

### DIFF
--- a/network/vpc/how-to/create-private-network.mdx
+++ b/network/vpc/how-to/create-private-network.mdx
@@ -90,7 +90,7 @@ If you prefer, you can define your own custom IPv4 CIDR block when creating your
     - `172.16.0.0` - `172.31.255.255`
     - `10.0.0.0` - `10.255.255.255`
 
-4. Choose your **network size** from the options available. The range of options begins at `/20`, with 2094 addresses available for resources on the Private Network, and ends at `/28`, with 14 addresses available for resources on the Private Network.
+4. Choose your **network size** from the options available. The range of options begins at `/20`, with 4094 addresses available for resources on the Private Network, and ends at `/28`, with 14 addresses available for resources on the Private Network.
 
 5. Click **Create Private Network** to finish.
 


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

/20 is 4094 not 2094 IPs
