### PR TITLE
feat(changelog): secret-manager-added-secrets-can-be-set-as-ephemeral 2024-01-04

### DIFF
--- a/changelog/january2024/2024-01-04-secret-manager-added-secrets-can-be-set-as-ephemeral.mdx
+++ b/changelog/january2024/2024-01-04-secret-manager-added-secrets-can-be-set-as-ephemeral.mdx
@@ -3,15 +3,15 @@ title: Secrets can be set as ephemeral
 status: added
 author:
     fullname: 'Join the #secret-manager channel on Slack.'
-    url: 'https://slack.scaleway.com/T7YEXCR7X/C04KGMME3U1'
+    url: 'https://slack.scaleway.com'
 date: 2024-01-04
 category: security-identity
 product: secret-manager
 ---
 
-Ephemeral secrets are available on Secret Manager API.
+Ephemeral secrets are now available on the Secret Manager API.
 
-At their creation, Secrets can now be set up with a time-to-live or an expiration after a single access. All secrets versions will inherit from this ephemeral policy.
+Upon creation, secrets can now be configured with a time-to-live or to expire after a single access through an ephemeral policy. If applied on a secret, all its versions will inherit from the policy.
 
-Refer to the [Secret Manager API](https://www.scaleway.com/en/developers/api/secret-manager) for more information.
+Refer to the [Secret Manager API documentation](https://www.scaleway.com/en/developers/api/secret-manager) for more information.
 

--- a/changelog/january2024/2024-01-04-secret-manager-added-secrets-can-be-set-as-ephemeral.mdx
+++ b/changelog/january2024/2024-01-04-secret-manager-added-secrets-can-be-set-as-ephemeral.mdx
@@ -1,0 +1,17 @@
+---
+title: Secrets can be set as ephemeral
+status: added
+author:
+    fullname: 'Join the #secret-manager channel on Slack.'
+    url: 'https://slack.scaleway.com/T7YEXCR7X/C04KGMME3U1'
+date: 2024-01-04
+category: security-identity
+product: secret-manager
+---
+
+Ephemeral secrets are available on Secret Manager API.
+
+At their creation, Secrets can now be set up with a time-to-live or an expiration after a single access. All secrets versions will inherit from this ephemeral policy.
+
+Refer to the [Secret Manager API](https://www.scaleway.com/en/developers/api/secret-manager) for more information.
+


### PR DESCRIPTION
Reporter: Cyril Petel

This PR is a new changelog contribution. It has been created automatically.

Make sure to review it carefully before merging it.