### PR TITLE
fix(vpc): remove refs to regional

### DIFF
--- a/containers/kubernetes/how-to/create-cluster.mdx
+++ b/containers/kubernetes/how-to/create-cluster.mdx
@@ -36,12 +36,12 @@ To administrate your Kubernetes Cluster easily, Scaleway provides a `.kubeconfig
       </Message>
     * The geographical **region** of the cluster.
     * The Kubernetes **version** for the cluster.
-4. Configure the **regional Private Network** for the cluster. A Private Network allows your cluster to communicate in an isolated and secure network. Each cluster is autoconfigured using a /22 IP subnet.
+4. Configure the **Private Network** for the cluster. A Private Network allows your cluster to communicate in an isolated and secure network. Each cluster is autoconfigured using a /22 IP subnet.
    You can either:
-    * Attach an existing regional Private Network (VPC) within the same Availability Zone from the drop-down.
-    * Attach a new regional Private Network to the cluster.
+    * Attach an existing Private Network (VPC) within the same Availability Zone from the drop-down.
+    * Attach a new Private Network to the cluster.
     <Message type="important">
-      The regional Private Network of your cluster can not be detached, and the cluster can not be moved to another Private Network after creation.
+      The Private Network of your cluster can not be detached, and the cluster can not be moved to another Private Network after creation.
     </Message>
 5. Enter the **name** for the cluster and optionally a description and tags, which can help you to organize your cluster.
 6. Click **Next**. The second page of the Kapsule cluster creation wizard displays.

--- a/containers/kubernetes/quickstart.mdx
+++ b/containers/kubernetes/quickstart.mdx
@@ -75,12 +75,12 @@ Scaleway [Kubernetes Kapsule and Kosmos](/containers/kubernetes/concepts/#kubern
       </Message>
     * The geographical **region** of the cluster.
     * The Kubernetes **version** for the cluster.
-4. Configure the **regional Private Network** for the cluster. A Private Network allows your cluster to communicate in an isolated and secure network. Each cluster is autoconfigured using a /22 IP subnet.
+4. Configure the **Private Network** for the cluster. A Private Network allows your cluster to communicate in an isolated and secure network. Each cluster is autoconfigured using a /22 IP subnet.
    You can either:
-    * Attach an existing regional Private Network (VPC) within the same Availability Zone from the drop-down.
-    * Attach a new regional Private Network to the cluster.
+    * Attach an existing Private Network (VPC) within the same Availability Zone from the drop-down.
+    * Attach a new Private Network to the cluster.
     <Message type="important">
-      The regional Private Network of your cluster can not be detached, and the cluster can not be moved to another Private Network after creation.
+      The Private Network of your cluster can not be detached, and the cluster can not be moved to another Private Network after creation.
     </Message>
 5. Enter the **name** for the cluster and optionally a description and tags, which can help you to organize your cluster.
 6. Click **Next**. The second page of the Kapsule cluster creation wizard displays.

--- a/tutorials/install-cockroachdb-scaleway-instances/index.mdx
+++ b/tutorials/install-cockroachdb-scaleway-instances/index.mdx
@@ -22,7 +22,7 @@ Its reliability lies in the ability to overcome software and hardware failures. 
 
 Thanks to its serializable SQL transactions, CockroachDB also ensures that data remains consistent and accurate. To do so, it combines both the Raft algorithm to read data and timestamps and multiple versions of data (MVCC) to write data. MVCC provides you with a stable and unchanging view of the data whenever you start a transaction, regardless of other changes happening in the database at the same time.
 
-This article shows you how to install CockroachDB using three nodes on a regional Private Network as well as a Scaleway Load Balancer to access the database and console.
+This article shows you how to install CockroachDB using three nodes on a Private Network as well as a Scaleway Load Balancer to access the database and console.
 
 <Macro id="iam-requirements" />
 


### PR DESCRIPTION
Remove all references to "regional Private Network" - no longer necessary to add the regional caveat since this is the new norm.
