### PR TITLE
docs(help-banner): update editor components

### DIFF
--- a/editor-components.mdx
+++ b/editor-components.mdx
@@ -61,6 +61,21 @@ content:
 
 ---
 
+## HelpBanner
+
+🧩 &nbsp;This component uses a **Tag** style.
+
+<HelpBanner href="https://console.scaleway.com/support/tickets" />
+
+**Code example**
+
+```jsx
+<HelpBanner href="https://console.scaleway.com/support/tickets" />
+```
+
+
+---
+
 
 ## Log (Changelog)
 
@@ -128,7 +143,6 @@ The content section works as any documentation `.mdx` file. It accepts both mark
 ## Navigation
 
 ### PreviousButton, NextButton
-
 
 <Navigation>
   <PreviousButton to="/">Previous</PreviousButton>


### PR DESCRIPTION

### Description

- Add `HelpBanner` to editor-components.mdx

---

![Capture d’écran 2023-11-22 à 6 31 08 PM](https://github.com/scaleway/docs-content/assets/341803/9079d023-43c8-49fa-bded-4654159ae22e)

---