### PR TITLE
docs(FAQ): remove deprecated extensions from RDB PostgreSQL extensions list

### DIFF
--- a/faq/databases-for-postgresql-and-mysql.mdx
+++ b/faq/databases-for-postgresql-and-mysql.mdx
@@ -101,7 +101,6 @@ The following `pg_extensions` are available for Scaleway Database:
 
 | Extension name               | Comment                                                                                                                                         |
 |------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|
-| chkpass                      | data type for auto-encrypted passwords                                                                                                          |
 | pgrowlocks                   | show row-level locking information                                                                                                              |
 | sslinfo                      | information about SSL certificates                                                                                                              |
 | citext                       | data type for case-insensitive character strings                                                                                                |
@@ -144,7 +143,6 @@ The following `pg_extensions` are available for Scaleway Database:
 | pgrouting                    | pgRouting extends the PostGIS / PostgreSQL geospatial database to provide geospatial routing functionality                                      |
 | ogr_fdw                      | OGR is the vector half of the GDAL spatial data access library                                                                                  |
 | timescaledb                  | enable handling of time-series data                                                                                                             |
-| tsearch2                     | backwards-compatible text search for applications that used tsearch2 before text searching was integrated into core PostgreSQL 8.3              |
 | pg_cron                      | cron-based job scheduler for PostgreSQL                                                                                                         |
 | pg_stat_statements           | track planning and execution statistics of all SQL statements executed by a server                                                              |
 


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description
Remove extensions `chkpass` (deprecated from PG11) and `tsearch2` (deprecated from PG10) from RDB Postgres extensions list in the FAQ.