### PR TITLE
docs(tem): remove mention of hourly quota in docs

### DIFF
--- a/console/account/reference-content/organization-quotas.mdx
+++ b/console/account/reference-content/organization-quotas.mdx
@@ -369,14 +369,15 @@ Additional IP addresses and placement groups are available with our compute offe
 Transactional Email is a platform that allows Scaleway clients to send [transactional emails](/managed-services/transactional-email/concepts/#transactional-email) with high quality [deliverability](/managed-services/transactional-email/concepts/#deliverability).
 
 <Message type="note">
- Additional quotas can be added on a case-by-case basis. If you have already validated your payment method and your identity and want to increase your quota beyond the values shown on this page, [contact our support team](https://console.scaleway.com/support/create).
+ - Additional quotas can be added on a case-by-case basis. If you have already validated your payment method and your identity and want to increase your quota beyond the values shown on this page, [contact our support team](https://console.scaleway.com/support/create).
+ - Starting from December 1st 2023, Transactional Email no longer applies an hourly quota for your email sending. Find out more about Transactional Email's pricing on the [product pricing page](https://www.scaleway.com/en/pricing/?tags=available,managedservices-transactionalemail-transactionalemail).
+
 </Message>
 
 |                                     | [Payment method validated](/console/account/how-to/manage-billing-information/#how-to-add-a-credit-card) | Payment method and [identity validated](/console/account/how-to/verify-identity) |
 |-------------------------------------|-------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------|
 | Max. of recipients                  | 3                                                                                                           | 3                                                                |
 | Domains per Organization            | 2                                                                                                           | 5                                                                |
-| Emails sent per hour                | 50                                                                                                          | 200                                                              |
 | Emails sent per month               | 500                                                                                                         | 5000                                                             |
 | Max. of attachments                 | 2                                                                                                           | 2                                                                |
 | Max. size of an email (Mo) for API  | 2*                                                                                                          | 2*                                                               |

--- a/managed-services/transactional-email/reference-content/tem-capabilities-and-limits.mdx
+++ b/managed-services/transactional-email/reference-content/tem-capabilities-and-limits.mdx
@@ -18,7 +18,8 @@ This page provides information about the capabilities and limits of Scaleway Tra
 Every [Organization](/identity-and-access-management/iam/concepts/#organization) has quotas, which are limits on the number of Scaleway resources they can use. Below is a list of basic quotas available for Transactional Email.
 
 <Message type="note">
- Additional quotas can be added on a case-by-case basis. If you have already validated your payment method and your identity and want to increase your quota beyond the values shown on this page, [contact our support team](https://console.scaleway.com/support/create).
+ - Additional quotas can be added on a case-by-case basis. If you have already validated your payment method and your identity and want to increase your quota beyond the values shown on this page, [contact our support team](https://console.scaleway.com/support/create)
+ - Starting from 1st December 2023, Transactional Email no longer applies an hourly quota for your email sending. Find out more about Transactional Email's pricing on the [product pricing page](https://www.scaleway.com/en/pricing/?tags=available,managedservices-transactionalemail-transactionalemail).
 </Message>
 
 
@@ -26,7 +27,6 @@ Every [Organization](/identity-and-access-management/iam/concepts/#organization)
 |-------------------------------------|-------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------|
 | Max. of recipients                  | 3                                                                                                           | 3                                                                |
 | Domains per Organization            | 2                                                                                                           | 5                                                                |
-| Emails sent per hour                | 50                                                                                                          | 200                                                              |
 | Emails sent per month               | 500                                                                                                         | 5000                                                             |
 | Max. of attachments                 | 2                                                                                                           | 2                                                                |
 | Max. size of an email (Mo) for API  | 2*                                                                                                          | 2*                                                               |

--- a/managed-services/transactional-email/reference-content/tem-capabilities-and-limits.mdx
+++ b/managed-services/transactional-email/reference-content/tem-capabilities-and-limits.mdx
@@ -19,7 +19,7 @@ Every [Organization](/identity-and-access-management/iam/concepts/#organization)
 
 <Message type="note">
  - Additional quotas can be added on a case-by-case basis. If you have already validated your payment method and your identity and want to increase your quota beyond the values shown on this page, [contact our support team](https://console.scaleway.com/support/create)
- - Starting from 1st December 2023, Transactional Email no longer applies an hourly quota for your email sending. Find out more about Transactional Email's pricing on the [product pricing page](https://www.scaleway.com/en/pricing/?tags=available,managedservices-transactionalemail-transactionalemail).
+ - Starting from December 1st 2023, Transactional Email no longer applies an hourly quota for your email sending. Find out more about Transactional Email's pricing on the [product pricing page](https://www.scaleway.com/en/pricing/?tags=available,managedservices-transactionalemail-transactionalemail).
 </Message>
 
 


### PR DESCRIPTION
Removed all mentions of hourly quota in the relevant docs, as TEM no longer applies it.