### PR TITLE
feat(changelog): kubernetes-changed-bumped-linux-kernel-to-620-36 2023-11-14

### DIFF
--- a/changelog/november2023/2023-11-14-kubernetes-changed-bumped-linux-kernel-to-620-36.mdx
+++ b/changelog/november2023/2023-11-14-kubernetes-changed-bumped-linux-kernel-to-620-36.mdx
@@ -9,6 +9,5 @@ category: containers
 product: kubernetes
 ---
 
-Bumped to kernel `6.2.0-36` for worker nodes running Kubernetes version 1.28.x. 
-Default to new nodes; Applied at reboot for existing nodes.
+Worker nodes running Kubernetes version 1.28.x have been upgraded to kernel version `6.2.0-36`. This change will automatically apply to new nodes and will take effect on existing nodes upon their next reboot.
 

--- a/changelog/november2023/2023-11-14-kubernetes-changed-bumped-linux-kernel-to-620-36.mdx
+++ b/changelog/november2023/2023-11-14-kubernetes-changed-bumped-linux-kernel-to-620-36.mdx
@@ -1,0 +1,14 @@
+---
+title: Bumped Linux kernel to 6.2.0-36
+status: changed
+author:
+    fullname: 'Join the #k8s channel on Slack.'
+    url: 'https://slack.scaleway.com'
+date: 2023-11-14
+category: containers
+product: kubernetes
+---
+
+Bumped to kernel `6.2.0-36` for worker nodes running Kubernetes version 1.28.x. 
+Default to new nodes; Applied at reboot for existing nodes.
+


### PR DESCRIPTION
Reporter: tgenaitay

This PR is a new changelog contribution. It has been created automatically.

Make sure to review it carefully before merging it.