### PR TITLE
ins(fix): add dns ipv6 only fixing guide

### DIFF
--- a/compute/instances/troubleshooting/fix-dns-routed-ipv6-only-debian-bullseye.mdx
+++ b/compute/instances/troubleshooting/fix-dns-routed-ipv6-only-debian-bullseye.mdx
@@ -107,19 +107,18 @@ If your Instance is concerned by the DNS resolution issue, follow the following 
 </Message>
 
 1. Force `cloud-init` to setup the network configuration using `netplan`.
-```sh
-> /etc/cloud/cloud.cfg.d/99_scw_ip6dns.cfg cat <<EOF
-system_info:
-  network:
-    renderers: [netplan, eni]
-    activators: [netplan, eni]
-EOF
-```
+    ```sh
+    > /etc/cloud/cloud.cfg.d/99_scw_ip6dns.cfg cat <<EOF
+    system_info:
+    network:
+        renderers: [netplan, eni]
+        activators: [netplan, eni]
+    EOF
+    ```
 2. Remove any `ifupdown` configuration from `cloud-init`.
-```
-rm -f /etc/network/interfaces.d/50-cloud-init
-```
-
+    ```
+    rm -f /etc/network/interfaces.d/50-cloud-init
+    ```
 3. *(optional)* Port your custom `ifupdown` configuration (if any) to `netplan`.
     <Message type="tip">
         Refer to the [Debian NetworkConfiguration wiki](https://wiki.debian.org/NetworkConfiguration) and the [`netplan` documentation](https://netplan.readthedocs.io/en/stable/) if required.

--- a/compute/instances/troubleshooting/fix-dns-routed-ipv6-only-debian-bullseye.mdx
+++ b/compute/instances/troubleshooting/fix-dns-routed-ipv6-only-debian-bullseye.mdx
@@ -104,7 +104,7 @@ In this situation, proceed with the next section to install `netplan` before app
 
 ## Fixing the DNS resolution issue
 
-If your Instance is concerned by the DNS resolution issue, follow the procedure below to fix it.
+If your Instance is affected by the DNS resolution issue, follow the procedure below to fix it.
 
 <Message type="note">
     All steps below require super-user (`root`) privileges.

--- a/compute/instances/troubleshooting/fix-dns-routed-ipv6-only-debian-bullseye.mdx
+++ b/compute/instances/troubleshooting/fix-dns-routed-ipv6-only-debian-bullseye.mdx
@@ -135,7 +135,7 @@ If your Instance is concerned by the DNS resolution issue, follow the following 
     ```
     host -W3 google.com
     ```
-7. *(optional)* It is strongly recommended that you upgrade `scaleway-ecosystem` package to at least version `0.0.6-10`.
+7. *(optional)* It is strongly recommended that you upgrade the `scaleway-ecosystem` package to at least version `0.0.6-10`.
     ```
     apt-get update
     apt-get -y upgrade scaleway-ecosystem

--- a/compute/instances/troubleshooting/fix-dns-routed-ipv6-only-debian-bullseye.mdx
+++ b/compute/instances/troubleshooting/fix-dns-routed-ipv6-only-debian-bullseye.mdx
@@ -43,6 +43,10 @@ You can check whether your Debian Bullseye Instance is concerned by running the 
 scw -o json Instance server get UUID | jq '.routed_ip_enabled and ([.public_ips[] | select(.family != "inet6")] == [])'
 ```
 
+<Message type="tip">
+    Make sure you have installed the [Scaleway CLI tools](/developer-tools/scaleway-cli/quickstart/) on your local machine before running the command above.
+</Message>
+
 The command will output:
 
 * `true` if the Instance is concerned by the present procedure.

--- a/compute/instances/troubleshooting/fix-dns-routed-ipv6-only-debian-bullseye.mdx
+++ b/compute/instances/troubleshooting/fix-dns-routed-ipv6-only-debian-bullseye.mdx
@@ -100,7 +100,7 @@ In this situation, proceed with the next section to install `netplan` before app
 
 ## Fixing the DNS resolution issue
 
-If your Instance is concerned by the DNS resolving issue, follow the following procedure to fix it.
+If your Instance is concerned by the DNS resolution issue, follow the following procedure to fix it.
 
 <Message type="note">
     All steps below require super-user (`root`) privileges.

--- a/compute/instances/troubleshooting/fix-dns-routed-ipv6-only-debian-bullseye.mdx
+++ b/compute/instances/troubleshooting/fix-dns-routed-ipv6-only-debian-bullseye.mdx
@@ -29,9 +29,9 @@ This guide outlines the steps to enable DNS resolution on a Scaleway Instance th
 
 When a Scaleway Instance uses routed IP addresses, the IPv6 stack is automatically configured using [`SLAAC`](https://datatracker.ietf.org/doc/html/rfc4862). With this method, the Instance is periodically advertised with various network configuration details, including the DNS server addresses it should use. The Instance is then free to consume these advertisements or not. By default, the operating system images provided by Scaleway are configured to leverage these advertisements to configure the IPv6 networking and the related DNS servers. The Debian Bullseye image is no exception.
 
-When configuring the network at boot time, the `cloud-init` software detects the appropriate network configuration method used by the system at hand and write and/or apply the necessary configuration files/parameters. On Debian Bullseye, and because of [`cloud-init`'s built-in order of detection](https://cloudinit.readthedocs.io/en/latest/reference/network-config.html#network-output-policy), the primarily detected method is [ENI](https://cloudinit.readthedocs.io/en/latest/reference/network-config-format-eni.html), which configures the network through Debian's well known `/etc/network/interfaces*` set of files, along with the `ifupdown` toolset.
+When configuring the network at boot time, the `cloud-init` software detects the appropriate network configuration method used by the system at hand and writes and/or applies the necessary configuration files/parameters. On Debian Bullseye, and because of [`cloud-init`'s built-in order of detection](https://cloudinit.readthedocs.io/en/latest/reference/network-config.html#network-output-policy), the primary detected method is [ENI](https://cloudinit.readthedocs.io/en/latest/reference/network-config-format-eni.html), which configures the network through Debian's well known `/etc/network/interfaces*` set of files, along with the `ifupdown` toolset.
 
-For some reason, this configuration method does not seem to play nicely with SLAAC's DNS advertisements. This results in an absence of DNS resolver configuration, thus breaking most of the network activities.
+This configuration method does not interact well with SLAAC's DNS advertisements. This results in an absence of DNS resolver configuration, thus breaking most of the network activities.
 
 Due to its modern nature and active maintenance, [`netplan` is a favorable option for configuring cloud systems](https://www.debian.org/doc/manuals/debian-reference/ch05.en.html#_the_modern_network_configuration_for_cloud) and conveniently addresses the current issue. However, in alignment with our image building policy, which aims to minimize alterations to the official upstream cloud image, `netplan` is intentionally not enabled by default in Scaleway's Debian Bullseye image.
 
@@ -104,13 +104,13 @@ In this situation, proceed with the next section to install `netplan` before app
 
 ## Fixing the DNS resolution issue
 
-If your Instance is concerned by the DNS resolution issue, follow the following procedure to fix it.
+If your Instance is concerned by the DNS resolution issue, follow the procedure below to fix it.
 
 <Message type="note">
     All steps below require super-user (`root`) privileges.
 </Message>
 
-1. Force `cloud-init` to setup the network configuration using `netplan`.
+1. Force `cloud-init` to set up the network configuration using `netplan`.
     ```sh
     > /etc/cloud/cloud.cfg.d/99_scw_ip6dns.cfg cat <<EOF
     system_info:
@@ -135,7 +135,7 @@ If your Instance is concerned by the DNS resolution issue, follow the following 
     ```
     reboot
     ```
-6. Connect back to the Instance and ensure you have DNS resolving working:
+6. Reconnect to the Instance and ensure DNS resolution is working:
     ```
     host -W3 google.com
     ```

--- a/compute/instances/troubleshooting/fix-dns-routed-ipv6-only-debian-bullseye.mdx
+++ b/compute/instances/troubleshooting/fix-dns-routed-ipv6-only-debian-bullseye.mdx
@@ -1,0 +1,144 @@
+---
+meta:
+  title: Fixing DNS resolution with a routed IPv6-only setup on Debian Bullseye
+  description: This page helps you to fix DNS resolution with a routed IPv6-only setup on Debian Bullseye
+content:
+  h1: Fixing DNS resolution with a routed IPv6-only setup on Debian Bullseye
+  paragraph: This page helps you to fix DNS resolution with a routed IPv6-only setup on Debian Bullseye
+tags: dns ipv6 Instance debian bullseye
+dates:
+  validation: 2024-01-23
+  posted: 2024-01-23
+categories:
+  - compute
+---
+
+This guide outlines the steps to enable DNS resolution on a Scaleway Instance that uses the Debian Bullseye image, configured with one or more routed IPv6 addresses while lacking any IPv4 addresses.
+
+<Message type="requirement">
+  - You have an account and are logged into the [Scaleway console](https://console.scaleway.com)
+  - You have [an Instance](/compute/Instances/how-to/create-an-Instance) running Debian Bullseye (11) with an IPv6-only setup
+</Message>
+
+<Message type="important">
+    This guide explains how to switch from the traditional `ifupdown` toolset to the modern `netplan`, which is used in recent Debian releases. The process is straightforward if your Instance is using the default network configuration provided by Scaleway metadata. 
+    However, if your Instance has a customized network setup, please ensure you are comfortable with both `ifupdown` and `netplan` before proceeding. You can safely apply this procedure to a newly created Instance.
+</Message>
+
+## Technical explanation
+
+When a Scaleway Instance uses routed IP addresses, the IPv6 stack is configured automatically using [`SLAAC`](https://datatracker.ietf.org/doc/html/rfc4862). With this method, the Instance is periodically advertised of various network configuration details, including the addresses of DNS servers that it should be using. The Instance is then free to consume these advertisements or not. By default, the operating system images provided by Scaleway are configured to leverage these advertisements to configure the IPv6 networking and the related DNS servers. The Debian Bullseye image is no exception.
+
+When configuring the network at boot time, the `cloud-init` software is in charge of detecting the appropriate network configuration method used by the system at hand, then to write and/or apply the needed configuration files/parameters according to this detected method. On Debian Bullseye, and because of [`cloud-init`'s built-in order of detection](https://cloudinit.readthedocs.io/en/latest/reference/network-config.html#network-output-policy), the primarily detected method is [ENI](https://cloudinit.readthedocs.io/en/latest/reference/network-config-format-eni.html), which configures the network through Debian's well known `/etc/network/interfaces*` set of files, along with the `ifupdown` toolset.
+
+For some reason, this configuration method does not seem to play nicely with SLAAC's DNS advertisements. This results in an absence of DNS resolver configuration, thus breaking most of the network activities.
+
+Due to its modern nature and active maintenance, [`netplan` is a favorable option for configuring cloud systems](https://www.debian.org/doc/manuals/debian-reference/ch05.en.html#_the_modern_network_configuration_for_cloud) and conveniently addresses the current issue. However, in alignment with our image building policy, which aims to minimize alterations to the official upstream cloud image, `netplan` is intentionally not enabled by default in Scaleway's Debian Bullseye image.
+
+## Checking if your Instance is concerned
+
+You can check whether your Debian Bullseye Instance is concerned by running the following command, where `UUID` is the identifier of your Instance:
+
+```sh
+scw -o json Instance server get UUID | jq '.routed_ip_enabled and ([.public_ips[] | select(.family != "inet6")] == [])'
+```
+
+The command will output:
+
+* `true` if the Instance is concerned by the present procedure
+* `false` otherwise
+
+<Message type="note">
+    The above command must only be run against a Debian Bullseye Instance. It does not check for this condition itself.
+</Message>
+
+## Installing netplan
+
+The `netplan` package needs to be installed **before** you apply this procedure. If you try to apply this procedure to an Instance where `netplan` is not installed, it will fail.
+
+<Message type="tip">
+    Latest Debian Bullseye images from Scaleway ship with `netplan` pre-installed.
+</Message>
+
+### Checking for netplan
+
+To check whether your Instance has `netplan` installed, run the following command:
+    ```sh
+    dpkg-query -W netplan.io
+    ````
+The command should return an output like this, where `<VERSION>` is the currently installed version of the package, meaning you can skip directly to the first step of the procedure:
+    ```sh
+    netplan.io	<VERSION>
+    ```
+If the tool is not installed, the command will print the following:
+    ```sh
+    dpkg-query: no packages found matching netplan.io
+    ````
+In this situation, proceed with the next section to install `netplan` before applying the procedure.
+
+### Installing the tool
+
+<Message type="note">
+    All steps below require super-user (`root`) privileges.
+</Message>
+
+1. *(optional)** If, **and only if**,  your Instance is already booted using a routed IPv6-only setup, you need to temporarily configure your DNS resolver so that it can reach the Debian repositories, in order to install `netplan`. The following uses Google's DNS server:
+    ```sh
+    > /etc/resolv.conf cat <<EOF
+    nameserver 2001:4860:4860::8888
+    EOF
+    ```
+
+2. Update your packages lists
+    ```
+    apt-get update
+    ```
+3. Install `netplan`
+    ```
+    apt-get -y install netplan.io
+    ```
+
+## Fixing the DNS resolution issue
+
+If your Instance is concerned by the DNS resolving issue, follow the following procedure to fix it.
+
+<Message type="note">
+    All steps below require super-user (`root`) privileges.
+</Message>
+
+1. Force `cloud-init` to setup the network configuration using `netplan`.
+```sh
+> /etc/cloud/cloud.cfg.d/99_scw_ip6dns.cfg cat <<EOF
+system_info:
+  network:
+    renderers: [netplan, eni]
+    activators: [netplan, eni]
+EOF
+```
+2. Remove any `ifupdown` configuration from `cloud-init`.
+```
+rm -f /etc/network/interfaces.d/50-cloud-init
+```
+
+3. *(optional)* Port your custom `ifupdown` configuration (if any) to `netplan`.
+    <Message type="tip">
+        Refer to the [Debian NetworkConfiguration wiki](https://wiki.debian.org/NetworkConfiguration) and the [`netplan` documentation](https://netplan.readthedocs.io/en/stable/) if required.
+    </Message>
+4. Enable the necessary `systemd` units:
+    ```sh
+    systemctl enable systemd-networkd-wait-online.service systemd-resolved.service
+    ```
+5. Reboot the Instance.
+    ```
+    reboot
+    ```
+6. Connect back to the Instance and ensure that you have DNS resolving working:
+    ```
+    host -W3 google.com
+    ```
+7. *(optional)* It is strongly recommended that you upgrade `scaleway-ecosystem` package to at least version `0.0.6-10`.
+    ```
+    apt-get update
+    apt-get -y upgrade scaleway-ecosystem
+    reboot
+    ```

--- a/compute/instances/troubleshooting/fix-dns-routed-ipv6-only-debian-bullseye.mdx
+++ b/compute/instances/troubleshooting/fix-dns-routed-ipv6-only-debian-bullseye.mdx
@@ -13,7 +13,7 @@ categories:
   - compute
 ---
 
-This guide outlines the steps to enable DNS resolution on a Scaleway Instance that uses the Debian Bullseye image, configured with one or more routed IPv6 addresses while lacking any IPv4 addresses.
+This guide outlines the steps to enable DNS resolution on a Scaleway Instance that uses the Debian Bullseye image, configured with one or more routed IPv6 addresses and without any IPv4 addresses.
 
 <Message type="requirement">
   - You have an account and are logged into the [Scaleway console](https://console.scaleway.com)
@@ -21,15 +21,15 @@ This guide outlines the steps to enable DNS resolution on a Scaleway Instance th
 </Message>
 
 <Message type="important">
-    This guide explains how to switch from the traditional `ifupdown` toolset to the modern `netplan`, which is used in recent Debian releases. The process is straightforward if your Instance is using the default network configuration provided by Scaleway metadata. 
-    However, if your Instance has a customized network setup, please ensure you are comfortable with both `ifupdown` and `netplan` before proceeding. You can safely apply this procedure to a newly created Instance.
+    This guide explains how to switch from the traditional `ifupdown` toolset to the more modern `netplan` solution, which is used in recent Debian releases. The process is straightforward if your Instance is using the default network configuration provided by Scaleway metadata. 
+    However, if your Instance has a customized network setup, ensure you are comfortable with both `ifupdown` and `netplan` before proceeding. You can safely apply this procedure to a newly created Instance.
 </Message>
 
 ## Technical explanation
 
-When a Scaleway Instance uses routed IP addresses, the IPv6 stack is configured automatically using [`SLAAC`](https://datatracker.ietf.org/doc/html/rfc4862). With this method, the Instance is periodically advertised of various network configuration details, including the addresses of DNS servers that it should be using. The Instance is then free to consume these advertisements or not. By default, the operating system images provided by Scaleway are configured to leverage these advertisements to configure the IPv6 networking and the related DNS servers. The Debian Bullseye image is no exception.
+When a Scaleway Instance uses routed IP addresses, the IPv6 stack is automatically configured using [`SLAAC`](https://datatracker.ietf.org/doc/html/rfc4862). With this method, the Instance is periodically advertised with various network configuration details, including the DNS server addresses it should use. The Instance is then free to consume these advertisements or not. By default, the operating system images provided by Scaleway are configured to leverage these advertisements to configure the IPv6 networking and the related DNS servers. The Debian Bullseye image is no exception.
 
-When configuring the network at boot time, the `cloud-init` software is in charge of detecting the appropriate network configuration method used by the system at hand, then to write and/or apply the needed configuration files/parameters according to this detected method. On Debian Bullseye, and because of [`cloud-init`'s built-in order of detection](https://cloudinit.readthedocs.io/en/latest/reference/network-config.html#network-output-policy), the primarily detected method is [ENI](https://cloudinit.readthedocs.io/en/latest/reference/network-config-format-eni.html), which configures the network through Debian's well known `/etc/network/interfaces*` set of files, along with the `ifupdown` toolset.
+When configuring the network at boot time, the `cloud-init` software detects the appropriate network configuration method used by the system at hand and write and/or apply the necessary configuration files/parameters. On Debian Bullseye, and because of [`cloud-init`'s built-in order of detection](https://cloudinit.readthedocs.io/en/latest/reference/network-config.html#network-output-policy), the primarily detected method is [ENI](https://cloudinit.readthedocs.io/en/latest/reference/network-config-format-eni.html), which configures the network through Debian's well known `/etc/network/interfaces*` set of files, along with the `ifupdown` toolset.
 
 For some reason, this configuration method does not seem to play nicely with SLAAC's DNS advertisements. This results in an absence of DNS resolver configuration, thus breaking most of the network activities.
 
@@ -45,8 +45,8 @@ scw -o json Instance server get UUID | jq '.routed_ip_enabled and ([.public_ips[
 
 The command will output:
 
-* `true` if the Instance is concerned by the present procedure
-* `false` otherwise
+* `true` if the Instance is concerned by the present procedure.
+* `false` otherwise.
 
 <Message type="note">
     The above command must only be run against a Debian Bullseye Instance. It does not check for this condition itself.
@@ -54,7 +54,7 @@ The command will output:
 
 ## Installing netplan
 
-The `netplan` package needs to be installed **before** you apply this procedure. If you try to apply this procedure to an Instance where `netplan` is not installed, it will fail.
+The `netplan` package must be installed **before** you apply this procedure, or it will fail.
 
 <Message type="tip">
     Latest Debian Bullseye images from Scaleway ship with `netplan` pre-installed.
@@ -89,11 +89,11 @@ In this situation, proceed with the next section to install `netplan` before app
     EOF
     ```
 
-2. Update your packages lists
+2. Update your packages lists:
     ```
     apt-get update
     ```
-3. Install `netplan`
+3. Install `netplan`:
     ```
     apt-get -y install netplan.io
     ```
@@ -119,7 +119,7 @@ If your Instance is concerned by the DNS resolution issue, follow the following 
     ```
     rm -f /etc/network/interfaces.d/50-cloud-init
     ```
-3. *(optional)* Port your custom `ifupdown` configuration (if any) to `netplan`.
+3. Optionally, port your custom `ifupdown` configuration (if any) to `netplan`.
     <Message type="tip">
         Refer to the [Debian NetworkConfiguration wiki](https://wiki.debian.org/NetworkConfiguration) and the [`netplan` documentation](https://netplan.readthedocs.io/en/stable/) if required.
     </Message>
@@ -127,11 +127,11 @@ If your Instance is concerned by the DNS resolution issue, follow the following 
     ```sh
     systemctl enable systemd-networkd-wait-online.service systemd-resolved.service
     ```
-5. Reboot the Instance.
+5. Reboot the Instance:
     ```
     reboot
     ```
-6. Connect back to the Instance and ensure that you have DNS resolving working:
+6. Connect back to the Instance and ensure you have DNS resolving working:
     ```
     host -W3 google.com
     ```

--- a/menu/navigation.json
+++ b/menu/navigation.json
@@ -601,6 +601,10 @@
                     "slug": "fix-cloud-init-debian12"
                   },
                   {
+                    "label": "Fixing DNS resolution with a routed IPv6-only setup on Debian Bullseye",
+                    "slug": "fix-dns-routed-ipv6-only-debian-bullseye"
+                  },
+                  {
                     "label": "Fixing unreachable IPv6 on RHEL based Instances after transition to routed ip",
                     "slug": "fix-unreachable-ipv6-rhel-based-instance"
                   },


### PR DESCRIPTION


### Description

Fixing DNS resolution with a routed IPv6-only setup on Debian Bullseye