### PR TITLE
docs(object-storage): add note to personalize number of days to keep …

### DIFF
--- a/storage/object/how-to/restore-an-object-from-glacier.mdx
+++ b/storage/object/how-to/restore-an-object-from-glacier.mdx
@@ -58,6 +58,12 @@ categories:
 
 ## How to restore all objects in a bucket
 
+<Message type="note">
+  By default, with s3cmd tool, the restored file is available 1 day. After, the file come back to `Glacier` class.
+  <br />
+  Set `-D NUM` or `--restore-days=NUM` in your restore command to increase this value.
+</Message>
+
 If you have numerous files in a bucket that you would like to restore, it may be more convenient to use the command line, for example with the [s3cmd tool](/tutorials/s3cmd/). To restore all files recursively in a bucket, you can invoke this command:
 
 ```


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

When you use `s3cmd restore`, the file switch from `GLACIER` class to `STANDARD` class for 1 day. This is not written in the [official documentation](https://s3tools.org/usage) but is written [in the code](https://github.com/s3tools/s3cmd/blob/master/s3cmd#L3057).

After several weeks of trying to understand why my files restored from my buckets automatically return to the glacier without lifecycles rules, Maxence from L2 scaleway support told me about this subtlety.

This PR is intended to inform future scaleway users of this subtlety and also save time (and money since restoration has become paid)

Thank you, I remain available if there is an error ;)


