### PR TITLE
feat(changelog): kubernetes-removed-managed-ingress-controllers-at-clust 2023-12-19

### DIFF
--- a/changelog/december2023/2023-12-19-kubernetes-removed-managed-ingress-controllers-at-clust.mdx
+++ b/changelog/december2023/2023-12-19-kubernetes-removed-managed-ingress-controllers-at-clust.mdx
@@ -9,5 +9,5 @@ category: containers
 product: kubernetes
 ---
 
-Ending the [deprecation cycle](/changelog/?a=kubernetes-52c54d18-c203&tags=containers_kubernetes), Kubernetes clusters do not have managed ingresses anymore. Users can deploy a [pre-configured Ingress Controller](/containers/kubernetes/how-to/deploy-ingress-controller/) after cluster creation using the Easy Deploy feature within the Scaleway console.
+Ending the [deprecation cycle](/changelog/?a=kubernetes-52c54d18-c203&tags=containers_kubernetes), Kubernetes clusters do not have managed ingresses anymore. Users can deploy a [pre-configured ingress controller](/containers/kubernetes/how-to/deploy-ingress-controller/) after cluster creation using the Easy Deploy feature within the Scaleway console.
 

--- a/changelog/december2023/2023-12-19-kubernetes-removed-managed-ingress-controllers-at-clust.mdx
+++ b/changelog/december2023/2023-12-19-kubernetes-removed-managed-ingress-controllers-at-clust.mdx
@@ -1,0 +1,13 @@
+---
+title: Managed ingress controllers at cluster creation
+status: removed
+author:
+    fullname: 'Join the #k8s channel on Slack.'
+    url: 'https://slack.scaleway.com'
+date: 2023-12-19
+category: containers
+product: kubernetes
+---
+
+Ending the [deprecation cycle](https://www.scaleway.com/en/docs/changelog/?a=kubernetes-52c54d18-c203&tags=containers_kubernetes), Kubernetes clusters do not have managed ingresses anymore. Users can deploy a [pre-configured Ingress Controller](https://www.scaleway.com/en/docs/containers/kubernetes/how-to/deploy-ingress-controller/) after cluster creation using the Easy Deploy feature within the Scaleway Console.
+

--- a/changelog/december2023/2023-12-19-kubernetes-removed-managed-ingress-controllers-at-clust.mdx
+++ b/changelog/december2023/2023-12-19-kubernetes-removed-managed-ingress-controllers-at-clust.mdx
@@ -9,5 +9,5 @@ category: containers
 product: kubernetes
 ---
 
-Ending the [deprecation cycle](https://www.scaleway.com/en/docs/changelog/?a=kubernetes-52c54d18-c203&tags=containers_kubernetes), Kubernetes clusters do not have managed ingresses anymore. Users can deploy a [pre-configured Ingress Controller](https://www.scaleway.com/en/docs/containers/kubernetes/how-to/deploy-ingress-controller/) after cluster creation using the Easy Deploy feature within the Scaleway Console.
+Ending the [deprecation cycle](/changelog/?a=kubernetes-52c54d18-c203&tags=containers_kubernetes), Kubernetes clusters do not have managed ingresses anymore. Users can deploy a [pre-configured Ingress Controller](/containers/kubernetes/how-to/deploy-ingress-controller/) after cluster creation using the Easy Deploy feature within the Scaleway console.
 


### PR DESCRIPTION
Reporter: tgenaitay

This PR is a new changelog contribution. It has been created automatically.

Make sure to review it carefully before merging it.