### PR TITLE
feat(lb): add doc for flex ips

### DIFF
--- a/menu/navigation.json
+++ b/menu/navigation.json
@@ -2453,6 +2453,10 @@
                     "slug": "set-up-s3-failover"
                   },
                   {
+                    "label": "Create and manage flexible IPs",
+                    "slug": "create-manage-flex-ips"
+                  },
+                  {
                     "label": "Monitor your Load Balancer with Scaleway Cockpit",
                     "slug": "monitor-lb-cockpit"
                   },

--- a/network/load-balancer/concepts.mdx
+++ b/network/load-balancer/concepts.mdx
@@ -118,6 +118,8 @@ Each Load Balancer is configured with one or several frontends. Frontends listen
 
 Flexible IP addresses are public IP addresses that you can hold independently of any Load Balancer. By default, each Load Balancer is created automatically with a flexible IP address, that the frontend listens to. In case of a failure of the Load Balancer, a replica Load Balancer is immediately spawned and deployed, and the flexible IP address is automatically rerouted to this replica.
 
+Find out how to create and manage flexible IP addresses in our [dedicated how-to](/network/load-balancer/how-to/create-manage-flex-ips/).
+
 </Concept>
 
 <Concept>

--- a/network/load-balancer/how-to/create-manage-flex-ips.mdx
+++ b/network/load-balancer/how-to/create-manage-flex-ips.mdx
@@ -1,0 +1,95 @@
+---
+meta:
+  title: How to create and manage Load Balancer flexible IPs
+  description: This page explains how to create and manage flexible IP addresses for your Scaleway Load Balancer
+content:
+  h1: How to create and manage Load Balancer flexible IPs
+  paragraph: This page explains how to create and manage flexible IP addresses for your Scaleway Load Balancer
+tags: load-balancer flexible-ip failover-ip flex-ip ip-address reverse reverse-dns  
+dates:
+  validation: 2023-12-05
+  posted: 2023-12-05
+categories:
+  - network
+---
+
+This page shows you how to use [Load Balancer flexible IP addresses](/network/load-balancer/concepts/#flexible-ip-address). A flexible IP address is a public IP address for your Load Balancer.
+
+- You can create and hold flexible IP addresses independently of any Load Balancer.
+- When you create a Load Balancer with public accessibility, you can choose whether to create a new flexible IP address with it, or use an existing flexible IP address you hold.
+- When you delete the Load Balancer, you can choose to also delete the flexible IP address, or else hold it in your account to use with a future Load Balancer you create.
+
+<Message type="note">
+The following limitations apply to Load Balancer flexible IPs:
+- You cannot currently change the flexible IP address of an existing Load Balancer, that is to say you cannot detach its flexible IP after creation to attach a different one.
+- Flexible IPs are associated with a particular product and cannot be moved to a different type of resource. For example, a flexible IP for Load Balancer can be used with another Load Balancer, but it cannot be used with other resource types like Instances or Elastic Metal servers.
+</Message>
+
+<Macro id="iam-requirements" />
+
+<Message type="requirement">
+  - You have an account and are logged into the [Scaleway console](https://console.scaleway.com)
+  - You have [created a Load Balancer](/network/load-balancer/how-to/create-load-balancer/)
+</Message>
+
+## How to create a flexible IP address
+
+When you create a Load Balancer, the creation wizard lets you create a new flexible IP address that will be automatically attached to the Load Balancer in question. See the [How to create a Load Balancer](/network/load-balancer/how-to/create-load-balancer/) for full details. However, if you wish to create a flexible IP address to hold independently of any Load Balancer, follow the steps below:
+
+1. Click **Load Balancers** in the **Network** section of the [Scaleway console](https://console.scaleway.com) side menu.
+
+2. Click the **Flexible IPs** tab.
+
+    <Message type="tip">
+    You must have already created a Load Balancer in order for this tab to be visible.
+    </Message>
+
+3. Click **Create flexible IP**.
+
+    The flexible IP creation wizard displays.
+
+4. Choose the **Availability Zone** you want to create your flexible IP in. 
+
+5. Check the estimated cost, and click **Create flexible IP**.
+
+    Your flexible IP address is created. You are returned to the flexible IPs tab, where your list of IPs displays.
+
+
+## How to edit the reverse DNS of a flexible IP address
+
+You can edit the reverse DNS of any of your flexible IP addresses at any time. This allows you to replace the automatically-generated domain with your own domain name, so that, with the correct configuration of your domain's DNS, you can resolve your domain to the IP address of the flexible IP and vice versa.
+
+1. Click **Load Balancers** in the **Network** section of the [Scaleway console](https://console.scaleway.com) side menu.
+
+2. Click the **Flexible IPs** tab.
+
+3. Click <Icon name="more" /> next to the flexible IP whose reverse DNS you want to edit, and select **Edit reverse**.
+
+    A pop-up displays.
+
+4. Replace the automatically-generated domain (e.g. `51-158-59-249.lb.fr-par.scw.cloud`) with your own (sub)domain (e.g. `blog.mydomain.com`) and click **Edit reverse**.
+
+    The reverse DNS of your flexible IP address is updated, and you are returned to the list of your flexible IPs.
+
+## How to delete a flexible IP address
+
+You can delete any flexible IP address that is not attached to a Load Balancer. The only way to delete a flexible IP address that is attached to a Load Balancer, is to delete the Load Balancer itself, and check the **Delete IP** box when prompted. 
+
+The steps below show how to delete a flexible IP that is not attached to a Load Balancer.
+
+1. Click **Load Balancers** in the **Network** section of the [Scaleway console](https://console.scaleway.com) side menu.
+
+2. Click the **Flexible IPs** tab.
+
+3. Click <Icon name="more" /> next to the flexible IP that you want to delete, and select **Delete**.
+
+    A pop-up displays, warning you that this action is irreversible and will permanently delete this flexible IP from your account.
+
+4. Click **Delete flexible IP** to confirm.
+
+    The flexible IP is deleted.
+
+<Navigation title="See Also">
+  <PreviousButton to="/network/load-balancer/how-to/set-up-s3-failover/">How to set up an S3 failover</PreviousButton>
+  <NextButton to="/network/load-balancer/how-to/monitor-lb-cockpit/">How to monitor your Load Balancer with Scaleway Cockpit</NextButton>
+</Navigation>

--- a/network/load-balancer/how-to/monitor-lb-cockpit.mdx
+++ b/network/load-balancer/how-to/monitor-lb-cockpit.mdx
@@ -151,6 +151,6 @@ Logs when a frontend's SSL/TLS certificate is about to expire or has expired.
 
 
 <Navigation title="See Also">
-  <PreviousButton to="/network/load-balancer/how-to/set-up-s3-failover/">How to set up an S3 failover</PreviousButton>
+  <PreviousButton to="/network/load-balancer/how-to/create-manage-flex-ips/">How to create and manage flexible IPs</PreviousButton>
   <NextButton to="/network/load-balancer/how-to/delete-load-balancer/">How to delete a Load Balancer</NextButton>
 </Navigation>

--- a/network/load-balancer/how-to/set-up-s3-failover.mdx
+++ b/network/load-balancer/how-to/set-up-s3-failover.mdx
@@ -56,5 +56,5 @@ See our [dedicated documentation](/storage/object/how-to/use-bucket-website/) to
 
 <Navigation title="See Also">
   <PreviousButton to="/network/load-balancer/how-to/use-with-private-network/">How to use your Load Balancer with a Private Network</PreviousButton>
-  <NextButton to="/network/load-balancer/how-to/monitor-lb-cockpit/">How to monitor your Load Balancer with Scaleway Cockpit</NextButton>
+  <NextButton to="/network/load-balancer/how-to/create-manage-flex-ips/">How to create and manage flexible IPs</NextButton>
 </Navigation>


### PR DESCRIPTION
Add doc for Load Balancer flexible IPs, including info for reverse DNS.

This doc will be used as the basis for adding additional info about IPv6 for Load Balancer, when that feature is launched.
