### PR TITLE
docs(k8s): removed outdated documentation

### DIFF
--- a/changelog/february2023/2023-02-07-kubernetes-removed-container-runtimes-docker-and.mdx
+++ b/changelog/february2023/2023-02-07-kubernetes-removed-container-runtimes-docker-and.mdx
@@ -11,5 +11,4 @@ product: kubernetes
 
 All new pools created in Scaleway Kubernetes clusters now use `Containerd` as their default runtime. 
 
-We recommend you migrate node pools to a supported CRI. You can find more details about migration policies in our [version support policy page](/containers/kubernetes/reference-content/version-support-policy/).
 

--- a/changelog/february2023/2023-02-07-kubernetes-removed-container-runtimes-docker-and.mdx
+++ b/changelog/february2023/2023-02-07-kubernetes-removed-container-runtimes-docker-and.mdx
@@ -11,5 +11,5 @@ product: kubernetes
 
 All new pools created in Scaleway Kubernetes clusters now use `Containerd` as their default runtime. 
 
-We recommend you [migrate node pools](/containers/kubernetes/how-to/change-container-runtime-interface/) to a supported CRI. You can find more details about migration policies in our [version support policy page](/containers/kubernetes/reference-content/version-support-policy/).
+We recommend you migrate node pools to a supported CRI. You can find more details about migration policies in our [version support policy page](/containers/kubernetes/reference-content/version-support-policy/).
 

--- a/containers/kubernetes/how-to/change-container-runtime-interface.mdx
+++ b/containers/kubernetes/how-to/change-container-runtime-interface.mdx
@@ -13,6 +13,10 @@ categories:
   - kubernetes
 ---
 
+<Message type="important">
+  Docker and CRI-O container runtimes [are no longer available](https://www.scaleway.com/en/docs/changelog/?a=kubernetes-05cf9bcf-5681).
+</Message>
+
 A container runtime is a software that manages the starting and stopping of containers, among other tasks. It is a fundamental component of Kubernetes. Initially, Docker was used as the container runtime for Kubernetes. However, as container runtimes continued to evolve rapidly, it became apparent that Docker was not the best choice. Other solutions emerged as more suitable alternatives.
 The Container Runtime Interface (CRI) was developed as a means to open up Kubernetes to other container runtimes. CRI is a plugin within a Kubernetes cluster that allows the `kubelet` to use more than one type of container runtime. It consists of a protocol buffer and a gRPC API, as well as libraries, with additional specifications and tools.
 At Scaleway, we favor Containerd, the industry-leading CRI solution. [Containerd](https://containerd.io/) was initially developed by Docker and donated to the Cloud Native Computing Foundation (CNCF). It uses a subset of the original Docker engine and comes with most of Docker's functionalities for running containers and managing storage and images - but lacks many developer-oriented features. It is, therefore, suitable for large-scale use as part of a container orchestrator, such as Kubernetes. 

--- a/containers/kubernetes/how-to/upgrade-kubernetes-version.mdx
+++ b/containers/kubernetes/how-to/upgrade-kubernetes-version.mdx
@@ -152,5 +152,5 @@ The process is quite similar to the previous one except you need to repeat the s
 
 <Navigation title="See Also">
   <PreviousButton to="/containers/kubernetes/how-to/monitor-cluster/">How to monitor a cluster</PreviousButton>
-  <NextButton to="/containers/kubernetes/how-to/change-container-runtime-interface/">How to change the Container Runtime Interface of a node pool</NextButton>
+  <NextButton to="/containers/kubernetes/how-to/use-nvidia-gpu-operator/">How to use the NVIDIA GPU operator on Kapsule and Kosmos with GPU Instances</NextButton>
 </Navigation>

--- a/containers/kubernetes/how-to/use-nvidia-gpu-operator.mdx
+++ b/containers/kubernetes/how-to/use-nvidia-gpu-operator.mdx
@@ -80,6 +80,6 @@ The GPU operator on your Scaleway node pools is fully configurable, either throu
 6. Click **Update and deploy** to update and deploy the configuration of the GPU operator.
 
 <Navigation title="See Also">
-  <PreviousButton to="/containers/kubernetes/how-to/change-container-runtime-interface/">How to change the Container Runtime Interface of a node pool</PreviousButton>
+  <PreviousButton to="/containers/kubernetes/how-to/upgrade-kubernetes-version/">How to upgrade the Kubernetes version on a Kapsule cluster</PreviousButton>
   <NextButton to="/containers/kubernetes/how-to/delete-cluster/">How to delete a cluster</NextButton>
 </Navigation>

--- a/containers/kubernetes/reference-content/version-support-policy.mdx
+++ b/containers/kubernetes/reference-content/version-support-policy.mdx
@@ -145,5 +145,4 @@ Starting from Kubernetes version 1.25 launch, **containerd** is the only runtime
 * Migration policies:
   * Pools using deprecated CRIs cannot scale up.
   * Control Planes cannot be upgraded if CRI used by any pool is obsolete.
-  * *Recommended action:* Delete your old pools and create new ones with **containerd** as default, either via API or from the Scaleway console. [Learn how  in this tutorial.](/containers/kubernetes/how-to/change-container-runtime-interface/)
 

--- a/menu/navigation.json
+++ b/menu/navigation.json
@@ -1416,10 +1416,6 @@
                     "slug": "upgrade-kubernetes-version"
                   },
                   {
-                    "label": "Change the Container Runtime Interface of a node pool",
-                    "slug": "change-container-runtime-interface"
-                  },
-                  {
                     "label": "Use the NVIDIA GPU operator on Kapsule and Kosmos with GPU Instances",
                     "slug": "use-nvidia-gpu-operator"
                   },


### PR DESCRIPTION
### Description

Removed outdated CRI migration documentation