### PR TITLE
feat(changelog): apple-silicon-deprecated-fr-par-1-is-disabled-in-the-ap 2023-11-08

### DIFF
--- a/changelog/november2023/2023-11-08-apple-silicon-deprecated-fr-par-1-is-disabled-in-the-ap.mdx
+++ b/changelog/november2023/2023-11-08-apple-silicon-deprecated-fr-par-1-is-disabled-in-the-ap.mdx
@@ -9,5 +9,5 @@ category: bare-metal
 product: apple-silicon
 ---
 
-Every request on `/apple-silicon/v1alpha1/zones/fr-par-1/*` will no longer be responded for Apple Silicon M1 servers. The PAR-3 AZ must be used instead by requesting `/apple-silicon/v1alpha1/zones/fr-par-3/*`
+For Apple Silicon M1 servers, requests to `/apple-silicon/v1alpha1/zones/fr-par-1/*` will no longer receive responses. All requests should now go to the PAR-3 AZ, using `/apple-silicon/v1alpha1/zones/fr-par-3/*`.
 

--- a/changelog/november2023/2023-11-08-apple-silicon-deprecated-fr-par-1-is-disabled-in-the-ap.mdx
+++ b/changelog/november2023/2023-11-08-apple-silicon-deprecated-fr-par-1-is-disabled-in-the-ap.mdx
@@ -1,0 +1,13 @@
+---
+title: fr-par-1 is disabled in the API
+status: deprecated
+author:
+    fullname: 'Join the #apple-silicon channel on Slack.'
+    url: 'https://slack.scaleway.com'
+date: 2023-11-08
+category: bare-metal
+product: apple-silicon
+---
+
+Every request on `/apple-silicon/v1alpha1/zones/fr-par-1/*` will no longer be responded for Apple Silicon M1 servers. The PAR-3 AZ must be used instead by requesting `/apple-silicon/v1alpha1/zones/fr-par-3/*`
+


### PR DESCRIPTION
Reporter: Simon Grelet

This PR is a new changelog contribution. It has been created automatically.

Make sure to review it carefully before merging it.