### PR TITLE
docs(tutorial): remove comment that produce error on container launch

### DIFF
--- a/tutorials/deploy-laravel-on-serverless-containers/index.mdx
+++ b/tutorials/deploy-laravel-on-serverless-containers/index.mdx
@@ -188,7 +188,6 @@ In this section, we will focus on building the containerized image. With Docker,
 4. Create the php-fpm configuration file. The configuration `stubs/php/php-fpm.d/zz-docker.conf` file should be created, and the php-fpm pool configured to render the dynamic pages of the Laravel application. Depending on the needs of your application, you might have to fine-tune the configuration of the process manager. Further information is available in the [php manual](https://www.php.net/manual/en/install.fpm.configuration.php).
     
     ``` 
-    # stubs/php/php-fpm.d/zz-docker.conf
     [global]
     daemonize = no
 


### PR DESCRIPTION
### Description

Remove that comment in Deploying Laravel 10.x on Serverless Containers tutorial : 
`# stubs/php/php-fpm.d/zz-docker.conf`

PHP don't appreciate the "#" and the container crash on launch