### PR TITLE
fix(menu): change Console category label 

### DIFF
--- a/console/index.mdx
+++ b/console/index.mdx
@@ -1,8 +1,8 @@
 ---
 meta:
-  title: Discover the Scaleway Console
-  description: Discover the Scaleway Console
+  title: Discover Scaleway Account & Billing
+  description: Discover Scaleway Account & Billing
 content:
-  h1: Discover the Scaleway Console
-  paragraph: Discover the Scaleway Console
+  h1: Discover Scaleway Account & Billing
+  paragraph: Discover Scaleway Account & Billing
 ---

--- a/menu/navigation.json
+++ b/menu/navigation.json
@@ -157,7 +157,7 @@
             "slug": "project"
           }
         ],
-        "label": "Console",
+        "label": "Account & Billing",
         "slug": "console"
       },
       {


### PR DESCRIPTION
Change "Console" category label to "Account & Billing"