### PR TITLE
docs(instances): Fix Buster IPV6 connectivity when routed IP used

### DIFF
--- a/compute/instances/troubleshooting/fix-lost-ip-connectivity-on-debian-buster.mdx
+++ b/compute/instances/troubleshooting/fix-lost-ip-connectivity-on-debian-buster.mdx
@@ -23,7 +23,7 @@ add-apt-repository ppa:scaleway/debian-staging
 vi /etc/apt/sources.list.d/scaleway-ubuntu-debian-staging-noble.list
 Replace `noble` with `bionic`
 ```
-Following this change, a new version of `scaleway-ecosystem` and `cloud-init` may be installed. It is important to clean the previous `cloud-init` data as the new version contains structure that may cause a failure of cloud-init at the next boot.
+Following this change, a new version of `scaleway-ecosystem` and `cloud-init` may be installed. It is important to clean the previous `cloud-init` data as the new version contains a structure that may cause a failure of cloud-init at the next boot.
 ```
 apt update
 apt -y install scaleway-ecosystem cloud-init

--- a/compute/instances/troubleshooting/fix-lost-ip-connectivity-on-debian-buster.mdx
+++ b/compute/instances/troubleshooting/fix-lost-ip-connectivity-on-debian-buster.mdx
@@ -14,19 +14,19 @@ categories:
 ---
 
 On older Debian Buster images, the installed custom version of `cloud-init` may interfere with the IPv6 connectivity when the Instance has been transitioned to use routed IP. This may be avoided by installing a newer version of cloud-init prior to the migration to routed IP. The procedure is also valid to recover connectivity for an Instance already using routed IP.
-The procedure to install the newer `cloud-init` is as follow :
+The procedure to install the newer `cloud-init` is as follows:
 
-* Install the new `debian-stable` PPA
+* Install the new `debian-stable` PPA. The URL of the PPA may be configured to use the `noble` series. Make sure that you replace it with `bionic` in the URL. 
 ```
 rm -f /etc/apt/sources.list.d/scaleway-ubuntu-stable-bionic.list
 add-apt-repository ppa:scaleway/debian-staging
 vi /etc/apt/sources.list.d/scaleway-ubuntu-debian-staging-noble.list
 Replace `noble` with `bionic`
 ```
-The URL of the PPA may be configured to use the `noble` series. This must be changed to `bionic` if it is the case. Following this change, a new version of `scaleway-ecosystem` and `cloud-init` may be installed. It is important to clean the previous `cloud-init` data as the new version contains structure that may cause a failure of cloud-init at the next boot.
+Following this change, a new version of `scaleway-ecosystem` and `cloud-init` may be installed. It is important to clean the previous `cloud-init` data as the new version contains structure that may cause a failure of cloud-init at the next boot.
 ```
 apt update
 apt -y install scaleway-ecosystem cloud-init
 cloud-init clean
 ```
-The Instance must be rebooted for the fix to take effect.
+Reboot the Instance for your changes to be taken into effect.

--- a/compute/instances/troubleshooting/fix-lost-ip-connectivity-on-debian-buster.mdx
+++ b/compute/instances/troubleshooting/fix-lost-ip-connectivity-on-debian-buster.mdx
@@ -21,12 +21,12 @@ The procedure to install the newer `cloud-init` is as follow :
 rm -f /etc/apt/sources.list.d/scaleway-ubuntu-stable-bionic.list
 add-apt-repository ppa:scaleway/debian-staging
 vi /etc/apt/sources.list.d/scaleway-ubuntu-debian-staging-noble.list
