### PR TITLE
feat(changelog): object-storage-changed-the-75gb-free-tier-is-replaced-b 2023-12-01

### DIFF
--- a/changelog/december2023/2023-12-01-object-storage-changed-the-75gb-free-tier-is-replaced-b.mdx
+++ b/changelog/december2023/2023-12-01-object-storage-changed-the-75gb-free-tier-is-replaced-b.mdx
@@ -1,0 +1,13 @@
+---
+title: The 75GB free tier is replaced by a 750GB free trial on Multi-AZ class!
+status: changed
+author:
+    fullname: 'Join the #object-storage channel on Slack.'
+    url: 'https://slack.scaleway.com'
+date: 2023-12-01
+category: storage
+product: object-storage
+---
+
+The existing free tier is evolving to better support our customers' intensive use cases. The brand new free trial offers you 750 GB of free Multi-AZ Standard class for 90 days. You can activate your Object Storage free trial directly from the Scaleway Console https://console.scaleway.com/object-storage/buckets. The trial is available to those who never used the Multi-AZ class before December, 1st. Be ready for a 90-day deep dive into Object Storage features, with special insights and onboarding tips!
+


### PR DESCRIPTION
Reporter: Marie Debard

This PR is a new changelog contribution. It has been created automatically.

Make sure to review it carefully before merging it.