### PR TITLE
fix(tutorial): remove duplicate triple-quote

### DIFF
--- a/tutorials/create-wordpress-instances-cli/index.mdx
+++ b/tutorials/create-wordpress-instances-cli/index.mdx
@@ -128,7 +128,6 @@ A random password will be generated and will be accessible when you log into you
     ```
     The following output displays when you log into your Instance:
     ```
-    ```
     ###############################################################################
     #                      SCALEWAY WORDPRESS INSTANTAPP                          #
     ###############################################################################


### PR DESCRIPTION
### Your checklist for this pull request

- [X] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

Remove a duplicate triple-quote in [this tutorial](https://www.scaleway.com/en/docs/tutorials/create-wordpress-instances-cli/).