-Replace `noble` by `bionic`
+Replace `noble` with `bionic`
 ```
-The URL of the PPA may be configured to use the `noble` serie. This must be change to `bionic` if it is the case. Following this change, a new version of `scaleway-ecosystem` and `cloud-init` may be installed. It is important to clean the previous `cloud-init` data as the new version contains structure that may cause a failure of cloud-init at the next boot.
+The URL of the PPA may be configured to use the `noble` series. This must be changed to `bionic` if it is the case. Following this change, a new version of `scaleway-ecosystem` and `cloud-init` may be installed. It is important to clean the previous `cloud-init` data as the new version contains structure that may cause a failure of cloud-init at the next boot.
 ```
 apt update
 apt -y install scaleway-ecosystem cloud-init
 cloud-init clean
 ```
-The Instance requires to be rebooted for the fix to be active.
+The Instance must be rebooted for the fix to take effect.

--- a/compute/instances/troubleshooting/fix-lost-ip-connectivity-on-debian-buster.mdx
+++ b/compute/instances/troubleshooting/fix-lost-ip-connectivity-on-debian-buster.mdx
@@ -7,8 +7,8 @@ content:
   paragraph: This page helps recover or avoid unreachable IPv6 Instances after transitioning to routed IP on older Debian Buster images
 tags: ipv6 routed ip debian buster
 dates:
-  validation: tbd
-  posted: tbd
+  validation: 2024-01-22
+  posted: 2024-01-22
 categories:
   - compute
 ---

--- a/compute/instances/troubleshooting/fix-lost-ip-connectivity-on-debian-buster.mdx
+++ b/compute/instances/troubleshooting/fix-lost-ip-connectivity-on-debian-buster.mdx
@@ -13,8 +13,8 @@ categories:
   - compute
 ---
 
-On old Debian Buster images, the installed custom version of cloud-init may interfere with the IPv6 connectivity when the instance has been transitioned to use routed IP. This may be avoided by installing a newer version of cloud-init prior to the migration to routed IP. The procedure is also valid to recover connectivity for an instance already using routed IP.
-The procedure to install the newer cloud-init is as follow :
+On older Debian Buster images, the installed custom version of `cloud-init` may interfere with the IPv6 connectivity when the Instance has been transitioned to use routed IP. This may be avoided by installing a newer version of cloud-init prior to the migration to routed IP. The procedure is also valid to recover connectivity for an Instance already using routed IP.
+The procedure to install the newer `cloud-init` is as follow :
 
 * Install the new `debian-stable` PPA
 ```
@@ -23,10 +23,10 @@ add-apt-repository ppa:scaleway/debian-staging
 vi /etc/apt/sources.list.d/scaleway-ubuntu-debian-staging-noble.list
 Replace `noble` by `bionic`
 ```
-The URL of the PPA may be configured to use the `noble` serie. This must be change to `bionic` if it is the case. Following this change, a new version of `scaleway-ecosystem` and `cloud-init` may be installed. It is important to clean the previous cloud-init data as the new version contains structure that may cause a failure of cloud-init at the next boot.
+The URL of the PPA may be configured to use the `noble` serie. This must be change to `bionic` if it is the case. Following this change, a new version of `scaleway-ecosystem` and `cloud-init` may be installed. It is important to clean the previous `cloud-init` data as the new version contains structure that may cause a failure of cloud-init at the next boot.
 ```
 apt update
 apt -y install scaleway-ecosystem cloud-init
 cloud-init clean
 ```
-The server needs to be rebooted for the fix to be active.
+The Instance requires to be rebooted for the fix to be active.

--- a/compute/instances/troubleshooting/fix-lost-ip-connectivity-on-debian-buster.mdx
+++ b/compute/instances/troubleshooting/fix-lost-ip-connectivity-on-debian-buster.mdx
@@ -1,0 +1,32 @@
+---
+meta:
+  title: Fix lost IPv6 connectivity on old Debian Buster images when migrating to routed IP
+  description: This page helps recover or avoid unreachable IPv6 Instances after transitioning to routed IP on older Debian Buster images
+content:
+  h1: Fix lost IPv6 connectivity on old Debian Buster images when migrating to routed IP
+  paragraph: This page helps recover or avoid unreachable IPv6 Instances after transitioning to routed IP on older Debian Buster images
+tags: ipv6 routed ip debian buster
+dates:
+  validation: tbd
+  posted: tbd
+categories:
+  - compute
+---
+
+On old Debian Buster images, the installed custom version of cloud-init may interfere with the IPv6 connectivity when the instance has been transitioned to use routed IP. This may be avoided by installing a newer version of cloud-init prior to the migration to routed IP. The procedure is also valid to recover connectivity for an instance already using routed IP.
+The procedure to install the newer cloud-init is as follow :
+
+* Install the new `debian-stable` PPA
+```
+rm -f /etc/apt/sources.list.d/scaleway-ubuntu-stable-bionic.list
+add-apt-repository ppa:scaleway/debian-staging
+vi /etc/apt/sources.list.d/scaleway-ubuntu-debian-staging-noble.list
+Replace `noble` by `bionic`
+```
+The URL of the PPA may be configured to use the `noble` serie. This must be change to `bionic` if it is the case. Following this change, a new version of `scaleway-ecosystem` and `cloud-init` may be installed. It is important to clean the previous cloud-init data as the new version contains structure that may cause a failure of cloud-init at the next boot.
+```
+apt update
+apt -y install scaleway-ecosystem cloud-init
+cloud-init clean
+```
+The server needs to be rebooted for the fix to be active.


### PR DESCRIPTION
### Your checklist for this pull request

- [ x] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

Add a document describing how to fix loss of IPv6  connectivity on old debian buster instances when they have been migrated to use routed IP.
