### PR TITLE
feat(changelog): object-storage-added-deleteobjects-is-now-applicable-to 2023-11-27

### DIFF
--- a/changelog/november2023/2023-11-27-object-storage-added-deleteobjects-is-now-applicable-to.mdx
+++ b/changelog/november2023/2023-11-27-object-storage-added-deleteobjects-is-now-applicable-to.mdx
@@ -1,0 +1,13 @@
+---
+title: DeleteObjects is now applicable to VersionID
+status: added
+author:
+    fullname: 'Join the #object-storage channel on Slack.'
+    url: 'https://slack.scaleway.com'
+date: 2023-11-27
+category: storage
+product: object-storage
+---
+
+It is now possible to specify a versionID to limit deletion to specific objects versions, or to versions other than current version, for multiple objects at a time.
+

--- a/changelog/november2023/2023-11-27-object-storage-added-deleteobjects-is-now-applicable-to.mdx
+++ b/changelog/november2023/2023-11-27-object-storage-added-deleteobjects-is-now-applicable-to.mdx
@@ -9,5 +9,5 @@ category: storage
 product: object-storage
 ---
 
-It is now possible to specify a versionID to limit deletion to specific objects versions, or to versions other than current version, for multiple objects at a time.
+It is now possible to specify a `VersionId` to limit deletion to specific objects versions, or to versions other than current version, for multiple objects at a time.
 


### PR DESCRIPTION
Reporter: Marie Debard

This PR is a new changelog contribution. It has been created automatically.

Make sure to review it carefully before merging it.