### PR TITLE
fix(gen): remove concepts markdown

### DIFF
--- a/bare-metal/apple-silicon/concepts.mdx
+++ b/bare-metal/apple-silicon/concepts.mdx
@@ -10,37 +10,24 @@ categories:
   - bare-metal
 ---
 
-<Concept opened>
-  ## Apple silicon
+## Apple silicon
 
-  Apple silicon is Apple's own design of processor. It is the basis of Mac computers, as well as many other Apple products.
-</Concept>
+Apple silicon is Apple's own design of processor. It is the basis of Mac computers, as well as many other Apple products.
 
-<Concept opened>
-  ## Apple silicon as-a-service
+## Apple silicon as-a-service
 
-  Scaleway Apple silicon as-a-Service uses [Apple Mac mini](#mac-mini) hardware. These devices rely on the power of Apple's [silicon](#apple-silicon) technology, ensuring exceptional performance and energy efficiency.
+Scaleway Apple silicon as-a-Service uses [Apple Mac mini](#mac-mini) hardware. These devices rely on the power of Apple's [silicon](#apple-silicon) technology, ensuring exceptional performance and energy efficiency.
 
-  Apple silicon as-a-Service is tailored for developing, building, testing, and signing applications for Apple devices such as iPhones, iPads, Mac computers and more. The Mac mini boasts a sophisticated neural engine that significantly enhances machine learning capabilities.
-</Concept>
+Apple silicon as-a-Service is tailored for developing, building, testing, and signing applications for Apple devices such as iPhones, iPads, Mac computers and more. The Mac mini boasts a sophisticated neural engine that significantly enhances machine learning capabilities.
 
-<Concept>
-  ## Mac mini
+## Mac mini
 
-  The Mac mini is a physical hardware designed by Apple, powered by the [Apple silicon](#apple-silicon) chip. It is the basis for Scaleway's [Apple silicon as-a-service](#apple-silicon-as-a-service) offer.
-</Concept>
-
-<Concept>
+The Mac mini is a physical hardware designed by Apple, powered by the [Apple silicon](#apple-silicon) chip. It is the basis for Scaleway's [Apple silicon as-a-service](#apple-silicon-as-a-service) offer.
 
 ## Region and Availability Zone
 
 <Macro id="region-and-az" />
 
-</Concept>
+## VNC
 
-<Concept>
-  ## VNC
-
-  Virtual Network Computing (VNC) is a remote desktop-sharing protocol. It allows you to visualize the graphical screen output of a remote computer and transfer local keyboard and mouse events to the remote computer using a network connection. The protocol is platform-independent, which means that various clients exist for Linux, Windows, and macOS-based computers. The VNC server used on the Mac mini is directly integrated with the macOS system without any restrictions from our side. Check out our documentation on [how to connect to your Mac mini via VNC](/bare-metal/apple-silicon/how-to/connect-to-mac-mini/#how-to-connect-via-vnc).
-</Concept>
-
+Virtual Network Computing (VNC) is a remote desktop-sharing protocol. It allows you to visualize the graphical screen output of a remote computer and transfer local keyboard and mouse events to the remote computer using a network connection. The protocol is platform-independent, which means that various clients exist for Linux, Windows, and macOS-based computers. The VNC server used on the Mac mini is directly integrated with the macOS system without any restrictions from our side. Check out our documentation on [how to connect to your Mac mini via VNC](/bare-metal/apple-silicon/how-to/connect-to-mac-mini/#how-to-connect-via-vnc).

--- a/bare-metal/dedibox/concepts.mdx
+++ b/bare-metal/dedibox/concepts.mdx
@@ -10,25 +10,13 @@ categories:
   - bare-metal
 ---
 
-
-
-<Concept opened>
-
 ## Administrator Password
 
 The administrator password is set during the installation of your Dedibox server. It represents the password of the `root` user on the system. The administrator account has full rights to modify or delete any data on the server. Make sure that you set a strong administrator password.
 
-</Concept>
-
-<Concept opened>
-
 ## Access Control List (ACL)
 
 ACL allows you to restrict access to your backup space to the IP address of your Dedibox server. The connection attempts (successful or unsuccessful) are stored in your console in real time.
-
-</Concept>
-
-<Concept opened>
 
 ## Auto Login
 
@@ -38,57 +26,29 @@ Auto Login allows you to log into your account without a password (automatic aut
   Once this feature has been activated in your account, use the `auto` user and an empty password to connect.
 </Message>
 
-</Concept>
-
-<Concept opened>
-
 ## Backup
 
 A backup is a copy of your data, stored in another location. In case of any hardware or software failure, you can restore your data from the backup. It is recommended to make backups regularly. Each Dedibox server comes with 100 GB of free [Dedibackup](https://www.scaleway.com/en/dedibox/storage/) storage. You can upload your backups to this storage using the FTP protocol. A 750 GB Dedibackup is available as a further option.
-
-</Concept>
-
-<Concept opened>
 
 ## cPanel
 
 [cPanel](https://cpanel.net/) is an industrial leading hosting automation platform. It allows you to automate server management tasks and to provision webhosting accounts for your users.
 
-</Concept>
-
-<Concept opened>
-
 ## Dedibackup
 
 Dedibackup is backup solution for your Dedibox server. Dedibackup is based on Scaleway's Object Storage solution and provides FTP access to a secure backup space located in the DC5 datacenter. This allows you to store copies of your data for security purposes.
-
-</Concept>
-
-<Concept>
 
 ## Dedicated server
 
 A dedicated server is a physical computer hosted in a datacenter and connected to the internet. Each dedicated server is rented out to one single customer who has full access to the machine to install any software of their choice on it.
 
-</Concept>
-
-<Concept>
-
 ## Hostname
 
 A hostname is a name associated with a machine. On the Internet, hostnames are formed mostly of two parts, the local name of the computer, for example: `myserver` and the domain name, for example: `mywebsite.org`. The complete hostname of that machine would be `myserver.mywebsite.org`.
 
-</Concept>
-
-<Concept>
-
 ## IPMI
 
 Intelligent Platform Management Interface (IPMI) provides a way to access a computer using a network connection. It is independent from the main computer and allows you to access a remote computer that is not responding or powered off. Another use case is the installation of a custom operating system by mounting an ISO file on a virtual optical device. The installation of the remote computer can be done over the network without need for physical access to the machine.
-
-</Concept>
-
-<Concept>
 
 ## OS Type
 
@@ -99,91 +59,45 @@ Scaleway Dedibox provides a wide range of operating systems which can be automat
 - Panel distributions: Distributions with a preinstalled management panel to administrate the Dedibox server from a web based control panel.
 - Desktop distributions: Distributions with a preinstalled graphical interface. Server administration can be done from a remote desktop tool.
 
-</Concept>
-
-<Concept>
-
 ## Partitioning
 
 The partition layout of your Dedibox server can be customized during the installation of the server. You can customize the RAID settings and the disk layout towards your applications needs.
-
-</Concept>
-
-<Concept>
 
 ## Proxmox
 
 Proxmox is an open-source virtualization distribution, based on Debian. It provides both KVM hypervisor, and LXC container based virtualization combined with an easy-to-use web interface to manage resources. Proxmox is available for automatic installation from the Dedibox console.
 
-</Concept>
-
-<Concept>
-
 ## Remote reboot
 
 This feature allows you to reboot your Dedibox server from the Dedibox console if it is not responding via the network. You can also use this feature to reboot your server into rescue mode for maintenance actions.
-
-</Concept>
-
-<Concept>
 
 ## Rescue mode
 
 Rescue mode is a small Linux distribution that is loaded during the system boot into the RAM of your Dedibox server. It allows you to gain access to your system and data if your server is not reachable on the internet in normal mode. You can perform maintenance tasks on your system and fix broken configurations before rebooting your server back into normal mode.
 
-</Concept>
-
-<Concept>
-
 ## Secondary DNS
 
 When you run your own DNS server (for example BIND) on your Dedibox, you can use the Secondary DNS server to provide redundancy for your DNS infrastructure. You can allow the transfer of your domains' primary DNS zone to the secondary DNS server to automatically update it whenever the zonefile on the primary server changes.
-
-</Concept>
-
-<Concept>
 
 ## Server log files
 
 Your Dedibox server logs important events in log files located in the directory `/var/log` on Linux based operating systems. Reading these files is a crucial element in the analysis of any issue with your server. Windows provides a [series of tools](https://docs.microsoft.com/en-us/troubleshoot/windows-server/system-management-components/system-management-components-overview) to track the health state of your server.
 
-</Concept>
-
-<Concept>
-
 ## Statistics
 
 The statistics page in the Dedibox console provides detailed bandwidth usage information of your server for the internet interface, as well as for the RPN interface (if available on the server). The measurement of your bandwith consumption is done at the network switch of your server's rack.
-
-</Concept>
-
-<Concept>
 
 ## User login
 
 During the installation of your server a user account is created. The user account is a regular user account with `sudo` rights ob Ubuntu Linux.
 
-</Concept>
-
-<Concept>
-
 ## User password
 
 The password associated with the user login. You can set the user password during the installation of your Dedibox server. For security reasons it is recommended to choose a temporary password for the installation and to change it once the server has been installed. The password must have at least 8 characters must only contain alphanumeric characters.
-
-</Concept>
-
-<Concept>
 
 ## VMware vSphere Hypervisor (ESXi)
 
 A virtualization solution developed by VMware. It is a _type-1_ hypervisor, meaning that ESXi is not a software application that is installed on the servers' operating system. It includes and integrates important OS components, such as a proprietary kernel.
 
-</Concept>
-
-<Concept>
-
 ## Windows PE rescue mode
 The Windows PE or Windows Preinstallation Environment rescue mode is a minimal Windows operating system. It is used to prepare a computer for Windows installation, but also to copy disk images from a network file server, launch a Windows installation, or - to have minimal access to fix an error on the servers operating system configuration.
-
-</Concept>

--- a/bare-metal/dedibox/reference-content/dedibox-datasheet.mdx
+++ b/bare-metal/dedibox/reference-content/dedibox-datasheet.mdx
@@ -15,8 +15,6 @@ categories:
 
 This datasheet provides a concise overview of the performance, technical features, components, materials, and associated documentation for different Dedibox offers.
 
-<Concept>
-
 ## Server Dedibox PRO-9-M
 
 | Dedibox PRO-9-M       |                                   |
@@ -28,10 +26,6 @@ This datasheet provides a concise overview of the performance, technical feature
 | **[RPN](/dedibox-network/rpn/concepts/#rpn) private bandwidth** | 1 Gbps (10 Gbps optional)         |
 | **Datacenter**        | DC2, DC5                          |
 
-</Concept>
-
-<Concept>
-
 ## Server Dedibox PRO-9-L
 
 | Dedibox PRO-9-L       |                                   |
@@ -42,5 +36,3 @@ This datasheet provides a concise overview of the performance, technical feature
 | **Public bandwidth**  | 1 Gbps                            |
 | **[RPN](/dedibox-network/rpn/concepts/#rpn) private bandwidth** | 1 Gbps (10 Gbps optional) |
 | **Datacenter**        | DC2, DC5                          |
-
-</Concept>

--- a/bare-metal/elastic-metal/concepts.mdx
+++ b/bare-metal/elastic-metal/concepts.mdx
@@ -11,15 +11,9 @@ categories:
   - elastic-metal
 ---
 
-<Concept opened>
-
 ## Elastic Metal server
 
 Scaleway Elastic Metal are dedicated physical servers you can order on-demand, like Instances. These servers can be used for large workloads, big data and applications that require increased security and dedicated resources.
-
-</Concept>
-
-<Concept opened>
 
 ## Flexible IP
 
@@ -29,53 +23,29 @@ You can keep several flexible IP addresses in your account, and they can either 
 
 When you delete a flexible IP address, it is disassociated from your account to be claimed by other users.
 
-</Concept>
-
-<Concept opened>
-
 ## Image
 
 An image is a file that contains the OS, application data, and any files that might be related to your applications.
 
 If you do not know yet which image you want to run on the Elastic Metal, you can order a server without a preinstalled image.
 
-</Concept >
-
-<Concept>
-
 ## Public IP
 
 Public IP addresses are routed on the internet. You can enter the public IP address of your Elastic Metal server into any browser connected to the internet, and access content being served from that Elastic Metal. You can think of public IP addresses like postal addresses for buildings - they are unique, and tell the routers directing traffic through the internet where to find a particular server.
-
-</Concept>
-
-<Concept>
 
 ## Private Networks
 
 [Private Networks allow your Elastic Metal servers to communicate with other Scaleway resources](/bare-metal/elastic-metal/how-to/use-private-networks/) in an isolated and secure network without requiring a connection to the public internet.
 
-</Concept>
-
-<Concept>
-
 ## Region and Availability Zone
 
 <Macro id="region-and-az" />
-
-</Concept>
-
-<Concept>
 
 ## Remote access
 
 Remote access allows you to access the keyboard, video, and mouse of the machine remotely by using [KVM over IP device](https://en.wikipedia.org/wiki/KVM_switch#KVM_over_IP_(IPKVM)). It enables you access to the machine even if the installed OS is not working properly, to debug the system, or to install your own OS from a remote ISO file.
 
 Remote access is available as an option on most Elastic Metal offers. Currently, remote access must be configured [via the API](https://www.scaleway.com/en/developers/api/elastic-metal/#path-bmc-access-start-bmc-access).
-
-</Concept>
-
-<Concept>
 
 ## Rescue Mode
 
@@ -85,12 +55,6 @@ Your server must be powered on and running to switch to rescue mode, which creat
 
 After disabling rescue mode, you have to reboot your server.
 
-</Concept>
-
-<Concept>
-
 ## Tags
 
 Tags allow you to organize your resources by sorting and filtering your cloud assets in any organizational pattern you choose. This helps you arrange, control, and monitor your cloud resources. You can assign as many tags as you want to each Scaleway product.
-
-</Concept>

--- a/bare-metal/elastic-metal/reference-content/elastic-metal-datasheet.mdx
+++ b/bare-metal/elastic-metal/reference-content/elastic-metal-datasheet.mdx
@@ -21,9 +21,7 @@ The **Public bandwidth** refers to the designated internet bandwidth for the ser
 It is important to note that both public internet and Private Networks use the same physical network interface.
 </Message>
 
-## Aluminium range
-
-<Concept>
+### Aluminium range
 
 ## Server EM-A210R-HDD
 
@@ -37,10 +35,6 @@ It is important to note that both public internet and Private Networks use the s
 | **Private bandwidth** | 1 Gbps                            |
 | **Availability Zones** | PARIS 1, PARIS 2, AMSTERDAM 1    |
 
-</Concept>
-
-<Concept>
-
 ## Server EM-A315X-SSD
 
 | Server EM-A315X-SSD   |                                   |
@@ -52,10 +46,6 @@ It is important to note that both public internet and Private Networks use the s
 | **Public bandwidth**  | 1 Gbps                            |
 | **Private bandwidth** | 1 Gbps                            |
 | **Availability Zones**| PARIS 1, PARIS 2, AMSTERDAM 1     |
-
-</Concept>
-
-<Concept>
 
 ## Server EM-A410X-SSD
 
@@ -69,11 +59,7 @@ It is important to note that both public internet and Private Networks use the s
 | **Private bandwidth** | 1 Gbps                            |
 | **Availability Zones**| PARIS 1, PARIS 2                  |
 
-</Concept>
-
-## Beryllium range
-
-<Concept>
+### Beryllium range
 
 ## Server EM-B111X-SATA
 
@@ -87,10 +73,6 @@ It is important to note that both public internet and Private Networks use the s
 | **Private bandwidth** | 1 Gbps                            |
 | **Availability Zones**| PARIS 1, PARIS 2                  |
 
-</Concept>
-
-<Concept>
-
 ## Server EM-B112X-SSD
 
 | Server EM-B112X-SSD   |                                   |
@@ -102,10 +84,6 @@ It is important to note that both public internet and Private Networks use the s
 | **Public bandwidth**  | 1 Gbps                            |
 | **Private bandwidth** | 1 Gbps                            |
 | **Availability Zones**| PARIS 1, PARIS 2, AMSTERDAM 1     |
-
-</Concept>
-
-<Concept>
 
 ## Server EM-B211X-SATA
 
@@ -119,10 +97,6 @@ It is important to note that both public internet and Private Networks use the s
 | **Private bandwidth** | 1 Gbps                            |
 | **Availability Zones**| PARIS 2                           |
 
-</Concept>
-
-<Concept>
-
 ## Server EM-212X-SSD
 
 | Server EM-B212X-SSD   |                                   |
@@ -134,10 +108,6 @@ It is important to note that both public internet and Private Networks use the s
 | **Public bandwidth**  | 1 Gbps                            |
 | **Private bandwidth** | 1 Gbps                            |
 | **Availability Zones**| PARIS 1, PARIS 2, AMSTERDAM 1     |
-
-</Concept>
-
-<Concept>
 
 ## Server EM-B220E-NVME
 
@@ -151,10 +121,6 @@ It is important to note that both public internet and Private Networks use the s
 | **Private bandwidth** | 10 Gbps                           |
 | **Availability Zones**| PARIS 2                           |
 
-</Concept>
-
-<Concept>
-
 ## Server EM-B311X-SATA
 
 | Server EM-B311X-SATA  |                                   |
@@ -166,10 +132,6 @@ It is important to note that both public internet and Private Networks use the s
 | **Public bandwidth**  | 1 Gbps                            |
 | **Private bandwidth** | 1 Gbps                            |
 | **Availability Zones**| PARIS 2                           |
-
-</Concept>
-
-<Concept>
 
 ## Server EM-B312X-SSD
 
@@ -183,10 +145,6 @@ It is important to note that both public internet and Private Networks use the s
 | **Private bandwidth** | 1 Gbps                            |
 | **Availability Zones**| PARIS 2                           |
 
-</Concept>
-
-<Concept>
-
 ## Server EM-B320E-NVME
 
 | Server EM-B320E-NVME  |                                   |
@@ -198,10 +156,6 @@ It is important to note that both public internet and Private Networks use the s
 | **Public bandwidth**  | 1 Gbps                            |
 | **Private bandwidth** | 10 Gbps                           |
 | **Availability Zones**| PARIS 2                           |
-
-</Concept>
-
-<Concept>
 
 ## Server EM-B420E-NVME
 
@@ -215,10 +169,6 @@ It is important to note that both public internet and Private Networks use the s
 | **Private bandwidth** | 10 Gbps                           |
 | **Availability Zones**| PARIS 2                           |
 
-</Concept>
-
-<Concept>
-
 ## Server EM-B520E-NVME
 
 | Server EM-B520E-NVME  |                                   |
@@ -231,11 +181,7 @@ It is important to note that both public internet and Private Networks use the s
 | **Private bandwidth** | 10 Gbps                           |
 | **Availability Zones**| PARIS 2                           |
 
-</Concept>
-
-## Iridium range
-
-<Concept>
+### Iridium range
 
 ## Server EM-I210E-NVME
 
@@ -249,11 +195,7 @@ It is important to note that both public internet and Private Networks use the s
 | **Private bandwidth** | 10 Gbps                           |
 | **Availability Zones**| PARIS 1, PARIS 2                  |
 
-</Concept>
-
-## Lithium range
-
-<Concept>
+### Lithium range
 
 ## Server EM-L101X-SATA
 
@@ -267,10 +209,6 @@ It is important to note that both public internet and Private Networks use the s
 | **Private bandwidth** | 1 Gbps                            |
 | **Availability Zones**| PARIS 1, PARIS 2, AMSTERDAM 1     |
 
-</Concept>
-
-<Concept>
-
 ## Server EM-L105X-SATA
 
 | Server EM-L101X-SATA  |                                   |
@@ -282,10 +220,6 @@ It is important to note that both public internet and Private Networks use the s
 | **Public bandwidth**  | 1 Gbps                            |
 | **Private bandwidth** | 1 Gbps                            |
 | **Availability Zones**| PARIS 1, PARIS 2, AMSTERDAM 1     |
-
-</Concept>
-
-<Concept>
 
 ## Server EM-L110X-SATA
 
@@ -299,11 +233,7 @@ It is important to note that both public internet and Private Networks use the s
 | **Private bandwidth** | 1 Gbps                            |
 | **Availability Zones**| PARIS 1, PARIS 2, AMSTERDAM 1     |
 
-</Concept>
-
-## Titanium range
-
-<Concept>
+### Titanium range
 
 ## Server EM-T210E-NVME
 
@@ -317,10 +247,6 @@ It is important to note that both public internet and Private Networks use the s
 | **Private bandwidth** | 10 Gbps                           |
 | **Availability Zones**| PARIS 2                           |
 
-</Concept>
-
-<Concept>
-
 ## Server EM-T510E-NVME
 
 | Server EM-T510E-NVME  |                                   |
@@ -333,6 +259,3 @@ It is important to note that both public internet and Private Networks use the s
 | **Public bandwidth**  | 10 Gbps                           |
 | **Private bandwidth** | 10 Gbps                           |
 | **Availability Zones**| PARIS 2                           |
-
-</Concept>
-

--- a/compute/gpu/concepts.mdx
+++ b/compute/gpu/concepts.mdx
@@ -14,26 +14,16 @@ categories:
   GPU Instances share many concepts in common with traditional Instances. See also the [Instances Concepts page](/compute/instances/concepts/) for more information.
 </Message>
 
-<Concept opened>
-
 ## AI-enabled applications
 
 These applications will feature conversational and multimodal user interfaces (UIs) that will revolutionize interactions within smart spaces, smart robots, and autonomous vehicles.
 The proliferation of AI-enabled applications and innovative use cases is poised to bring transformative changes to various domains, including business, social interactions, and human-machine interfaces.
-
-</Concept>
-
-<Concept opened>
 
 ## Automatic mixed precision
 
 Mixed precision is an emerging technique allowing training with half-precision while retaining the network's accuracy achieved with single precision.
 This innovative technique, known as mixed-precision, combines both single- and half-precision representations.
 Major AI frameworks (such as TensorFlow and PyTorch) have embraced this approach, offering automatic mixed-precision support to accelerate AI training on NVIDIA GPUs with minimal code adjustments.
-
-</Concept>
-
-<Concept opened>
 
 ## BF16
 
@@ -42,17 +32,9 @@ It strikes a balance between range and precision, making it efficient for deep l
 BF16 uses 1 bit for the sign, 8 bits for the exponent, and 7 bits for the mantissa (fractional part). This format provides a wider range than IEEE 754 half-precision (FP16) while still maintaining better precision than integer formats. 
 It was introduced to address the limitations of FP16 for deep learning tasks, offering improved efficiency and accuracy for training and running neural network models.
 
-</Concept>
-
-<Concept>
-
 ## CUDA
 
 CUDA is a parallel computing platform and API model created by NVIDIA. CUDA is an acronym for **C**ompute **U**nified **D**evice **A**rchitecture.
-
-</Concept>
-
-<Concept>
 
 ## Data-centric AI
 
@@ -60,18 +42,10 @@ Data-Centric AI delves into diverse data and analytics techniques, aiming to der
 Additionally, it seeks to enhance AI-enabled decisions, making them not only more accurate but also explainable and ethical.
 In this context, the trustworthiness of AI systems, which operate with varying degrees of autonomy, is essential, and their risks need to be effectively managed.
 
-</Concept>
-
-<Concept>
-
 ## Docker
 
 [Docker](https://www.docker.com/) is a platform as a service (PaaS) tool, that uses OS-level virtualization to deliver software in packages called containers.
 Scaleway provides a number of pre-built Docker images, which allow you to [run a Docker container on your GPU Instance](/compute/gpu/how-to/use-gpu-with-docker/) and access a preinstalled Pipenv environment ideal for your AI projects.
-
-</Concept>
-
-<Concept>
 
 ## Flexpoint
 
@@ -79,18 +53,10 @@ Flexpoint is a numerical representation format tailored for efficient computatio
 It offers a dynamic range and adaptable precision, optimizing both accuracy and computational efficiency.
 This format's flexibility in bit allocation makes it well-suited for tasks where balancing precision and performance is crucial.
 
-</Concept>
-
-<Concept>
-
 ## FP8
 
 FP8, or Quarter Precision, uses an **8**-bit **f**loating-**p**oint representation. It offers even greater speed and memory efficiency at the cost of reduced precision compared to FP16, FP32, or FP64.
 FP8 is often used in specialized applications where extremely fast calculations are required, such as some forms of real-time graphics rendering. However, it may not be suitable for tasks that demand high numerical accuracy.
-
-</Concept>
-
-<Concept>
 
 ## FP16
 
@@ -98,27 +64,15 @@ FP16, or Half Precision, uses a **16**-bit **f**loating-**p**oint representation
 FP16 is commonly used in deep learning and neural network training, where fast matrix operations are crucial.
 Although it may introduce some numerical instability, techniques like mixed-precision training can mitigate these issues by combining FP16 with higher precision formats for specific operations, achieving a balance between speed and accuracy.
 
-</Concept>
-
-<Concept>
-
 ## FP32
 
 FP32, or Single Precision, is a **32**-bit **f**loating-**p**oint representation used in GPUs. It provides a balance between precision and performance, making it the standard for most graphics rendering and general-purpose GPU computing tasks.
 FP32 GPUs are capable of handling a wide range of applications, including gaming, machine learning, and scientific computing, with good numerical accuracy and faster computation compared to FP64.
 
-</Concept>
-
-<Concept>
-
 ## FP64
 
 FP64, or Double Precision, refers to a **64**-bit **f**loating-**p**oint representation used in GPUs. It offers high precision for numerical calculations, making it suitable for scientific simulations, engineering, and financial applications where precision is critical.
 Double-precision GPUs perform arithmetic operations with high accuracy but are generally slower compared to lower-precision counterparts due to the larger data size.
-
-</Concept>
-
-<Concept>
 
 ## Generative AI
 
@@ -127,18 +81,9 @@ These artifacts can be applied for both positive and negative purposes.
 Generative AI has the ability to generate fresh media content, such as text, images, videos, and audio, as well as synthetic data and models of physical objects.
 Additionally, it finds applications in fields like drug discovery and material design.
 
-</Concept>
-
-<Concept>
-
 ## GPU
 
 **G**raphical **P**rocessing **U**nit (GPU) became a go-to term for the specialized electronic circuits, designed to power graphics on a machine. The term was popularized in the late 1990s by the chip manufacturer NVIDIA. GPUs were originally produced primarily to drive high-quality gaming experiences, producing life-like digital graphics. Today, those capabilities are being harnessed more broadly for data processing, artificial intelligence, rendering and video encoding.
-
-</Concept>
-
-
-<Concept>
 
 ## Model-centric AI
 
@@ -146,18 +91,9 @@ Model-centric AI focuses on the most promising and emerging techniques that will
 These techniques include foundation models, composite AI, physics-informed AI, neuromorphic computing, and biology-inspired algorithms.
 By leveraging these innovative approaches, Model-centric AI aims to drive revolutionary progress in the world of artificial intelligence.
 
-</Concept>
-
-<Concept>
-
 ## Nvidia
 
 Nvidia is a brand of GPU for the gaming and professional markets. Scaleway GPU Instances are equipped with NVidia GPUs.
-
-</Concept>
-
-
-<Concept>
 
 ## Inference and training
 
@@ -165,35 +101,19 @@ At a high level, working with deep neural networks involves a two-stage process.
 First, the neural network undergoes training, where its parameters are determined by using labeled examples of inputs and corresponding desired outputs.
 Then, the trained network is deployed for inference, utilizing the learned parameters to classify, recognize, and process unfamiliar inputs.
 
-</Concept>
-
-<Concept>
-
 ## Moore's Law
 
 Moore's law, originally observed by Intel co-founder Gordon Moore in 1965, describes a consistent trend wherein the number of transistors per square inch on integrated circuits doubles every year since their inception.
 However, over the past decade, Moore's law has shown signs of deceleration, mainly due to the rapid advancement of GPU architectures, which have outpaced the rate of CPU performance-per-watt growth.
-
-</Concept>
-
-<Concept>
 
 ## MXNet
 
 MXNet is a modern, open-source deep learning framework employed for the training and deployment of deep neural networks.
 It provides scalability, facilitating swift model training, while also supporting a versatile programming model and multiple languages. 
 
-</Concept>
-
-<Concept>
-
 ## PetaFLOPS
 
 PetaFLOPS is a unit of computing speed equal to one thousand million million (10^15) floating-point operations per second.
-
-</Concept>
-
-<Concept>
 
 ## Pipenv
 
@@ -206,28 +126,16 @@ Pipenv is a package and dependency manager for Python projects. It harnesses the
 
 Pipenv is preinstalled on all of Scaleway's AI Docker images for GPU Instances, making it easy to [use virtual environments](/compute/gpu/how-to/use-pipenv/). Pipenv replaces Anaconda for this purpose.
 
-</Concept>
-
-<Concept>
-
 ## PyTorch
 
 PyTorch is a GPU-accelerated tensor computational framework with a Python front end.
 It provides a seamless integration with popular Python libraries like NumPy, SciPy, and Cython, allowing for easy extension of its functionality.
-
-</Concept>
-
-<Concept>
 
 ## Responsible and human-centric AI
 
 Responsible and Human-centric AI emphasizes the positive impact of AI on individuals and society, while also addressing the need to manage and mitigate AI-related risks.
 It encourages vendors to adopt ethical and responsible practices in their AI implementations.
 Additionally, it advocates for combining AI with a human touch and common sense to ensure a more holistic and beneficial AI experience for everyone.
-
-</Concept>
-
-<Concept>
 
 ## Scratch storage
 
@@ -239,49 +147,26 @@ Scratch storage is an ephemeral storage solution that does not support features 
   Scratch storage does not survive once the server is stopped: doing a full stop/start cycle will erase the scratch data. However, doing a simple reboot or using the stop in place function will keep the data.
 </Message>
 
-
-</Concept>
-
-<Concept>
-
 ## Structural sparsity
 
 Modern AI networks are characterized by their substantial size, as they contain millions or even billions of parameters.
 However, not all these parameters are indispensable for precise predictions, and certain ones of these parameters can be transformed into zeros, resulting in "sparse" models that maintain accuracy.
 Although the sparsity feature in the A100 and H100 GPUs primarily enhances AI inference, it also contributes to improved model training performance.
 
-</Concept>
-
-<Concept>
-
 ## TensorFlow
 
 TensorFlow is an open-source machine learning software library designed to address a diverse array of tasks.
 Initially developed by Google, it caters to their requirements for creating and training neural networks capable of detecting and interpreting patterns and correlations, akin to human learning and reasoning processes.
-
-</Concept>
-
-<Concept>
 
 ## Tensor Cores
 
 NVIDIA's V100, A100, H100, L4, and L40 GPUs are equipped with Tensor Cores, which significantly enhance the performance of matrix-multiplication operations, crucial for neural network training and inferencing.
 These Tensor Cores and their associated data paths are engineered to substantially increase floating-point compute throughput while incurring only modest area and power costs.
 
-</Concept>
-
-<Concept>
-
 ## TeraFLOPS
 
 TeraFLOPS is a unit of computing power equal to one million (10^12) floating-point operations per second.
 
-</Concept>
-
-<Concept>
-
 ## TF32
 
 TF32 is a new precision that functions similarly to FP32. It provides remarkable speed improvements of up to 10X for AI tasks, all without necessitating any alterations to the existing code.
-
-</Concept>

--- a/compute/instances/concepts.mdx
+++ b/compute/instances/concepts.mdx
@@ -10,67 +10,36 @@ categories:
   - compute
 ---
 
-<Concept opened>
-
 ## Availability Zone
 
 An Availability Zone refers to an isolated location within a specific region. Each Availability Zone provides its own services and infrastructure. For example, `fr-par-1`, `fr-par-2` and `fr-par-3` are Availability Zones within the Paris region.
 
 For an extensive list of which regions and AZ a resource is available in, refer to our [Products availability guide](/console/account/reference-content/products-availability/)
 
-</Concept>
-
-<Concept opened>
-
 ## Block volumes
 
 Block volumes provide network-attached storage that can be plugged in/out of Instances like a virtual hard drive. From a user's point of view, block volumes behave like regular disks, and can be used to increase the storage of an Instance.
 
-</Concept>
-
-
-<Concept opened>
-
 ## Boot-on-block
 
 <Macro id="storage-boot-on-block" />
-
-</Concept>
-
-<Concept opened>
 
 ## Carrier-grade NAT (CGNAT)
 
 Scaleway uses a 1:1 carrier-grade (CGNAT) setup for legacy Instance types. With this architecture, each Instance is assigned a unique NAT IP that directly maps to a unique public IP, unlike standard CGNAT, where multiple users share a single public IP.
 This setup ensures that all outbound and inbound traffic for an Instance is translated between these two addresses, preserving the exclusivity of IP addresses and avoiding certain connectivity issues related to a shared IP setup.
 
-</Concept>
-
-<Concept opened>
-
 ## Cloud-init
 
 Cloud-init is a multi-distribution package that [provides boot time customization for cloud servers](/compute/instances/how-to/use-boot-modes/#how-to-use-cloud-init). It enables automatic configuration of Instances as it boots into the cloud, turning a generic Ubuntu image into a configured server in a few seconds.
-
-</Concept>
-
-<Concept>
 
 ## Cost-Optimzed Instances
 
 [Cost-Optimized Instances](https://www.scaleway.com/en/cost-optimized-instances/) are production-grade [Instances](#instance) designed for scalable infrastructures. Cost-Optimized Instances support the boot-on-block feature and allow you to launch high-performance services with high-end CPUs.
 
-</Concept>
-
-<Concept>
-
 ## Development Instance
 
 [Development Instances](https://www.scaleway.com/en/cost-optimized-instances/) are reliable and flexible Instances tuned to host your websites, applications, and development environments.
-
-</Concept>
-
-<Concept>
 
 ## Dynamic IP
 
@@ -78,49 +47,25 @@ A dynamic IP is an alternative type of public IP address for your Instance. This
 
 You can choose to give your Instance a dynamic IP address when creating or updating your Instance via the [Scaleway API](https://www.scaleway.com/en/developers/api/instance/) only. Find more information about the billing of dynamic IPs compared to flexible IPs on our [billing FAQ](/faq/billing/#when-does-the-billing-of-an-instance-start-and-stop).
 
-</Concept>
-
-<Concept>
-
 ## Flexible IP
 
 Flexible IP addresses are public IP addresses that you can hold independently of any Instance. When you create a Scaleway Instance, by default its public IP address is also a flexible IP address. Flexible IP addresses can be attached to and detached from any of your Instances as you wish. You can keep a number of flexible IP addresses in your account at any given time. When you delete a flexible IP address, it is disassociated from your account to be used by other users. Find out more with our dedicated documentation on [how to use flexible IP addresses](/compute/instances/how-to/use-flexips/). See also [Dynamic IPs](#dynamic-ip).
-
-</Concept>
-
-<Concept>
 
 ## GPU Instance
 
 [GPU Instances](https://www.scaleway.com/en/gpu-instances/) are powerful Instances equipped with dedicated high-end Nvidia graphics processing units. See our [dedicated GPU documentation](/compute/gpu/) for more details.
 
-</Concept>
-
-<Concept>
-
 ## Image
 
 Creating an image allows you to make a complete backup of your Instance. One image will contain all the [volumes](#volumes) of your Instance, and can be used to restore your Instance and its data. You can also use it to create a series of Instances with a predefined configuration. To copy not all but only one specific volume of an Instance, you can use the [snapshot](#snapshot) feature instead.
-
-</Concept>
-
-<Concept>
 
 ## Instance
 
 An Instance is a virtual computing unit that offers resources for running applications. It functions as a self-contained entity with its own operating system, RAM, and storage. Each type of Instance has unique specifications. You can choose the type that best meets your requirements. Refer to our [Instance types documentation](/compute/instances/reference-content/choosing-instance-type/) for further details on the various Scaleway Instance options.
 
-</Concept>
-
-<Concept>
-
 ## InstantApp
 
 An InstantApp is an image with a preinstalled application. By choosing an InstantApp when prompted to select an image during the [creation of your Instance](/compute/instances/how-to/create-an-instance/), you choose to install the specified application on your Instance. You can then start using the application immediately.
-
-</Concept>
-
-<Concept>
 
 ## IP mobility
 
@@ -134,40 +79,21 @@ With IP mobility, there are no NAT IPs anymore. The public IP is entirely routed
   Your IP address will be retained during stop/start operations only if you have linked a flexible public IP address to your Instance. If you are using a dynamic IP address, the behavior remains consistent, whether your Instance has a routed IP enabled or is a legacy one.
 </Message>
 
-</Concept>
-
-<Concept>
 ## Learning Instance
 
 [Learning Instances](https://www.scaleway.com/en/stardust-instances/) are the perfect Instances for small workloads and simple applications. You can create up to one Instance per Availability Zone (available in FR-PAR-1 and NL-AMS-1).
-
-</Concept>
-
-<Concept>
 
 ## Local volumes
 
 The local volume of an Instance is an all-SSD-based storage solution, using a RAID array for redundancy and performance, hosted on the local hypervisor. On Scaleway Instances, the size of the local volume is fixed and depends on the Instance type. Some Instance types do not use local volumes at all, and [boot directly on block volumes](#boot-on-block). In any case, it is always possible to increase the storage of a Virtual Cloud Instance by adding additional block volumes.
 
-</Concept>
-
-<Concept>
-
 ## Unified snapshots
 
 Unified [snapshots](#snapshot) are a type of snapshot that can be created from either local (LSSD) or block (BSSD) volumes. Unified snapshots can be used to create either LSSD or BSSD volumes, so they are more flexible than other snapshot types.
 
-</Concept>
-
-<Concept>
-
 ## Placement groups
 
 Placement groups allow you to run multiple Compute Instances each on a different physical hypervisor. Placement groups have two operating modes. The first one is called `max_availability`. It ensures that all the Compute Instances that belong to the same cluster will not run on the same underlying hardware. The second one is called `low_latency` and does the exact opposite: it brings Compute Instances closer together to achieve higher network throughput. Find [how to use placement groups](/compute/instances/how-to/use-placement-groups/) with our documentation.
-
-</Concept>
-
-<Concept>
 
 ## Production-Optimized Instances
 
@@ -178,19 +104,11 @@ Three variants of POP2 Instances are available:
 * **POP2-HC**: Workload-Optimized Instances, providing a ratio of vCPU:RAM of 1:8
 * **POP2-HM**: Workload-Optimized Instances, providing a ratio of vCPU:RAM of 1:2
 
-</Concept>
-
-<Concept>
-
 ## Power-off mode
 
 The Power-off mode [shuts down an Instance](/compute/instances/how-to/power-off-instance/) by transferring all data on the local volume of the Instance to a volume store. The physical node is released back to the pool of available machines. The reserved flexible IP of the Instance remains available in the account.
 
 **Note:**  Depending on the amount of data to be archived, this process can take some time.
-
-</Concept>
-
-<Concept>
 
 ## Private Networks
 
@@ -198,25 +116,13 @@ Private Networks allow your virtual Instances to communicate in an isolated and 
 
 Private Networks are a LAN-like layer 2 Ethernet network. A new network interface with a unique media access control address (MAC address) is configured on each Instance in a Private Network. Use this interface to communicate in a secure and isolated network, using private IP addresses of your choice.
 
-</Concept>
-
-<Concept>
-
 ## Protected Instance
 
 The Protected Instance feature is used to prevent any halt action from being performed on your Instance. This only applies to running Instances. [Enabling the Protected Instance feature](/compute/instances/how-to/use-protected-instance/) means that you will not be able to delete, power off or reboot your Instance, nor put it into standby mode.
 
-</Concept>
-
-<Concept>
-
 ## Public IP
 
 Public IP addresses are routed on the internet. You can enter the public IP address of your Instance into any browser connected to the Internet, and access content being served from that Instance. You can think of public IP addresses like postal addresses for buildings - they are unique and tell the routers directing traffic through the internet where to find a particular server.
-
-</Concept>
-
-<Concept>
 
 ## Region
 
@@ -224,90 +130,46 @@ A region is a geographical area such as France (Paris: fr-par), the Netherlands 
 
 For an extensive list of which regions and AZ a resource is available in, refer to our [Products availability guide](/console/account/reference-content/products-availability/)
 
-</Concept>
-
-<Concept>
-
 ## Rescue mode
 
 Rescue mode restarts your server via the network on a minimal operating system. You can [use rescue mode](/compute/instances/how-to/use-boot-modes/#how-to-use-rescue-mode) to debug your server and recover your system data. Rescue mode creates a ramdisk with the content of a downloaded rootfs. You will have access to all your disks and will be able to perform debug and rescue actions. After disabling rescue mode, you will have to reboot your server. Your server needs to be running to switch to rescue mode.
 
-</Concept>
-
-<Concept>
-
 ## Reverse DNS
 
 Reverse DNS is the opposite of classic "forward" DNS, and maps an IP address to a hostname. This can be useful if, for example, you want to send emails from your Instance. Find out how to [configure reverse DNS on your Instance](/compute/instances/how-to/configure-reverse-dns/) with our how-to documentation.
-
-</Concept>
-
-<Concept>
 
 ## Routed flexible IP
 
 A routed flexible IP means assigning a public IP address to an Instance (virtual machine) that is reachable directly from the internet. This means there's [no address translation](/compute/instances/concepts/#carrier-grade-nat-(cgnat)), and the Instance uses the public IP as its identity on the internet.
 The Instance can be accessed or can communicate directly using this public IP, which helps to make network configuration straightforward, unrestricted inbound and outbound connections, crucial for services like web hosting or email servers.
 
-</Concept>
-
-<Concept>
-
 ## Security group
 
 Security groups allow you to [create rules to drop or allow traffic coming to and from your Instances](/compute/instances/how-to/use-security-groups/). You can set default policies for inbound and outbound traffic, and/or define rules to deal with traffic differently depending on its source. If you wish, you can then create your own private infrastructure by disabling the public IPs of your Instances. Security groups can be [stateful](#stateful-security-groups) to concept or [stateless](#stateless-security-groups). Note that security groups for Elastic Metal servers cannot be stateful.
-
-</Concept>
-
-<Concept>
 
 ## Snapshot
 
 A snapshot takes a picture of a specific volume at one point in time. For example, you may have a server with one volume containing the OS and another containing the application data, and want to use different snapshot strategies on both volumes. [Creating snapshots of your volumes](/compute/instances/how-to/create-a-snapshot/) gives you total freedom of which volumes you want to back up, while [images](#image) are more convenient for full backups of your Instance.
 
-</Concept>
-
-<Concept>
-
 ## Snapshot type
 
 An image is composed of snapshots of volumes. By default, snapshots can only be restored to a volume of the original type. Unified snapshots can be restored  to a different volume type, for example to move from an Instance with local storage to a block-only Instance.
-
-</Concept>
-
-<Concept>
 
 ## Standby mode
 
 Standby mode is designed to temporarily stop an Instance. When you [put an Instance in standby mode](/compute/instances/how-to/use-standby-mode/), the server is halted, but the Instance remains allocated to your account and all data remains on the local storage of the Instance.
 
-</Concept>
-
-<Concept>
-
 ## Stateful security groups
 
 Stateful security groups disregard the default policy and inbound/outbound rules if a connection is initiated from your Instance. Traffic will always be permitted on connections that you initiated. This is useful for example if you want to initiate connections on many and various ports for messaging, video streaming, or other purposes. In this case, the traffic from/to that connection will not be blocked, even if you have defined a rule that would otherwise do so. Find out more with our dedicated documentation: [how to use security groups](/compute/instances/how-to/use-security-groups/)
-
-</Concept>
-
-<Concept>
 
 ## Stateless security groups
 
 Stateless security groups strictly apply the default policy and inbound/outbound rules, regardless of whether a connection is initiated from your Instance or not. This is useful if you know exactly which ports you will always require for your Instance, e.g. port `22` for SSH. You can make your security group stateless, define a rule to allow traffic on port `22`, and block incoming traffic on other ports regardless of whether a connection is initiated from your Instance on this port or not. Find out more with our dedicated documentation: [how to use security groups](/compute/instances/how-to/use-security-groups/)
 
-</Concept>
-
-<Concept>
-
 ## Tags
 
 Tags allow you to organize your resources. This gives you the possibility of sorting and filtering your cloud assets in any organizational pattern of your choice, which in turn helps you arrange, control and monitor your cloud resources. You can assign as many tag as you want to each Scaleway product.
-
-</Concept>
-
-<Concept>
 
 ## Volumes
 
@@ -316,5 +178,3 @@ Volumes are the storage space of your Instances. Two types of volumes exist:
 * **Local volumes**: The local volume of an Instance is an all-SSD-based storage solution, using a RAID array for redundancy and performance, hosted on the local hypervisor. On Scaleway Instances, the size of the local volume is fixed and depends on the Instance type. Some Instance types do not use local volumes at all, and [boot directly on block volumes](#boot-on-block).
 
 * **Block volumes**: Block volumes provide network-attached storage that can be plugged in/out of Instances like a virtual hard drive. Block volumes behave like regular disks, and can be used to increase the storage of an Instance.
-
-</Concept>

--- a/compute/instances/reference-content/instances-datasheet.mdx
+++ b/compute/instances/reference-content/instances-datasheet.mdx
@@ -12,13 +12,12 @@ dates:
 categories:
   - compute
 ---
+
 This datasheet provides a concise overview of the performance, technical features, components, materials, and associated documentation for different Instance offers.
 
 <Message type="note">
   Note that the **Max. NIC bandwidth** specifies the maximum available bandwidth for this Instance type. Bandwidth is shared between public internet and Private Network traffic.
 </Message>
-
-<Concept>
 
 ## STARDUST1 Instances
 
@@ -37,10 +36,6 @@ This datasheet provides a concise overview of the performance, technical feature
 | vCPU:RAM ratio    	| 1:1                     	                |
 | SLA               	| None                    	                |
 
-</Concept>
-
-<Concept>
-
 ## Developement and General Purpose Instances
 
 See below the technical specifications of Development and General Purpose Instances:
@@ -56,10 +51,6 @@ See below the technical specifications of Development and General Purpose Instan
 | Resources   	                  | Shared vCPUs                                                                  |
 | Sizing   	                      | From 2 to 4 vCPUs <br />From 2 to 12 GiB RAM                                   |
 | vCPU:RAM ratio                  | Various<br />(1:1, 1:2, 1:3)                                                  |
-
-</Concept>
-
-<Concept>
 
 ## PLAY2 and PRO2 Instances
 
@@ -77,10 +68,6 @@ See below the technical specifications of PLAY2 and PRO2 Instances:
 | Sizing   	                      | From 1 to 32 vCPUs <br />From 2 to 128 GiB RAM                                |
 | vCPU:RAM ratio                  | Various<br />(1:2, 1:4)                                                       |
 
-</Concept>
-
-<Concept>
-
 ## COP-ARM Instances
 
 The table below displays the technical specifications of COP-ARM Instances:
@@ -96,10 +83,6 @@ The table below displays the technical specifications of COP-ARM Instances:
 | Resources   	                  | Shared vCPUs                                                                  |
 | Sizing   	                      | From 2 to 128 vCPUs <br />From 8 to 128 GiB RAM                               |
 | vCPU:RAM ratio                  | 1:4                                                                           |
-
-</Concept>
-
-<Concept>
 
 ## Enterprise Instances
 
@@ -120,10 +103,6 @@ See below the technical specifications of Enterprise Instances:
 
 \* Instances with dedicated vCPU do not share their compute resources with other Instances (1 vCPU = 1 CPU thread dedicated to that Instance). This type of Instance is particularly recommended for running production-grade compute-intensive applications.
 
-</Concept>
-
-<Concept>
-
 ## Production-Optimized Instances
 
 See below the technical specifications of Production-Optimized Instances:
@@ -141,10 +120,6 @@ See below the technical specifications of Production-Optimized Instances:
 | vCPU:RAM ratio                  | 1:4                                                                           |
 
 \* Instances with dedicated vCPU do not share their compute resources with other Instances (1 vCPU = 1 CPU thread dedicated to that Instance). This type of Instance is particularly recommended for running production-grade compute-intensive applications.
-
-</Concept>
-
-<Concept>
 
 ## Workload-Optimized Instances
 
@@ -166,6 +141,4 @@ See below the technical specifications of Workload-Optimized Instances:
 | Sizing   	                      | From 2 to 64 dedicated vCPUs <br /> From 4 GiB to 512 GiB RAM                 |
 | vCPU:RAM ratio                  | 1:8 (POP2-HM), 1:2 (POP2-HC)                                                  |
 
-\* Instances with dedicated vCPU do not share their compute resources with other Instances (1 vCPU = 1 CPU thread dedicated to that Instance). This type of Instance is particularly recommended for running production-grade compute-intensive applications
-
-</Concept>
+\* Instances with dedicated vCPU do not share their compute resources with other Instances (1 vCPU = 1 CPU thread dedicated to that Instance). This type of Instance is particularly recommended for running production-grade compute-intensive applications.

--- a/console/account/concepts.mdx
+++ b/console/account/concepts.mdx
@@ -10,96 +10,49 @@ categories:
   - console
 ---
 
-
-<Concept opened>
-
 ## Abuse
 
 [Abuse](https://www.scaleway.com/en/abuse-notice/) of Scaleway services includes cyber-crime, copyright violation, illegal or offensive content, spamming and malware distribution. Abuse should be [reported in the console](https://console.scaleway.com/support/abuses/create).
-
-</Concept>
-
-<Concept opened>
 
 ## Active session
 
 An active session begins when a computer or device signs into your account. To connect you to your account, Scaleway uses JSON Web Tokens (JWT). JWT allows secure transmission of information between parties through tokens. These parties can be users, servers, or any other combination of services. In the case of Scaleway, when a user connects to their account (e.g. via an email address and password), we generate a token, associate it with the session and send it to the user. The token is composed of a header, a payload, and a signature. You can see the list of your active sessions in the [Scaleway console](https://console.scaleway.com/account/user/profile), to get an overview of all devices that are signed in and recently active on your account.
 
-</Concept>
-
-<Concept>
-
 ## Billing Alert
 
 The billing alerts feature allows you to keep track of your billing costs. When you activate this feature, you define a monthly **budget**, in euros, and an alert **threshold**, which is a percentage of this monthly budget. When your Scaleway billing reaches this threshold (e.g. 70% of your monthly budget), an alert is sent to you by SMS, email, or API webhook.
-
-</Concept>
-
-<Concept>
 
 ## Console
 
 The Scaleway console allows you to view and manage your Scaleway products, billing information, support tickets and more. [Access the Scaleway console](https://console.scaleway.com/organization).
 
-</Concept>
-
-<Concept>
-
 ## KYC
 
 **K**now **Y**our **C**ustomer is the process of verifying a client's identity. An ID document such as a passport, driver's license or identity card is required to [complete KYC verification](/console/account/how-to/verify-identity/).
-
-</Concept>
-
-<Concept>
 
 ## Login information
 
 Consists of the **e-mail address** your account is registered to and its corresponding [**password**](#password). With your login information, you can connect to your Scaleway Organization via the Scaleway console. As an alternative to using a password, you can use login using a [magic link](#magic-link).
 
-</Concept>
-
-<Concept>
-
 ## MAC Address
 
 A **M**edia **A**ccess **C**ontrol Address is a unique ID assigned to network interface cards (NICs), used to ensure the physical address of a computer. It identifies the hardware manufacturer and is used for network communication between devices in a network segment.
-
-</Concept>
-
-<Concept>
 
 ## Magic Link
 
 A magic link provides quick and secure access to your account without the hassle of remembering your [password](#login-information). When you choose to sign in with a magic link, you receive a unique link sent directly to your email inbox which you can use one time only to authenticate your login. Afterward, it automatically becomes invalid.
 
-</Concept>
-
-<Concept>
-
 ## Multifactor Authentication (MFA)
 
 Multifactor authentication (MFA) is any form of verification that requires two factors to authenticate to a device you wish to connect to. Scaleway supports MFA for Cloud accounts in the form of a security code that you use in addition to your [password](#password) when you log in. You can receive the code via SMS or an authenticator app on your smartphone. Enabling MFA adds an additional layer of security against unauthorized access to your account.
-
-</Concept>
-
-<Concept>
 
 ## Organization Quotas
 
 Every [Organization](#organization) has quotas, which are limits on the number of Scaleway resources they can use. Quotas are per product (e.g. Instances) and product type (e.g. GP1-L Instance). Quotas are designed to prevent abuse, and can be viewed on the [Organization dashboard](https://console.scaleway.com/organization/settings) of the console.
 
-</Concept>
-
-<Concept>
-
 ## Password
 
 A password is a string of characters associated to your account's email address that allows you to access the [Scaleway console](https://console.scaleway.com/). It is personal and must not be shared with anyone. Alternatively, you can use a [magic link](#magic-link) to authenticate yourself.
-
-</Concept>
-
-<Concept>
 
 ## SSH key
 
@@ -110,20 +63,10 @@ An SSH key (**S**ecure **Sh**ell key) allows passwordless connection to an [Inst
 
 The public key is kept in your Scaleway account and transferred to the instance during the boot process, while the identification key is kept securely on your local computer. When connecting to the instance via SSH, a trusted connection to the machine is established using the key pair.
 
-</Concept>
-
-<Concept>
-
 ## Support plan
 
 Scaleway provides four different types of [support plans](https://console.scaleway.com/support/plans): Basic, Bronze, Silver and Gold. Your support plan determines the level of service and dedicated assistance you have access to, and the guaranteed response time of your support requests. You can [configure your support plan in the console](/console/account/how-to/configure-support-plans/).
 
-</Concept>
-
-<Concept>
-
 ## UUID
 
 A Universally Unique Identifier (UUID) is a 128-bit label attributed by Scaleway to each resource, used to identify them in CLI and API operations. UUIDs can also identify users and Organizations, as well as cloud resources.
-
-</Concept>

--- a/console/project/concepts.mdx
+++ b/console/project/concepts.mdx
@@ -10,39 +10,21 @@ categories:
   - console
 ---
 
-<Concept opened>
-
 ## Default Project
 
 Each [Organization](#organization) has at least one associated [Project](#project). Upon account creation, this Project is called **default**. The default Project takes on the Organization ID. Therefore, the default status cannot be transferred to other Projects, nor can the default Project's name be altered.
-
-</Concept>
-
-<Concept>
 
 ## Project
 
 A Project is a grouping of Scaleway [resources](#resource). Each Scaleway Organization comes with a default Project, and you can create new Projects if necessary. Projects are cross-region, meaning resources located in different [regions](/compute/instances/concepts/#region) can be grouped in one single Project. When grouping resources into different Projects, you can use [IAM](/identity-and-access-management/iam/concepts/#iam) to define custom access rights for each Project.
 
-</Concept>
-
-<Concept>
-
 ## Project Dashboard
 
 The Project Dashboard can be viewed within the [console](https://console.scaleway.com/project). On this dashboard, you can see an overview of the Project's [resources](#resources), along with the Project's settings and credentials ([SSH keys](#ssh-key)).
 
-</Concept>
-
-<Concept>
-
 ## Resource
 
 A Scaleway resource is either a product or a feature in the Scaleway Ecosystem. Examples of resources include Instances, Private Networks, Kubernetes Kapsule and Flexible IPs, to name a few.
-
-</Concept>
-
-<Concept>
 
 ## SSH key
 
@@ -52,5 +34,3 @@ An SSH key (**S**ecure **Sh**ell key) allows passwordless connection to an [Inst
 - a **public key**, which is uploaded to the Scaleway interface.
 
 The public key is kept in your Scaleway account and transferred to the Instance during the boot process, while the identification key is kept securely on your local computer. When connecting to the Instance via SSH, a trusted connection to the machine is established using the key pair.
-
-</Concept>

--- a/containers/container-registry/concepts.mdx
+++ b/containers/container-registry/concepts.mdx
@@ -10,60 +10,30 @@ categories:
   - container-registry
 ---
 
-
-
-<Concept opened>
-
 ## Container Registry
 
 Scaleway Container Registry is a fully-managed mutualized Container Registry, designed to facilitate the storage, management, and deployment of [container images](#container-image). The service simplifies the development-to-production workflow, as there is no need to operate your own Container Registry or worry about the underlying infrastructure.
-
-</Concept>
-
-<Concept opened>
 
 ## Container image
 
 A container image is a file that includes all the requirements and instructions of a complete and executable version of an application. When running, it becomes one or multiple instances of that application. You can [pull the image](/containers/container-registry/how-to/pull-images/), [edit its settings](/containers/container-registry/how-to/manage-image-privacy-settings/), [view its versions](/containers/container-registry/how-to/display-image-versions/) or [delete it](/containers/container-registry/how-to/delete-image/).
 
-</Concept>
-
-<Concept opened>
-
 ## Docker
 
 Docker is a tool that makes it easy to manage container images. You can [use Docker from your local computer](/containers/container-registry/how-to/connect-docker-cli/) to [push and pull images to and from your Scaleway Container Registry](/containers/container-registry/how-to/push-images/).
-
-</Concept>
-
-<Concept opened>
 
 ## Image privacy policies
 
 Image privacy policies specify whether everyone has the right to pull the image or not. When an image is set to public, anyone is able to pull it. [Set your image to private](/containers/container-registry/how-to/manage-image-privacy-settings/) if you want to restrict access. You can also specify that an image should inherit its privacy policy from its namespace.
 
-</Concept>
-
-<Concept>
-
 ## Namespace
 
 Namespaces allow you to [manage your Container Registry](/containers/container-registry/how-to/create-namespace/) in a simple, clear and human-readable way. A namespace is a collection of container images, each bearing the unique identifier of that namespace (each namespace must have a globally unique name). A namespace belongs to a user, who is responsible for configuring the push and pull permissions with [privacy policies](#namespace-privacy-policies).
-
-</Concept>
-
-<Concept>
 
 ## Namespace privacy policies
 
 Namespace privacy policies specify whether everyone has the right to pull an image from the namespace or not. When an image is in a public namespace, anyone is able to pull it. [Set your namespace to private](/containers/container-registry/how-to/manage-namespace-privacy-policies/) if you want to restrict access.
 
-</Concept>
-
-<Concept>
-
 ## Registry
 
 A Registry is a service which stores container images.
-
-</Concept>

--- a/containers/kubernetes/concepts.mdx
+++ b/containers/kubernetes/concepts.mdx
@@ -10,60 +10,29 @@ categories:
   - kubernetes
 ---
 
-
-
-<Concept opened>
-
 ## Autoheal
 
 Autoheal allows you to keep the nodes in your pool in a healthy state. When enabled, periodic checks are performed to ensure all your nodes are running properly.
-
-</Concept>
-
-
-<Concept opened>
 
 ## Autoscale
 
 Autoscale allows your cluster to automatically scale up or down.
 
-</Concept>
-
-
-<Concept opened>
-
 ## Auto-upgrade
 
 Auto-upgrade allows you to schedule a maintenance window for your cluster to be upgraded to a more recent version of Kubernetes. The upgrade process will occur within two hours from the time defined by you.
-
-</Concept>
-
-<Concept opened>
 
 ## Cluster
 
 A cluster is a set of machines, called nodes, running containerized applications managed by [Kubernetes](#kubernetes). A cluster has several worker nodes and at least one control plane. Each cluster is built for High Availability with a redundancy on the control plane. Refer to the [control plane](#control-plane) concept for more information regarding the cluster's limitations. Scaleway allows you to create two types of clusters: [Kapsule](#kubernetes-kapsule), for clusters comprising Scaleway Instances, and [Kosmos](#kubernetes-kosmos), for multi-cloud clusters.
 
-</Concept>
-
-<Concept>
-
 ## Container Network Interface (CNI)
 
 CNI (Container Network Interface) is a [Cloud Native Computing Foundation project](https://www.cncf.io/). It consists of a specification and libraries for writing plugins to configure network interfaces in Linux containers, along with a number of plugins.
 
-</Concept>
-
-<Concept>
-
 ## Container runtime
 
 The container runtime is the software that is responsible for running containers.
-
-</Concept>
-
-
-<Concept>
 
 ## Control plane
 
@@ -73,89 +42,45 @@ The control plane manages the worker nodes and the pods in the cluster. In produ
 - As the cluster's control plane and Load Balancer are managed by Scaleway, it is not possible to access them directly or configure them individually.
 - A cluster requires a minimum of one pool of worker machines to deploy Kubernetes resources. Note that pods must run on a worker node.
 
-</Concept>
-
-<Concept>
-
 ## Easy Deploy
 
 The Easy Deploy feature allows you to pull images directly from Scaleway Container Registry, instantly deploying containerized applications in your Kubernetes Kapsule cluster. With only the basic options to set, you can use Kubernetes Kapsule without needing to manage your `.yaml ` manifests. Check out our documentation on [creating containerized applications with the Easy Deploy feature](/containers/kubernetes/how-to/enable-easy-deploy/) for more information.
-
-</Concept>
-
-<Concept>
 
 ## Image pull secret
 
 Image pull secrets are tokens that authorize Kubernetes to pull images from private container registries.
 
-</Concept>
-
-<Concept>
-
 ## Ingress
 
 Ingress is an API object that manages external access to the services in a cluster, typically HTTPS. Ingress can provide load balancing, SSL termination, and name-based virtual hosting.
-
-</Concept>
-
-<Concept>
 
 ## Ingress controller
 
 Kubernetes supports a high-level abstraction called Ingress, which allows simple host or URL-based HTTP routing. Ingress is a core concept (in beta) of Kubernetes, but is always implemented by a third-party proxy. These implementations are known as ingress controllers. An ingress controller is responsible for reading the Ingress Resource information and processing that data accordingly. Different ingress controllers have extended the specification in different ways to support additional use cases. For more information, see our [dedicated how-to](/containers/kubernetes/how-to/deploy-ingress-controller/) on deploying ingress controllers.
 
-</Concept>
-
-<Concept>
-
 ## KubeConfig
 
 `kubeconfig` is a file provided by Scaleway when creating a Kubernetes cluster. It allows you to manage your cluster from your local computer by using kubectl.
-
-</Concept>
-
-<Concept>
 
 ## Kubectl
 
 Kubectl is the command line interface for running commands against Kubernetes clusters. You can [use kubectl](/containers/kubernetes/how-to/connect-cluster-kubectl/) to connect to and manage your clusters from the command line.
 
-</Concept>
-
-<Concept>
-
 ## Kubernetes
 
 Kubernetes (K8s) is an open-source platform for managing containerized workloads and services. Google initially developed the project, which became publicly available in 2014.
-
-</Concept>
-
-<Concept>
 
 ## Kubernetes Kapsule
 
 Kubernetes Kapsule provides a managed environment for you to create, configure, and run a cluster of pre-configured machines for containerized applications. It allows you to create [Kubernetes](https://kubernetes.io) clusters without the complexity of managing the infrastructure. Kubernetes Kapsule clusters are composed uniquely of Scaleway Instances. Read our documentation on [how to create a Kubernetes Kapsule](/containers/kubernetes/how-to/create-cluster/). To create clusters including Instances from external cloud providers, see [Kubernetes Kosmos](#kubernetes-kosmos).
 
-</Concept>
-
-<Concept>
-
 ## Kubernetes Kosmos
 
 Kubernetes Kosmos is the first-of-its-kind managed multi-cloud Kubernetes Engine. It allows the connection of Instances and servers from any Cloud provider to a single managed control plane hosted by Scaleway. Using Kubernetes in a multi-cloud cluster provides a high level of application redundancy by authorizing pod replication across different providers, regions, and Availability Zones. See our documentation to learn [how to create a Kubernetes Kosmos cluster](/containers/kubernetes/how-to/create-kosmos-cluster/).
 
-</Concept>
-
-<Concept>
-
 ## Load Balancer
 
 Load balancing efficiently distributes incoming network traffic across a group of backend servers. Scaleway manages the entire Load Balancer service, including traffic between API masters.
-
-</Concept>
-
-<Concept>
 
 ## Managed service
 
@@ -163,10 +88,6 @@ Scaleway Kapsule and Kosmos are managed Kubernetes services. Scaleway's managed 
 These services allow users to focus on deploying and running applications on Kubernetes without worrying about the underlying infrastructure and operational complexities.
 
 For more information, refer to the [managed Kubernetes service definition](/containers/kubernetes/reference-content/managed-kubernetes-service-definition).
-
-</Concept>
-
-<Concept>
 
 ## Minikube
 
@@ -180,33 +101,17 @@ Minikube runs a single-node Kubernetes cluster inside a VM on your computer or c
 - Enabling CNI (Container Network Interface)
 - Ingress
 
-</Concept>
-
-<Concept>
-
 ## Namespace
 
 Namespaces are used in Kubernetes to divide the same cluster resources between multiple virtual users. Namespaces are intended for use in environments with many users spread across multiple teams or projects.
-
-</Concept>
-
-<Concept>
 
 ## Node
 
 Kubernetes runs your workload by placing containers into pods to run on nodes. A node may be a virtual or physical machine, depending on the cluster. Each node is managed by the control plane and contains the services necessary to run pods.
 
-</Concept>
-
-<Concept>
-
 ## Pods
 
 A pod is the smallest and simplest unit in the Kubernetes object model. Containers are not directly assigned to hosts in Kubernetes. Instead, one or multiple containers that are working closely together are bundled in a pod together, sharing a unique network address, storage resources and information on how to govern the containers.
-
-</Concept>
-
-<Concept>
 
 ## Pool
 
@@ -214,10 +119,6 @@ The Pool resource is a group of Scaleway Instances, organized by type (e.g., GP1
 
 - Containers require a minimum of one Instance in the Pool.
 - A pool belongs to only one cluster, in the same region.
-
-</Concept>
-
-<Concept>
 
 ## ReplicaSet
 
@@ -228,18 +129,10 @@ The task of a ReplicaSet is to create and delete pods as needed to reach the des
 - A pod template, specifying the data of new pods to meet the number of replicas criteria.
   Each pod within a ReplicaSet can be identified via the `metadata.ownerReference` field, allowing the ReplicaSet to monitor each pod's state.
 
-</Concept>
-
-<Concept>
-
 ## Services
 A service is an abstraction that defines a logical group of pods that perform the same function, and a policy on how to access them. The service provides a stable endpoint (IP address) and acts as a Load Balancer by redirecting requests to the different pods in the service. The service abstraction allows the scaling out or replacement of dead pods without making changes to the configuration of an application.
 By default, services are only available using internally routable IP addresses, but can be exposed publicly.
 This can be done using the `NodePort` configuration, which opens a static port on each node's external networking interface. Alternatively, it is also possible to use the `load-balancer` service, which creates an external Load Balancer at a cloud provider using Kubernetes `load-balancer` integration.
-
-</Concept>
-
-<Concept>
 
 ## System volume
 
@@ -251,5 +144,3 @@ Depending on the type of node selected, we provide one or two types of volume.
   - **Block Storage:** your system is remotely stored on a centralized and resilient cluster.
 
 As a general guideline, your system volume disk should have a capacity of at least 20 GB to ensure enough space to store the necessary system files and configurations.
-
-</Concept>

--- a/dedibox-console/account/concepts.mdx
+++ b/dedibox-console/account/concepts.mdx
@@ -10,17 +10,9 @@ categories:
   - account
 ---
 
-
-<Concept opened>
-
 ## Abuse
 
 [Abuse](https://www.scaleway.com/en/abuse-notice/) of Scaleway services includes cyber-crime, copyright violation, illegal or offensive content, spamming and malware distribution. Abuse can be [reported in the Scaleway console](https://console.scaleway.com/support/abuses/create).
-
-</Concept>
-
-
-<Concept opened>
 
 ## Authorized SSH key
 
@@ -31,25 +23,13 @@ An SSH key (**S**ecure **Sh**ell key) allows passwordless authentication on SSH 
 
 The public key is kept in your Scaleway account and transferred to the Dedibox server during the installation, while the identification key is kept securely on your local computer. When connecting to the instance via SSH, a trusted connection to the machine is established using the key pair.
 
-</Concept>
-
-<Concept opened>
-
 ## Billing
 
 The billing section contains all information related to the payment of your invoices. You can update your billing method from this page and download your invoices. It also allows you to define an additional billing contact, who receives a copy of your monthly invoice by email.
 
-</Concept>
-
-<Concept opened>
-
 ## Dedibox console
 
 The Dedibox console allows you to view and manage your Scaleway Dedibox products, billing information, support tickets and more. You can access the console at the address [console.online.net](https://console.online.net).
-
-</Concept>
-
-<Concept>
 
 ## Logs
 
@@ -64,5 +44,3 @@ On this page you can see a list of connections made to your account. Each connec
 * **Personal information**: The personal information section of the Scaleway Dedibox console allows you to view and update certain personal information related to your account. You can also update your password or email address from this section of the Dedibox console.
 
 * **Security**: The security section of the Scaleway Dedibox console allows you to configure optional multifactor authentication to increase the security of your account. You can configure MFA using authentications applications such as Authy or Google Authenticator. French residents cans optionally also configure MFA by SMS.
-
-</Concept>

--- a/dedibox-console/classic-hosting/concepts.mdx
+++ b/dedibox-console/classic-hosting/concepts.mdx
@@ -10,80 +10,42 @@ categories:
   - webhosting
 ---
 
-<Concept opened>
-
 ## Alias
 
 An email alias is an additional email address for an email account, with which a user can send and receive emails, or set forwards to. A single user account can have multiple email aliases, with different domains or even with the same domain.
-
-</Concept>
-
-<Concept opened>
 
 ## Cloud hosting
 
 Cloud hosting uses Scaleway cloud Instances for your hosting needs. With this option, you can benefit from all the technologies and features of the cloud. Cloud hosting solutions work with all CMS and PHP frameworks. Storage is via SSD, giving better performance.
 
-</Concept>
-
-<Concept opened>
-
 ## Email account
 
 An email account is an email address on which mail is stored (unlike an alias / catchall). You can check your mail accounts via two protocols: POP3 and IMAP.
-
-</Concept>
-
-<Concept opened>
 
 ## FTP account
 
 FTP, or File Transfer Protocol, is a protocol that allows you to transfer files between different computers over the internet. It allows you, as part of our Webhosting service, to transfer your files from your computer to Scaleway.com - for example, to update your website. It also works vice versa: you can recover the files stored on Scaleway.com and transfer them to your personal computer, for example to make a backup.
 
-</Concept>
-
-<Concept>
-
 ## Filtering
 
 Filtering allows you to sort your emails depending on different criteria (the sender, the subject, the object and much more). If the email meets one or more criteria you can define different actions (delete the email, move it into a folder, etc.).
-
-</Concept>
-
-<Concept>
 
 ## htaccess
 
 `.htaccess` is a simple text file containing commands for the configuration of the Apache web server. It allows you to personalize the server dynamically and per folder. The configuration values are inherited through directories. Common applications for setting up a `.htaccess` file are switching between PHP4 and PHP5, protection of a part of the site, redirecting a website to another, or customizing error messages. Once on the server, its name must be `.htaccess` with a point ahead.
 
-</Concept>
-
-<Concept>
-
 ## PHP
 
 PHP is a server-side scripting language designed for web development but also used as a general-purpose programming language. While PHP originally stood for Personal Home Page, it now stands for PHP: Hypertext Preprocessor, which is a recursive backronym. 
-
-</Concept>
-
-<Concept>
 
 ## php.ini
 
 The `php.ini` file is the configuration file used for applications that require PHP. It contains the configuration of variables such as upload sizes, file timeouts, and resource limits. At Scaleway we provide PHP with the most common values preconfigured for each webhosting. If required, you can [customize the configuration of PHP](/dedibox-console/classic-hosting/how-to/configure-php/) towards your needs.
 
-</Concept>
-
-<Concept>
-
 ## Redirection
 
 A redirection is an alternative email address for one or multiple email accounts of the same domain. For example, you can create the alias `[contact@example.com](mailto:contact@example.com)` which will redirect the mail to the personal email account `[firstname.lastname@example.com](mailto:firstname.lastname@example.com)`
 This allows you to not only have multiple email addresses without needing multiple email accounts, but also to deliver the email to multiple recipients.
-
-</Concept>
-
-<Concept>
 
 ## Webhosting
 
@@ -95,5 +57,3 @@ Webhosting is a service provided by Scaleway which offers storage space and acce
 - Unlimited subdomains
 - An FTP account to upload your website
 - At least one database
-
-</Concept>

--- a/dedibox-network/dns/concepts.mdx
+++ b/dedibox-network/dns/concepts.mdx
@@ -10,60 +10,33 @@ categories:
   - dedibox-network
 ---
 
-<Concept opened>
-
 ## Domain Name / Domain
 
 See [Domains](/dedibox-network/domains/concepts/#domain-name).
 
-</Concept>
-
-<Concept opened>
-
 ## DNS
 
 The **D**omain **N**ame **S**ystem is a name management system for computing devices connected to a network, be it public (Internet) or private. It translates text-based [domain names](/dedibox-network/domains/concepts/#domain-name) to numerical [IP addresses](#ip-address).
-</Concept>
-
-<Concept opened>
 
 ## DNS Delegation
 
 DNS delegation is when a [DNS Name Server](#dns-name-servers) delegates authority over a part of its [namespace](#dns-namespace) to one or more other DNS servers. Delegation can be seen as a pointer to the authoritative name servers for a subdomain. With Dedibox, this can be useful to edit the reverse of IPv4/27 blocks and the IPv6 blocks (/48 - /56 - /64), as that cannot be done directly in the console. You can, alternatively, delegate those subnets to your name servers, who will then take on the task of propagating the DNS reverses of your IPs on the internet.
-</Concept>
-
-<Concept opened>
 
 ## DNS Name Servers
 
 A DNS Name Server stores the [DNS Records](#dns-record) for a given domain(s).
-</Concept>
-
-<Concept>
 
 ## DNS Record
 
 A [DNS](#dns) Record holds information translating a domain or subdomain to an IP address, mail server or other domain/subdomain. DNS records for each [DNS Zone](#dns-zone) are stored within files called [DNS Zone Files](#dns-zone-file). These are hosted on [DNS Name Servers](#dns-name-servers). DNS records act as instructions for the DNS servers, so they know which domain names and IP addresses are associated with each other. DNS records can be of multiple types, called [Resource Records](#resource-records).
 
-</Concept>
-
-<Concept>
-
 ## DNS Zone
 
 A DNS zone hosts the [DNS records](#dns-record) for a distinct part of the global domain namespace, and is managed by a specific organization or administrator.
 
-</Concept>
-
-<Concept>
-
 ## DNS Zone File
 
 A DNS Zone File describes a [DNS Zone](#dns-zone), containing DNS records which constitute mappings between domain names, IP addresses and other resources.
-
-</Concept>
-
-<Concept>
 
 ## DNS Namespace
 
@@ -73,17 +46,9 @@ DNS domains are all organized in a hierarchy called the DNS namespace. The hiera
   - **Second-level domains**: example.com
   - **Subdomains**: mysite.example.com or sub.domain.example.com.
 
-</Concept>
-
-<Concept>
-
 ## IP Address
 
 An Internet Protocol address is a unique address that identifies a device on the internet or a local network. Generally, when we talk about IP addresses, we are referring to IPv4 addresses. However, due to the global shortage of IPv4 addresses, IPv6 addresses have also been in deployment since the mid-2000s.
-
-</Concept>
-
-<Concept>
 
 ## Resource Records
 
@@ -97,29 +62,14 @@ The most common records are:
 - **MX record**: Mail exchange record, it maps a domain name to a list of one or several mail servers for that domain.
 - **TXT record**: Text record, it is often used to carry machine-readable data such as information for automated domain validation.
 
-</Concept>
-
-<Concept>
-
 ## Reverse DNS
 
 Reverse DNS, or rDNS, is exactly the opposite of classic [forward DNS](#dns) as we know it. Forward DNS maps a hostname to an IP address. Reverse DNS means we are mapping the IP address to a hostname. This can be very useful, especially if you want to send emails from your server.
-
-</Concept>
-
-<Concept>
 
 ## Root Server 
 
 Root Servers are a type of [DNS Name Server](#dns-name-servers) pertaining to [Top Level domains](/dedibox-network/domains/concepts/#tld). They are the first step in the resolution of any domain name, since they contain information about the authoritative DNS servers for each Top Level Domain.
 
-</Concept>
-
-<Concept>
-
 ## Secondary DNS
 
 Secondary DNS uses zone transfer to automatically transfer DNS zones from a primary DNS server to a secondary DNS server. The secondary server is useful for redundancy, resiliency, and load balancing. The zone files on a secondary DNS server are read-only copies of the files on the primary server, and are automatically updated if a file changes on the primary server.
-
-</Concept>
-

--- a/dedibox-network/domains/concepts.mdx
+++ b/dedibox-network/domains/concepts.mdx
@@ -10,23 +10,13 @@ categories:
   - dedibox-network
 ---
 
-<Concept opened>
-
 ## Domain Name
 
 A domain name is an unique alphanumeric name used to identify a computer (web or email server) on the internet. It translates the numeric address of the computer to a more memorable name.
 
-</Concept>
-
-<Concept opened>
-
 ## DNS Server
 
 A DNS server is a program that responds to requests for DNS zones configured by the administrator. DNS servers typically operate in pairs, each pair consisting of a primary and secondary server.
-
-</Concept>
-
-<Concept opened>
 
 ## DNS Zone
 
@@ -38,33 +28,17 @@ The DNS zone links these memorable names with their IP addresses.
 If you want to connect to our website **www.scaleway.com**, your computer sends a request to a DNS server, hosting the DNS zone.
 This is a file that has the information about the IP addresses linked to a domain name.
 
-</Concept>
-
-<Concept opened>
-
 ## IP Address
 
 An Internet Protocol address is a unique address that identifies a device on the internet or a local network. Generally, when we talk about IP addresses, we are referring to IPv4 addresses. However, due to the global shortage of IPv4 addresses, IPv6 addresses have also been in deployment since the mid-2000s.
-
-</Concept>
-
-<Concept opened>
 
 ## TLD 
 
 TLD is the acronym used for top-level domains. It is the last segment of a domain name after the final dot. The most common example is `.com`, but there is a whole wide world of different TLDs.
 
-</Concept>
-
-<Concept>
-
 ## DNSSEC
 
 DNSSEC cryptographically ensures that DNS content cannot be modified from its source without being detected. It works by digitally signing each DNS record so that any tampering of that record can be detected.
-
-</Concept>
-
-<Concept>
 
 ## TLD specifications at Scaleway
 
@@ -76,12 +50,6 @@ Some TLDs have special requirements that can block you from ordering or renewing
 - **.la**: administrative contact and technical contact must be an individual
 - **.li**: administrative contact and technical contact must be an individual
 
-</Concept>
-
-<Concept>
-
 ## WAPS
 
 WAPS, or **W**hois **A**ccuracy **P**rogram **S**pecification, is a system introduced by the [ICANN](https://www.icann.org/) to validate the contact information of a domain name. ICANN requires that all registrars validate the identity and the continuity of the information entered in the contact of a domain name in order to have up-to-date information about the owners.
-
-</Concept>

--- a/dedibox-network/ip-failover/concepts.mdx
+++ b/dedibox-network/ip-failover/concepts.mdx
@@ -10,58 +10,30 @@ categories:
   - dedibox-network
 ---
 
-<Concept opened>
-
 ## Bridged Network
 
 A bridged network is a mode of networking for virtual machines, another being [NAT-ed networks](/dedibox-network/ip-failover/concepts/#nat-ed-network). In bridge mode, your server and your virtual machines are seen as different servers at the level of the network equipment. Setting up a bridged network requires a [Virtual MAC address](/dedibox-network/ip-failover/concepts/#virtual-mac-address).
-
-</Concept>
-
-<Concept opened>
 
 ## Failover IPs
 
 Failover IPs are IP addresses that you can order and move from one server to another (even across datacenters), without changing your whole configuration. If your server is out of order, you can move the failover IP to your fallback server, and have your services remain available without any downtime. Failover IPs can also be used as additional IP addresses for a single server, for example if you want to give each website in Plesk its own IP. Another functionality of Failover IPs is to create virtual machines on your Dedibox.
 
-</Concept>
-
-<Concept opened>
-
 ## IP Configuration
 
 IP configuration refers to the assignment and management of IP addresses. Any server that needs to connect to the internet or to another computer, needs an IP address. There are many ways to configure IP addresses, including the use of Failover IPs, Virtual MAC addresses, and the Reverse DNS of IPs.
-
-</Concept>
-
-<Concept opened>
 
 ## NAT-ed Network
 
 A NAT-ed network is a mode of networking for virtual machines, another being [bridged networks](/dedibox-network/ip-failover/concepts/#bridged-network). In NAT mode, your server and its virtual machines are seen as one single server. As only the MAC address of your physical network card is broadcasted on the network, you do not require virtual MAC addresses for this network mode.
 
-</Concept>
-
-<Concept>
-
 ## Reverse DNS
 
 Reverse DNS, or rDNS, is exactly the opposite of classic forward DNS as we know it. Forward DNS maps a hostname to an IP address. Reverse DNS means we are mapping the IP address to a hostname. This can be very useful, especially if you want to send emails from your server.
-
-</Concept>
-
-<Concept>
 
 ## Virtual MAC Address
 
 Virtual MAC addresses are associated with Failover IPs, and are virtual versions of MAC addresses that identify physical hardware. Virtual MAC addresses allow you to create a [bridged network](/dedibox-network/ip-failover/concepts/#bridged-network) of virtual machines from your server, where the physical server and its virtual machines are identified as different machines at the network level. The same virtual MAC can be associated with several Failover IPs.
 
-</Concept>
-
-<Concept>
-
 ## Virtualization
 
 Virtualization refers to the creation of one or multiple virtual machines on a physical server. This can be achieved via virtualization solutions such as VMware vSphere Hypervisor (ESXi) or Proxmox. Virtualization allows you to create separate environments for your different services (for example keeping mail and web services on different VMs) or to launch several virtual machines to make better use of the performance of the server. To communicate on the Internet, each of your virtual machines needs an IP Address. You can use [Failover IPs](/dedibox-network/ip-failover/concepts/#failover-ips) for this purpose. If you want to create a bridged network for your virtual machines, you will also need to configure [Virtual MAC addresses](/dedibox-network/ip-failover/concepts/#virtual-mac-address).
-
-</Concept>

--- a/dedibox-network/ipv6/concepts.mdx
+++ b/dedibox-network/ipv6/concepts.mdx
@@ -10,15 +10,9 @@ categories:
   - dedibox-network
 ---
 
-<Concept opened>
-
 ## DHCPv6
 
 **D**ynamic **H**ost **C**onfiguration **P**rotocol **V**ersion **6** (DHCPv6) is a network management protocol for dynamically assigning IPv6 addresses and other configuration parameters to clients on IPv6 networks. It represents a complete re-design of the functionalities of "classic" v4 DHCP, and comes in three different "flavors": SLAAC, Stateless, and Stateful.
-
-</Concept>
-
-<Concept opened>
 
 ## DUID
 
@@ -28,59 +22,30 @@ _ Vendor-assigned unique ID based on enterprise number (DUID-EN)
 _ Link-layer address (MAC address) (DUID-LL)
 _ UUID-based DUID (DUID-UUID)
 
-</Concept>
-
-<Concept opened>
-
 ## IP Address
 
 An **I**nternet **P**rotocol address is a unique address that identifies a device on the internet or a local network. Generally, when we talk about IP addresses, we are referring to IPv4 addresses. However, due to the global shortage of IPv4 addresses, IPv6 addresses have also been in deployment since the mid-2000s.
-
-</Concept>
-
-<Concept opened>
 
 ## IPv4
 
 **I**nternet **P**rotocol **V**ersion **4** is the standard protocol used for IP addresses, and routes most internet traffic as of today. Each IPv4 address has 32 bits. Written in human-readable form, an IPv4 address is generally shown as four octets of numbers separated by periods, e.g. `72.16.254.1`
 
-</Concept>
-
-<Concept>
-
 ## IPv6
 
 **I**nternet **P**rotocol **V**ersion **6** is the most recent version of the IP protocol used for IP addresses. Each IPv6 address has 128 bits. Written in human-readable form, an IPv6 address can be shown as eight groups of four hexadecimal digits, each group representing 16 bits and separated by a colon, e.g. `2001:0DB8:0000:0003:0000:01FF:0000:002E`. This can also be notated as `2001:DB8::3:0:1FF:0:2E.`Dedibox network is wholly IPv6 compatible. IPv6 can be used as the main IP of your server, and also as an [IP failover](/dedibox-network/ip-failover/concepts/#failover-ips) using the principle of [virtual MAC](/dedibox-network/ip-failover/concepts/#virtual-mac-address).
-
-</Concept>
-
-<Concept>
 
 ## Neighbor Discovery Protocol
 
 The Neighbour Discovery Protocol (NDP) allows devices to discover neighbors, routers, prefixes and other services on a Layer 3 network. When a client first comes online, it sends a Router Solicitation message, and if a router exists on the network it replies with a Router Advertisement message. From this message, the client learns the default gateway (the address of the router) and the global network prefix.
 
-</Concept>
-
-<Concept>
-
 ## SLAAC
 
 **S**tateless **A**uto **A**ddress **C**onfiguration is the simplest way to assign IP addresses in an IPv6 network. Using the [Neighbor Discovery Protocol](/dedibox-network/ipv6/concepts/#neighbor-discovery-protocol), devices request the network prefix from the router, and then use this prefix and their own MAC address to create an IPv6 address.
 
-</Concept>
-
-<Concept>
-
 ## Stateful DHCPv6
 
 With [stateful DHCPv6](/dedibox-network/ipv6/concepts/#stateful-dhcpv6), it is the DHCPv6 server that chooses and assigns IPv6 addresses to clients, unlike with [SLAAC](/dedibox-network/ipv6/concepts/#slaac) or [Stateless DHCPv6](/dedibox-network/ipv6/concepts/#stateless-dhcpv6)  where the client creates their own IPv6 address. Stateful DHCPv6 is so-called because the DHCPv6 server keeps track of the state of IPv6 addresses on the network.
-</Concept>
-
-<Concept>
 
 ## Stateless DHCPv6
 
 [Stateless DHCPv6](/dedibox-network/ipv6/concepts/#stateless-dhcpv6) involves the initial use of [SLAAC](/dedibox-network/ipv6/concepts/#slaac) by a client to create its own IPv6 address, followed by an extra DHCPv6 request to get extra details from the DHCPv6 server, such as DNS server or domain name information. Stateful DHCPv6 is so-called because no server or client is keeping track of the overall state of IPv6 addresses on the network.
-
-</Concept>

--- a/dedibox-network/rpn/concepts.mdx
+++ b/dedibox-network/rpn/concepts.mdx
@@ -10,8 +10,6 @@ categories:
   - dedibox-network
 ---
 
-<Concept opened>
-
 ## Q-in-Q mode 
 
 Q-in-Q mode allows you to use more VLANs than you can use in Normal Mode.
@@ -23,25 +21,13 @@ This way, we encapsule your tags inside our tag, and make use of numerous VLANs 
   Q-in-Q mode is not available on all offers. If you add a server that is not compatible with Q-in-Q mode, an error message will appear. Do not hesitate to contact our [support team](https://console.online.net/en/assistance/ticket/list) if you have any questions regarding the Q-in-Q compatibility of a server.
 </Message>
 
-</Concept>
-
-<Concept opened>
-
 ## RPN
 
 Real Private Network (RPN) is a second physical network that uses a dedicated ethernet adapter to enable network coverage over all of Scaleway datacenters. You can create "RPN Groups" with different servers that are able to communicate with each other. Servers of different accounts can be in the same RPN group and each server can be in multiple groups. The RPN allows you to exchange internal data in a dedicated and secure network and without using the bandwidth of your internet connection. "Jumboframes" with a MTU of 9000 are supported in the RPN.
 
-</Concept>
-
-<Concept opened>
-
 ## RPN SAN
 
 The RPN SAN is a network attached storage providing additional storage for your Dedibox. The RPN-SAN Basic provides a cost-efficient way to extend your storage with HDD based storage. The RPN-SAN HA provides high-available storage, replicated intra-DC and is available in both, HDD based and SSD based storage for highest performances.
-
-</Concept>
-
-<Concept opened>
 
 ## RPN v2
 
@@ -52,29 +38,15 @@ RPN-v2 is a new version of Dedibox RPN Network (Real Private Network). It allows
 - No MAC address restriction
 - Multicast
 
-</Concept>
-
-<Concept>
-
 ## RPN VPN
 
 RPN VPN allows you to connect to your RPN group using a VPN. The VPN is based on OpenVPN to ensure easy configuration. You can add the VPN server to your RPN group as any other server.
 Notably, it allows you to securely connect from anywhere in your private network as well as to connect servers that do not have an RPN interface to the RPN.
 
-</Concept>
-
-<Concept>
-
 ## VLAN
 
 A virtual local area network (VLAN) is a logical group of workstations, servers, and network devices that appear to be on the same LAN despite their geographical distribution. The purpose of implementing a VLAN is to improve the performance of a network or apply appropriate security features.
 
-</Concept>
-
-<Concept>
-
 ## VLAN ID
 
 VLANs are identified by a VLAN ID (a number between 0 – 4095), with the default VLAN on any network being VLAN 1. Each port on a switch or router can be assigned to be a member of a VLAN (enabling the receiving and sending traffic on that VLAN).
-
-</Concept>

--- a/dedibox/dedicated-servers/concepts.mdx
+++ b/dedibox/dedicated-servers/concepts.mdx
@@ -10,80 +10,41 @@ categories:
   - dedibox-servers
 ---
 
-
-
-<Concept opened>
-
 ## Administrator Password
 
 The administrator password is set during the installation of your Dedibox server. It represents the password of the `root` user on the system. The administrator account has full rights to modify or delete any data on the server. Make sure that you set a strong administrator password.
-
-</Concept>
-
-<Concept opened>
 
 ## Access Control List (ACL)
 
 This feature allows you to restrict access to your backup space to the IP address of your Dedibox. The connection attempts (successful or unsuccessful) are stored in your console in real time.
 
-</Concept>
-
-<Concept opened>
-
 ## Auto Login
 
 Auto Login allows you to log into your account without a password (automatic authentication based on your IP address and MAC address). This way you can avoid transmitting your unencrypted login information over the network. Once this feature has been activated in your account, use the "auto" user and an empty password to connect.
-
-</Concept>
-
-<Concept opened>
 
 ## Backup
 
 A backup is a copy of your data, stored in another location. In case of any hardware or software failure, you can restore your data from the backup. It is recommended to make backups regularly. Each Dedibox comes with 100 GB of free [Dedibackup](https://www.scaleway.com/en/dedibox/storage/) storage. You can upload your backups to this storage using the FTP protocol. A 750 GB Dedibackup is available as a further option.
 
-</Concept>
-
-<Concept opened>
-
 ## cPanel
 
 [cPanel](https://cpanel.net/) is an industrial leading hosting automation platform. It allows you to automate server management tasks and allows you to provision webhosting accounts to your users.
-
-</Concept>
-
-<Concept opened>
 
 ## Dedibackup
 
 A backup solution for your Dedibox. Dedibackup is based on Scaleway's Object Storage solution and provides FTP access to a secure backup space located in the DC5 datacenter. This allows you to store copies of your data for security purposes.
 
-</Concept>
-
-<Concept>
-
 ## Dedicated server
 
 A dedicated server is a physical computer hosted in a datacenter and connected to the internet. Each dedicated server is rented out to one single customer who has full access to the machine to install any software of their choice on it.
 
-</Concept>
-
-<Concept>
-
 ## Hostname
+
 A hostname is a name associated with a machine. On the Internet, hostnames are formed mostly of two parts, the local name of the computer, for example: `myserver` and the domain name, for example: `mywebsite.org`. The complete hostname of that machine would be `myserver.mywebsite.org`.
-
-</Concept>
-
-<Concept>
 
 ## IPMI
 
 IPMI or Intelligent Platform Management Interface (IPMI) provides a way to access a computer using a network connection. It is independent from the main computer and allows you to access a remote computer that is not responding or powered off. Another use case is the installation of a custom operating system by mounting an ISO file on a virtual optical device. The installation of the remote computer can be done over the network without need for physical access to the machine.
-
-</Concept>
-
-<Concept>
 
 ## OS Type
 
@@ -94,99 +55,50 @@ Scaleway Dedibox provides a wide range of operating systems which can be automat
 - Panel distributions: Distributions with a preinstalled management panel to administrate the Dedibox server from a web based control panel.
 - Desktop distributions: Distributions with a preinstalled graphical interface. Server administration can be done from a remote desktop tool.
 
-</Concept>
-
-<Concept>
-
 ## Partitioning
 
 The partition layout of your Dedibox server can be customized during the installation of the server. You can customize the RAID settings and the disk layout towards your applications needs.
-
-</Concept>
-
-<Concept>
 
 ## Proxmox
 
 Proxmox is an open-source virtualization distribution, based on Debian. It provides both KVM hypervisor, and LXC container based virtualization combined with an easy-to-use web interface to manage resources. Proxmox is available for automatic installation from the Dedibox console.
 
-</Concept>
-
-<Concept>
-
 ## Remote reboot
 
 This feature allows you to reboot your Dedibox server from the Dedibox console in case it does not respond any longer via the network. You can also use this feature to reboot your server into rescue mode for maintenance actions.
-
-</Concept>
-
-<Concept>
 
 ## Rescue mode
 
 Rescue mode is a small Linux distribution that is loaded during the system boot into the RAM of your Dedibox server. It allows you to get access to your system and your data in case your server is not reachable on the internet in normal mode. You can perform maintenance tasks on your system and fix broken configurations before rebooting your server back into normal mode.
 
-</Concept>
-
-<Concept>
-
 ## Secondary DNS
 
 When you run your own DNS server (for example BIND) on your Dedibox, you can use the Secondary DNS server to provide redundancy for your DNS infrastructure. You can allow the transfer of your domains' primary DNS zone to the secondary DNS server to automatically update it whenever the zonefile on the primary server changes.
-
-</Concept>
-
-<Concept>
 
 ## Server log files
 
 Your Dedibox server logs important events in log files located in the directory `/var/log` on Linux based operating systems. Reading these files is a crucial element in the analysis of any issue with your server. Windows provides a [series of tools](https://docs.microsoft.com/en-us/troubleshoot/windows-server/system-management-components/system-management-components-overview) to track the health state of your server.
 
-</Concept>
-
-<Concept>
-
 ## Statistics
 
 The statistics page in the Dedibox console provides detailed bandwidth usage information of your server for the internet interface, as well as for the RPN interface (if available on the server). The measurement of your bandwith consumption is done at the network switch of your server's rack.
-
-</Concept>
-
-<Concept>
 
 ## Suchard server
 
 The offers START-2-XS, START-2-S, and START-2-M use a mainboard developed in-house by Scaleway's R&D teams called *Suchard*. This mainboard is fully compatible with all Linux distributions. However to be able to run Windows on this type of motherboard, it is required to deploy a XEN Hypervisor and run Windows inside a virtual machine. The hypervisor reserves 1 GB of RAM, so the amount of available RAM in Windows will display as the servers total RAM - 1 GB. These offers also exists in a configuration using the Motherboard Dell DSS5100 which is able to run Windows natively.
 
-</Concept>
-
-<Concept>
-
 ## User login
 
 During the installation of your server a user account is created. The user account is a regular user account with `sudo` rights ob Ubuntu Linux.
-
-</Concept>
-
-<Concept>
 
 ## User password
 
 The password associated with the user login. You can set the user password during the installation of your Dedibox server. For security reasons it is recommended to choose a temporary password for the installation and to change it once the server has been installed.
 
-</Concept>
-
-<Concept>
-
 ## VMware vSphere Hypervisor (ESXi)
 
 A virtualization solution developed by VMware. It is a _type-1_ hypervisor, meaning that ESXi is not a software application that is installed on the servers' operating system. It includes and integrates important OS components, such as a proprietary kernel.
 
-</Concept>
-
-<Concept>
-
 ## Windows PE rescue mode
-The Windows PE or Windows Preinstallation Environment rescue mode is a minimal Windows operating system. It is used to prepare a computer for Windows installation, but also to copy disk images from a network file server, launch a Windows installation, or - to have minimal access to fix an error on the servers operating system configuration.
 
-</Concept>
+The Windows PE or Windows Preinstallation Environment rescue mode is a minimal Windows operating system. It is used to prepare a computer for Windows installation, but also to copy disk images from a network file server, launch a Windows installation, or - to have minimal access to fix an error on the servers operating system configuration.

--- a/dedibox/hardware/concepts.mdx
+++ b/dedibox/hardware/concepts.mdx
@@ -10,41 +10,21 @@ categories:
   - dedibox-servers
 ---
 
-
-
-<Concept opened>
-
 ## CPU
 
 A Central Processing Unit (CPU) is the computers main processor. The CPU executes instructions comprising a computer program. The choice for a specific CPU is depending on your products computing requirements. 
-
-</Concept>
-
-<Concept opened>
 
 ## HDD
 
 A Hard disk drive (HDD) utilses rotating magnetic disks to store data. HDD provide large storage capactity but slower read/write speed in comparision with SSDs. They are perfect for storing large volumes of data. 
 
-</Concept>
-
-<Concept opened>
-
 ## NVMe
 
 NVM Express (NVMe) disks are SSDs that are using the PCI Express bus for communication with the host. 
 
-</Concept>
-
-<Concept opened>
-
 ## SSD
 
 A Solid state disk (SSD) uses flash memory to store your data. As there are no rotating parts, they provide faster read/write speed than HDDs. 
-
-</Concept>
-
-<Concept>
 
 ## RAID
 
@@ -52,29 +32,15 @@ RAID is a data storage technology used for the purpose of data redundancy, perfo
 
 The different RAID schemes are referenced as levels and are named by the word RAID itself, followed by a number (For example [RAID 0](#raid-0), [RAID 1](#raid-1) or [RAID 5](#raid-5)). Depending on the RAID level, data is distributed and stored across the disks in one or several ways.
 
-</Concept>
-
-<Concept>
-
 ## RAID 0
 
 RAID 0 uses [data striping](https://en.wikipedia.org/wiki/Data_striping). This increases the storage capacity of the virtual disk to the sum of all available disks in the RAID. The write and read performances of the machine are increased in RAID 0 to concurrent read and write operations. There is zero fault tolerance in RAID 0, as the contents of each file are distributed among all disks in the set, the failure of any single disk in the RAID array causes the entire RAID 0 volume to break down.
 The minimum number of disks in a RAID 0 set is two.
 
-</Concept>
-
-<Concept>
-
 ## RAID 1
 
 RAID 1 uses [disk mirroring](https://en.wikipedia.org/wiki/Disk_mirroring), this means data is written identically to any of the two disks in the set. File requests are broadcasted to any drive in the array and can be served by the drive that accesses the data at first, improving read performances. Write performance can be slower than using a single drive, as any write request has to be sent to all drives in the set, limiting the write performances to the speed of the slowest disk. A fault tolerance is provided using this RAID level, as data can be restored from the second disk in case one disk fails. The minimum number of disks available in a RAID 1 set is two and the number can be increased in odd pairs (For example: 2, 4, 6, …)
 
-</Concept>
-
-<Concept>
-
 ## RAID 5
 
 RAID 5 uses block-level [data striping](https://en.wikipedia.org/wiki/Data_striping) with distributed [parity](https://en.wikipedia.org/wiki/Parity_drive). This means parity information is distributed among all available drives, resulting in a fault tolerance where all drives but one need to be present to operate. In case a single drive fails, subsequent reads can be calculated from the distributed parity available on the other drives, so that no data is lost. This RAID level requires a minimum of three disks in the set and the total available space of the virtual disk is the sum of all drives minus one.
-
-</Concept>

--- a/dedibox/kvm-over-ip/concepts.mdx
+++ b/dedibox/kvm-over-ip/concepts.mdx
@@ -10,32 +10,17 @@ categories:
   - dedibox-servers
 ---
 
-
-<Concept opened>
-
 ## KVM Over IP
 
 KVM Over IP is a hardware-based solution that enables remote access to the **k**eyboard, **v**ideo (screen) and **m**ouse ports of a physical server. A unit plugs into these ports, and transmits their signals to a connected user through a network. This allows access to the machine even if the installed OS is not working properly, and opens up possibilities for debugging and more.
-
-</Concept>
-
-<Concept opened>
 
 ## iDRAC
 
 The **I**ntegrated **D**ell **R**emote **A**ccess **C**ontroller is the hardware allowing KVM Over IP, as well as other management and monitoring features, for Dell servers.
 
-</Concept>
-
-<Concept opened>
-
 ## iLO card
 
 The **I**ntegrated **L**ights-**O**ut card is the hardware allowing KVM Over IP, as well as other management and monitoring features, for HP servers.
-
-</Concept>
-
-<Concept>
 
 ## ISO file
 
@@ -44,5 +29,3 @@ An ISO file, also called ISO image, is an archive file that contains an identica
   <Message type="tip">
     Scaleway provides a wide range of operating systems available for installation on Dedibox servers equipped with a KVM over IP device. You can find a list of all available images at [http://virtualmedia.online.net/](http://virtualmedia.online.net). For more information on how to install an operating system using the KVM device, refer to our [dedicated documentation](/dedibox/kvm-over-ip/quickstart/)
   </Message>
-
-</Concept>

--- a/identity-and-access-management/iam/concepts.mdx
+++ b/identity-and-access-management/iam/concepts.mdx
@@ -12,25 +12,15 @@ tags: advanced settings owner iam principal
 
 The diagram above shows how different IAM concepts mentioned on this page interact with one another.
 
-<Concept opened>
-
 ## Account
 
 A user account refers to a human who owns a Scaleway account. Your account bears your personal information and authentication methods required to access the [Scaleway console](https://console.scaleway.com/). When you create your Scaleway account, an [Organization](#organization) is automatically created with you as the designated Owner.
-
-</Concept>
-
-<Concept opened>
 
 ## Application
 
 An application (also known as an IAM application) is a non-human user in an [Organization](#organization). IAM applications can be used when you want to create an API key that is not linked to a user, to give programmatic access to resources.
 
 Note that applications cannot, by definition, have access to the Scaleway console, as they have only an API key and no account themselves (they are not [accounts](#account)).
-
-</Concept>
-
-<Concept opened>
 
 ## API key
 
@@ -40,18 +30,9 @@ Previously, an API key was associated with a single Scaleway [Project](#project)
 
 With the introduction of IAM, an API key is now associated with an IAM [user](#user) or [application](#application). This allows fine-grained access to be defined for the IAM user bearing the API key across different Organizations, Projects, and resources.
 
-</Concept>
-
-
-<Concept>
-
 ## Group
 
 A group (also known as an IAM group) is a grouping of [users](#user) and/or [applications](#application). Creating groups allows you to attach [policies](#policy) to multiple users and/or applications at the same time.
-
-</Concept>
-
-<Concept>
 
 ## Guest
 
@@ -60,10 +41,6 @@ You are the [Owner](#owner) of the Organization that is created with your Scalew
 Similarly, you can invite other users to be Guests in your Organization. Whereas Owners have full rights and access to all resources and features in their Organization, Guests have only the rights and permissions given to them via [policies](#policy).
 
 <Lightbox src="scaleway-iam-owners-guests.webp" alt="" />
-
-</Concept>
-
-<Concept>
 
 ## IAM
 
@@ -75,10 +52,6 @@ Similarly, you may participate as a Guest in someone else's Organization, where 
 
 You can also create non-human users in your Organization, called [IAM applications](#application), in order to give applications programmatic access to your Scaleway resources.
 
-</Concept>
-
-<Concept>
-
 ## Organization
 
 An Organization is made of one or several [Projects](#project). When you create your Scaleway account, an Organization is automatically created, of which you are the Owner. When you create [IAM rules](#rule), you can set their scope at Organization level.
@@ -87,19 +60,11 @@ This means you can give access to features managed at Organization level, like b
 
 <Lightbox src="scaleway-iam-organization.webp" alt="" />
 
-</Concept>
-
-<Concept>
-
 ## Organization ID
 
 The Organization ID identifies the [Organization](#organization) created with your account. It can be found on your [Organization dashboard](https://console.scaleway.com/organization/settings), in the **Settings** tab.
 
 <Lightbox src="scaleway-iam-organization.webp" alt="" />
-
-</Concept>
-
-<Concept>
 
 ## Owner
 
@@ -107,17 +72,9 @@ You are the [Owner](#owner) of the Organization that is created with your Scalew
 
 <Lightbox src="scaleway-iam-owners-guests.webp" alt="" />
 
-</Concept>
-
-<Concept>
-
 ## Permission
 
 A permission is a granular right, which is checked to determine whether to give access to an API endpoint. Permissions are grouped into [permission sets](#permission-set) to facilitate access management within [policies](#policy).
-
-</Concept>
-
-<Concept>
 
 ## Permission set
 
@@ -127,10 +84,6 @@ Permission set names contain descriptions that clearly explain their purpose. Fo
 
 Permissions sets (e.g.`InstanceReadAccess`) and their [scope](#scope) (e.g. "on Project A only") make up IAM rules, which define the access rights that a [principal](#principal) (user, group, or application) should have.
 
-</Concept>
-
-<Concept>
-
 ## Policy
 
 Policies control user rights by defining one or more [rules](#rule) to apply to the attached [principals](#principal) (users, groups, or applications). A policy rule has two parts: [permission set](#permission-set) and [scope](#scope).
@@ -139,17 +92,9 @@ For each policy rule, you specify one or more permission sets (e.g. "list all In
 
 <Lightbox src="scaleway-iam-policy.webp" alt="" />
 
-</Concept>
-
-<Concept>
-
 ## Preferred Project
 
 You can carry out actions on Scaleway Object Storage resources either via the [Scaleway console](https://console.scaleway.com), or via a third-party API or CLI, such as [the AWS CLI](/storage/object/api-cli/object-storage-aws-cli/), [MinIOClient](/storage/object/api-cli/installing-minio-client/) or [Rclone](/storage/object/api-cli/installing-rclone/). While the Scaleway console gives you the option to specify the [Scaleway Project](#what-is-a-project) to carry out your Object Storage actions in, this option is not available via third-party API/CLI tools. These tools are based on a [standard S3 programming interface](https://en.wikipedia.org/wiki/Amazon_S3#S3_API_and_competing_services), which does not accept Project ID as a parameter. Therefore, when you create a Scaleway API key with IAM, you are prompted to specify the API key's **preferred Project for Object Storage**. This API key will always use this Project when carrying out Object Storage actions via any API/CLI. See our page on [using API keys with Object Storage](/identity-and-access-management/iam/api-cli/using-api-key-object-storage/) for more information.
-
-</Concept>
-
-<Concept>
 
 ## Principal
 
@@ -157,27 +102,15 @@ A principal is the target of a [policy](#policy). They acquire the rights and pe
 
 <Lightbox src="scaleway-iam-concepts.webp" alt="" />
 
-</Concept>
-
-<Concept>
-
 ## Project
 
 Projects are groupings of Scaleway [resources](#resource). Every Scaleway Organization has a default Project, and you can create new projects if necessary. By grouping resources into Projects, you can then define access differently for each Project.
 
 For example, if IAM users within your [Organization](#organization) are working on building two different systems with Scaleway resources, you can group the resources for each system into different Projects. This then allows you to restrict [IAM users'](#user) access to only the Project they are working on. It also facilitates the separation of billing between Projects.
 
-</Concept>
-
-<Concept>
-
 ## Resource
 
 A Scaleway resource is either a product or a feature in the Scaleway Ecosystem. Examples of resources include Instances, Private Networks, Kubernetes Kapsule and Flexible IPs, to name a few.
-
-</Concept>
-
-<Concept>
 
 ## Rule
 
@@ -198,18 +131,9 @@ SCOPE
 PERMISSION SET
 : InstancesFullAccess, ObjectStorageReadOnly, DatabasesFullAccess
 
-
-</Concept>
-
-<Concept>
-
 ## Scope
 
 A scope defines where [permission sets](#permission-set) should apply within a [policy](#policy). At Scaleway, a scope can be at [Project](#project) or [Organization](#organization) level.
-
-</Concept>
-
-<Concept>
 
 ## Tags
 
@@ -222,10 +146,6 @@ Keep in mind that:
   - The same tag cannot be used twice
 </Message>
 
-</Concept>
-
-<Concept>
-
 ## User
 
 A user (also known as an IAM user) is a human user in an Organization. They can be of two types:
@@ -235,5 +155,3 @@ A user (also known as an IAM user) is a human user in an Organization. They can 
 Within each Organization, different IAM users can have different rights (defined through [policies](#policy)) to perform actions on resources.
 
 <Lightbox src="scaleway-iam-owners-guests.webp" alt="" />
-
-</Concept>

--- a/identity-and-access-management/secret-manager/concepts.mdx
+++ b/identity-and-access-management/secret-manager/concepts.mdx
@@ -8,16 +8,9 @@ content:
 tags: secret-manager secret version
 ---
 
-
-<Concept>
-
 ## Folder
 
 Folders are the underlying structure for organizing and grouping your secrets in one place. Folders are always within a [path](#path).
-
-</Concept>
-
-<Concept>
 
 ## Path
 
@@ -30,17 +23,9 @@ For example, if you create a folder `my-folder` within the path `/my-path`, your
   - If you leave the path name field empty when creating your folders or secrets, the default path will be `/`. Your folders and secrets will be stored under the `/` path.
 </Message>
 
-</Concept>
-
-<Concept>
-
 ## PEM
 
 A PEM or **Privacy Enhanced Mail** file is a security certificate file used to establish a secure communication channel between a web server and a browser. It is encoded in Base64 and may contain a private key, a server certificate and/or a combination of other certificates.
-
-</Concept>
-
-<Concept>
 
 ## Region
 
@@ -48,17 +33,9 @@ A region is the geographical area in which your folders, secrets, and versions a
 
 Secret Manager allows you to select your resources by region. This allows you to better sort through your resources, if you have created them in different regions but with the same name, for example.
 
-</Concept>
-
-<Concept opened>
-
 ## Secret
 
 Secrets are logical containers made up of zero or more immutable versions, that hold sensitive data.
-
-</Concept>
-
-<Concept opened>
 
 ## Secret Manager
 
@@ -70,29 +47,15 @@ Scaleway's Secret Manager can be managed using [APIs](https://www.scaleway.com/e
 
 <Lightbox src="scaleway-secret-manager-schema.webp" alt="" />
 
-</Concept>
-
-<Concept>
-
 ## Secret protection
 
 Secret protection is a feature that prevents the deletion of your secrets.  Users holding the `SecretManagerFullAccess`, `SecretManagerSecretWrite`, and `AllProductsFullAccess` [permission sets](/identity-and-access-management/iam/reference-content/permission-sets/) can enable it, ensuring that although your secrets can be accessed and modified, they remain **impossible to delete**.
 This ensures the protection of critical information against accidental deletion while maintaining secret management flexibility.
 
-</Concept>
-
-<Concept>
-
 ## Tag
 
 Tags allow you to organize your secrets. This gives you the possibility of sorting and filtering your secrets in any organizational pattern of your choice, which in turn helps you arrange, control and monitor your secrets.
 
-</Concept>
-
-<Concept>
-
 ## Version
 
 Versions store the data contained in your secret (API keys, passwords, or certificates).
-
-</Concept>

--- a/labs/ipfs-naming/concepts.mdx
+++ b/labs/ipfs-naming/concepts.mdx
@@ -12,51 +12,26 @@ categories:
   - ipfs-naming
 ---
 
-<Concept opened>
-
 ## Content-based addressing
 
 Data over IPFS is identified by its content, not by its location (like HTTP does), providing a new way to access data through a unique content identifier (CID). Consequently, data is immutable and verifiable, allowing any device to be involved in the network, enhancing the redundancy.
-
-</Concept>
-
-<Concept opened>
 
 ## Content Identifier (CID)
 
 The content identifier is a string of character that points to a content. The content can be available on the network, or not. The CID is composed of the cryptographic hash of the content. It is used to identify and fetch the content through the network.
 
-</Concept>
-
-<Concept opened>
-
 ## Distributed Hash Table (DHT)
 
 A distributed hash table (DHT) is a distributed system for mapping keys to values. In the context of the IPFS naming service, this is the association of a key (public hash key) with a record (value register in the IPFS naming service).
-
-</Concept>
-
-<Concept opened>
 
 ## InterPlanetary File System (IPFS)
 
 IPFS is a peer-to-peer protocol, made by [Protocol Labs](https://protocol.ai/), for decentralized storage and content sharing.
 
-</Concept>
-
-
-<Concept>
-
 ## IPNS Name
 
 The IPNS name corresponds to the cryptographic hash of your public key. It is linked to a value or record denoted by either `/ipfs/cid` or `/ipns/key`. Each name has a constant lifespan and is subject to regular updates by the service. Additionally, the record can be modified by the holder of the private key, ensuring continuous verifiability.
 
-</Concept>
-
-<Concept>
-
 ## Peer-to-peer (P2P)
 
 Architecture that partitions tasks or workloads between peers. Peers are equally privileged participants in the network. They form a peer-to-peer network of nodes.
-
-</Concept>

--- a/labs/ipfs-pinning/concepts.mdx
+++ b/labs/ipfs-pinning/concepts.mdx
@@ -14,50 +14,26 @@ categories:
   - ipfs-pinning
 ---
 
-<Concept opened>
-
 ## InterPlanetary File System (IPFS)
 
 IPFS is a peer-to-peer protocol, made by [Protocol Labs](https://protocol.ai/), for decentralized storage and content sharing.
-
-</Concept>
-
-<Concept opened>
 
 ## Peer-to-peer (P2P)
 
 Architecture that partitions tasks or workloads between peers. Peers are equally privileged participants in the network. They form a peer-to-peer network of nodes.
 
-</Concept>
-
-<Concept opened>
-
 ## Content-based addressing
 
 Data over IPFS is identified by its content, not by its location (like HTTP does), providing a new way to access data through a unique content identifier (CID). Consequently, data is immutable and verifiable, allowing any device to be involved in the network, enhancing the redundancy.
-
-</Concept>
-
-<Concept opened>
 
 ## Content Identifier (CID)
 
 The content identifier is string of character that points to a content. The content can be available on the network, or not. The CID is composed from the cryptographic hash of the content. It is used to identify and fetch the content through the network.
 
-</Concept>
-
-<Concept opened>
-
 ## Pin
 
 A pin is a content that remains available in the IPFS network until it is unpinned.
 
-</Concept>
-
-<Concept opened>
-
 ## Volume
 
 A volume is an abstract storage area that can hold a set of pins, which can be done via URLs or CID.
-
-</Concept>

--- a/managed-databases/document-database/concepts.mdx
+++ b/managed-databases/document-database/concepts.mdx
@@ -10,57 +10,31 @@ categories:
   - managed-databases
 ---
 
-<Concept opened>
-
 ## Allowed IPs
 
 Access Control List (ACL) rules [define permissions for remote access to an Instance](/managed-databases/document-database/how-to/manage-allowed-ip-addresses/). A rule consists of an IP address or an IP range. You can use them to define which host and networks can connect to your Database Instance's endpoint. You can add, edit or delete rules from your ACLs. The initial setup of a Database Instance allows full network access from anywhere (`0.0.0.0/0`).
 
 Access control is handled directly at network level by Load Balancers, making the filtering more efficient, universal and relieving the Database Instance from this task.
 
-</Concept>
-
-<Concept opened>
-
 ## Advanced settings
 
 Database Instances have settings that allow you to tune the behavior of their database engine to better fit your needs. Available settings depend on the database engine and its version. Each Database Instance setting entry has a default value that the user can override. The deletion of a setting entry restores the setting to the entry's default value. Some of the default values can be different from the engine's default, as their configuration is optimized to work at full potential with the Scaleway ecosystem.
-
-</Concept>
-
-<Concept opened>
 
 ## Clone feature
 
 Allows you to create a full copy of your Database Instance (including users and permissions) at a point in time. This new Instance is fully independent of its parent.
 
-</Concept>
-
-<Concept opened>
-
 ## Database snapshot
 
 A [Snapshot](/managed-databases/document-database/how-to/manage-snapshots/) is a consistent, instantaneous copy of the Block Storage volume of your Database Instance at a certain point in time. They are designed to recover your data in case of failure or accidental alterations of the data by a user. They allow you to quickly create a new Instance from a previous state of your database, regardless of the size of the volume. Snapshots can only be stored in the same location as the original data.
-
-</Concept>
-
-<Concept>
 
 ## Endpoint
 
 A point of connection to a database. The endpoint is associated with an IPv4 address and a port, and determines whether the endpoint is read-write or not.
 
-</Concept>
-
-<Concept>
-
 ## Engine
 
 A database engine is the software component that stores and retrieves your data from a database. Currently, FerretDB 1.2.0 is available. It runs on PostgreSQL 14.8. Users do not have direct access to the PostgreSQL layer when using FerretDB.
-
-</Concept>
-
-<Concept>
 
 ## High availability
 
@@ -76,52 +50,26 @@ The HA standby node is linked to the main node, using synchronous replication. S
   HA standby nodes are not accessible to users unless the main node becomes unavailable and the standby takes over. If you wish to run queries on a read-only node, you can use [Read Replicas](/managed-databases/document-database/how-to/create-read-replica).
 </Message>
 
-</Concept>
-
-<Concept>
-
 ## Database Instance
 
 A Database Instance is made up of multiple (at least 1) dedicated compute nodes, and is running a single Database Engine. Exactly one database engine is running on each node.
-
-</Concept>
-
-<Concept>
 
 ## Logs
 
 Logs can contain useful information for debugging or to know more about the behavior and activity of your databases.
 
-</Concept>
-
-<Concept>
-
 ## Managed Database
 
 Compared to traditional database management, which requires customers to provision their infrastructure and resources to manage their databases, managed databases offer the user access to a Database Instance without setting up the hardware or configuring the software.
-
-</Concept>
-
-<Concept>
 
 ## Read Replica
 
 A Read Replica is a live copy of a Database Instance that behaves like an Instance, but that only allows read-only connections. The replica mirrors the data of the primary Database node and any changes made are synchronized and reflected in the replica.
 
-</Concept>
-
-<Concept>
-
 ## Region and Availability Zone
 
 <Macro id="region-and-az" />
 
-</Concept>
-
-<Concept>
-
 ## Document database
 
 Document databases enable users to store and retrieve data in a document format, such as json. Compared to traditional relational databases where data is stored in a table-like format, document-type storage supports storing multiple nested keys and values in each document key.
-
-</Concept>

--- a/managed-databases/postgresql-and-mysql/concepts.mdx
+++ b/managed-databases/postgresql-and-mysql/concepts.mdx
@@ -11,33 +11,19 @@ categories:
   - postgresql-and-mysql
 ---
 
-<Concept opened>
-
 ## Allowed IPs
 
 Access Control List (ACL) rules [define permissions for remote access to an Instance](/managed-databases/postgresql-and-mysql/how-to/manage-allowed-ip-addresses/). A rule consists of an IP address or an IP range. You can use them to define which host and networks can connect to your Database Instance's endpoint. You can add, edit, or delete rules from your ACLs. The initial setup of a Database Instance allows full network access from anywhere (`0.0.0.0/0`).
 
 Access control is handled directly at network-level by Load Balancers, making the filtering more efficient, universal and relieving the Database Instance from this task.
 
-</Concept>
-
-<Concept opened>
-
 ## Advanced settings
 
 Database Instances have settings that allow you to tune the behavior of their database engine to better fit your needs. Available settings depend on the database engine and its version. Each Database Instance setting entry has a default value that the user can override. The deletion of a setting entry restores the setting to the entry's default value. Some default values can be different from the engine's default, as their configuration is optimized to work at full potential with the Scaleway ecosystem.
 
-</Concept>
-
-<Concept opened>
-
 ## Basic Block Storage
 
 Basic Block Storage is a volume type that is decoupled from your compute resources. You can increase your storage space to up to 10 TB without changing your node type.
-
-</Concept>
-
-<Concept opened>
 
 ## Block Storage Low Latency
 
@@ -49,57 +35,29 @@ Refer to the [Block Storage Low Latency documentation section](/storage/block/co
   Block Low Latency volumes are only available with new-generation node types and in the PAR and AMS regions.
 </Message>
 
-</Concept>
-
-<Concept opened>
-
 ## Clone feature
 
 Clone is a feature that allows you to create a full copy of your Database Instance, including users and permissions, at a point in time. This new Instance is fully independent of its parent.
-
-</Concept>
-
-<Concept>
 
 ## Database backup
 
 A database backup is a complete dated export of a logical database stored on a backup backend. You can use the [Managed Databases API](https://www.scaleway.com/en/developers/api/managed-database-postgre-mysql/#path-backups-create-a-database-backup) to define if the backup should be stored in a region different from the database.
 
-</Concept>
-
-<Concept>
-
 ## Database Instance
 
 A Database Instance is a managed database service created upon a custom base image, that incorporates different features such as high-availability, data replication, and automatic backups. Scaleway deploys and manages the custom image, allowing you to focus on development rather than on the administration of your database infrastructure. Different PostgreSQL and MySQL engine versions are available for Database Instances.
-
-</Concept>
-
-<Concept>
 
 ## Database snapshot
 
 A [snapshot](/managed-databases/postgresql-and-mysql/how-to/manage-snapshots/) is a consistent, instantaneous copy of the Block Storage volume of your Database Instance at a certain point in time. They are designed to recover your data in case of failure or accidental alterations of the data by a user. They allow you to quickly create a new Instance from a previous state of your database, regardless of the size of the volume. Their limitation is that, unlike backups, snapshots can only be stored in the same location as the original data.
 
-</Concept>
-
-<Concept>
-
 ## Endpoint
 
 A point of connection to a database. The endpoint is associated with an IPv4 address and a port, and contains the information of whether the endpoint is read-write or not.
 
-</Concept>
-
-<Concept>
-
 ## Engine
 
 A database engine is the software component that stores and retrieves your data from a database. Currently, PostgreSQL versions 9.6, 10, 11, 12, 13, 14, and 15 are available. MySQL is available in version 8.
-
-</Concept>
-
-<Concept>
 
 ## High availability
 
@@ -115,10 +73,6 @@ The HA standby node is linked to the main node, using synchronous replication. S
   HA standby nodes are not accessible to users unless the main node becomes unavailable and the standby takes over. If you wish to run queries on a read-only node, you can use [Read Replicas](/managed-databases/postgresql-and-mysql/how-to/create-read-replica).
 </Message>
 
-</Concept>
-
-<Concept>
-
 ## Local storage
 
 With this type, your storage is fixed and tied to your compute resource.
@@ -127,49 +81,25 @@ With this type, your storage is fixed and tied to your compute resource.
   Local storage is only available with first-generation node types.
 </Message>
 
-</Concept>
-
-<Concept>
-
 ## Logs
 
 Logs can contain useful information for debugging or to know more about the behavior and activity of your databases.
-
-</Concept>
-
-<Concept>
 
 ## Managed Database
 
 Compared to traditional database management, which requires customers to provision their infrastructure and resources to manage their databases, managed databases offer the user access to a Database Instance without setting up the hardware or configuring the software.
 
-</Concept>
-
-<Concept>
-
 ## Read Replica
 
 A Read Replica is a live copy of a Database Instance that behaves like an Instance, but that only allows read-only connections. The replica mirrors the data of the primary Database node and any changes made are synchronized and reflected in the replica.
-
-</Concept>
-
-<Concept>
 
 ## Region and Availability Zone
 
 <Macro id="region-and-az" />
 
-</Concept>
-
-<Concept>
-
 ## Relational database
 
 A database type that uses the relational model, which means that it stores and provides access to interrelated data points within the same database. Relational databases provide an intuitive, straightforward way of representing data in tables.
-
-</Concept>
-
-<Concept>
 
 ## Volume type
 
@@ -180,5 +110,3 @@ This is the type of storage used on your Database Instances. Three types are ava
 </Message>
 
 You can select the volume type upon Database Instance creation, and you can [change the type](/managed-databases/postgresql-and-mysql/how-to/change-volume-type) anytime.
-
-</Concept>

--- a/managed-databases/redis/concepts.mdx
+++ b/managed-databases/redis/concepts.mdx
@@ -11,114 +11,58 @@ categories:
   - redis
 ---
 
-<Concept opened>
-
 ## Allowed IPs
 
 Access control list (ACL) rules [define permissions for remote access to a Database Instance](/managed-databases/postgresql-and-mysql/how-to/manage-allowed-ip-addresses/). A rule consists of an IP address or an IP range.
-
-</Concept>
-
-<Concept opened>
 
 ## Cluster
 
 A Redis™ cluster consists of a set of primary and secondary nodes. The cluster nodes use hash partitioning to split the keyspace into 16,384 key slots. Each primary of the cluster is responsible for a subset of those slots. Each secondary node replicates the data of one of the primary ones.
 
-</Concept>
-
-<Concept opened>
-
 ## Cluster mode
 
 Each Managed Database for Redis™ cluster consists of minimum three and maximum six compute Instances hosting each a primary Redis™ Instance and a secondary Instance for one of the other nodes. If one of the primary nodes fails, the remaining nodes hold a vote and elect one of the remaining secondary nodes as the new primary node. When the failing node rejoins the cluster, it automatically becomes a secondary node and begins to replicate the data of another primary node.
-
-</Concept>
-
-<Concept>
 
 ## Endpoint
 
 An endpoint is a point of connection to a database. The endpoint is associated with one or more public IPv4 addresses and a port, or with a private IPv4 and a port (if you use [Private Networks](/network/vpc/concepts/#private-networks)).
 
-</Concept>
-
-<Concept>
-
 ## Database Instance
 
 A Database Instance is made up of multiple (at least 1) dedicated compute nodes, and is running a single Database Engine. Exactly one database engine is running on each node.
-
-</Concept>
-
-<Concept>
 
 ## High availability
 
 High Availability is handled through the Redis™ clustering feature. This is a 3-node multi-master architecture. In case of downtime on a node in the cluster, a new node is able to take over the requests with minimal downtime.
 
-</Concept>
-
-<Concept>
-
 ## Horizontal scaling
 
 A feature that allows you to increase the size of your Redis™ Database Instance infrastructure by adding more nodes to your Database Instance to increase your number of endpoints and distribute cache.
-
-</Concept>
-
-<Concept>
 
 ## In-memory database
 
 A database management system primarily built upon memory. Data is managed and stored within the main memory of an Instance. This allows the optimization of request speed and the improvement of application performance.
 
-</Concept>
-
-<Concept>
-
 ## Managed Database
 
 Compared to traditional database management, which requires customers to provision their own infrastructure and resources to manage their databases, Managed Databases offer the user access to a Database Instance without them needing to set up the hardware or configure the software.
-
-</Concept>
-
-<Concept>
 
 ## Max memory
 
 A configuration directive used to set the maximum amount of memory Redis™ can use for a data set. You can set this value via the Scaleway console or by configuring the `available_settings` via API.
 
-</Concept>
-
-<Concept>
-
 ## Region and Availability Zone
 
 <Macro id="region-and-az" />
-
-</Concept>
-
-<Concept>
 
 ## TCP Keep alive
 
 A packet that is sent by a device when the [TCP](https://en.wikipedia.org/wiki/Transmission_Control_Protocol) connection on a routing device has been idle for too long. The packet is sent to the peer with only the Acknowledgement flag (ACK) turned on.
 
-</Concept>
-
-<Concept>
-
 ## TLS
 
 Transport Layer Security (TLS) is an internet security protocol that enables data to be securely exchanged over a network using in transit encryption.
 
-</Concept>
-
-<Concept>
-
 ## Vertical scaling
 
 Feature that allows you to increase the size of your Redis™ Database Instance by upgrading to a bigger node type to allow increased traffic for the same endpoint.
-
-</Concept>

--- a/managed-services/iot-hub/concepts.mdx
+++ b/managed-services/iot-hub/concepts.mdx
@@ -10,31 +10,17 @@ categories:
   - managed-services
 ---
 
-<Concept opened>
-
 ## Auto-provisioning
 
 Auto-provisioning allows your hub to automatically onboard an unknown device when that device provides valid TLS credentials.
-
-</Concept>
-
-<Concept opened>
 
 ## Client
 
 A client refers to any software connected to the IoT Hub. The software could be running on a connected device (firmware), an IoT Gateway or a server (application).
 
-</Concept>
-
-<Concept opened>
-
 ## Device
 
 A device is a representation of a [client](#client). Each device that connects to the hub is represented by a unique ID. The concept of devices allows the hub to authenticate clients and modify its behavior towards each one appropriately. This includes the way the client connects to the hub, the way messages are filtered and the way metrics are collected. See [Understanding Devices](/managed-services/iot-hub/reference-content/devices/) for more information.
-
-</Concept>
-
-<Concept>
 
 ## Device authentication
 
@@ -44,113 +30,57 @@ Device authentication ensures that only authorized devices can connect to a hub.
 - the client certificate fingerprint, matched to a [device certificate](#device-certificate)
 - the MQTT username, matched to a device ID (if the device is configured to allow insecure connections)
 
-</Concept>
-
-<Concept>
-
 ## Device certificate
 
 A device certificate is a method of client [authentication](#device-authentication). A customer can provide any certificate for a specific device. In this case, the certificate does not need to be signed by the hub Certificate Authority.
-
-</Concept>
-
-<Concept>
 
 ## Hub server certificate authority
 
 Upon connecting to an IoT Hub using [TLS](#TLS), MQTT clients will be provided with a hub server certificate. The client can verify this certificate using the hub server Certificate Authority.
 
-</Concept>
-
-<Concept>
-
 ## Hub certificate authority
 
 This is the Certificate Authority the hub will use to verify the certificate provided by a connecting client.
-
-</Concept>
-
-<Concept>
 
 ## Hub Events
 
 Hub Events may be understood as log entries for your hub. They are triggered by events such as errors, security notices and auto-provisioning events, and then published on the hub.
 
-</Concept>
-
-<Concept>
-
 ## Insecure connection
 
 A connection is deemed insecure if [mutual TLS](#mutual-tls-(mtls)) is not enabled for it. This implies authenticating with a token, which is weaker than using a certificate. Devices may be configured to **allow** or **deny** insecure connections. If allowed, **TLS** and **Plaintext** are available. **mTLS** is always available.
-
-</Concept>
-
-<Concept>
 
 ## Last Will Message
 
 When connecting, a client can provide a Last Will message to the Broker. This is a regular message which will be published by the Broker if the client disconnects unexpectedly. This mechanism allows clients to make sure other clients will be notified when they disconnect, whether properly or unexpectedly.
 
-</Concept>
-
-<Concept>
-
 ## Message
 
 Messages are the base data transmission unit for IoT Hub. A message contains a payload (which can be any data) and a topic (which can be any string, and indicates what is in the payload). The hub dispatches messages between connected clients.
-
-</Concept>
-
-<Concept>
 
 ## Message Broker
 
 IoT Hub is a message broker. It dispatches messages from publishers to subscribers (connected clients). With IoT Hub, subscribers receive a copy of published messages they are subscribed to. See [Understanding Hubs](/managed-services/iot-hub/reference-content/hubs/).
 
-</Concept>
-
-<Concept>
-
 ## Message Filter
 
 Message filters restrict the messages a device can publish or subscribe to. Each filter can be configured to allow or reject given topics.
-
-</Concept>
-
-<Concept>
 
 ## MQTT
 
 Message Queuing Telemetry Transport (MQTT) is a lightweight publish/subscribe protocol for exchanging messages between devices and/or applications. Find out more about MQTT [on our blog](https://www.scaleway.com/en/blog/introduction-to-mqtt-protocol/).
 
-</Concept>
-
-<Concept>
-
 ## Mutual TLS (mTLS)
 
 Mutual TLS is a method of mutual authentication. It indicates that both the TLS client and TLS server are required to authenticate each other. Each party must therefore possess a certificate to provide to the other, as well as a Certificate Authority to verify the certificate provided by the other party.
-
-</Concept>
-
-<Concept>
 
 ## Network
 
 Networks are the front doors to a Hub. Each Network supports a different protocol to exchange messages with the hub. See [Understanding Networks](/managed-services/iot-hub/reference-content/networks/) for more information.
 
-</Concept>
-
-<Concept>
-
 ## Publish/Subscribe
 
 The publish/subscribe model (also known as pub/sub) provides an alternative to traditional client-server architecture. In the client-sever model, a client communicates directly with the application supposed to receive the information. The pub/sub model decouples the client that sends a message (the publisher) from the client or clients that receive the messages (the subscribers). The publishers and subscribers never contact each other directly. In fact, they are not even aware that the other exists. MQTT is a publish/subscribe protocol.
-
-</Concept>
-
-<Concept>
 
 ## Quality of Service levels (QoS)
 
@@ -162,45 +92,22 @@ Quality of Service level determines the reliability of the data flow between a c
 
 Increasing the QoS level decreases message throughput because of the additional exchanges required between the client and the broker.
 
-</Concept>
-
-<Concept>
-
 ## Routes
 
 IoT Routes forward messages to non publish/subscribe destinations such as databases, REST APIs, Serverless functions and S3 buckets. See [Understanding Routes](/managed-services/iot-hub/reference-content/routes/) for further information.
-
-</Concept>
-
-<Concept>
 
 ## TLS
 
 **T**ransport **L**ayer **S**ecurity, and its now-deprecated predecessor, **S**ecure **S**ockets **L**ayer (SSL), are cryptographic protocols designed to provide communications security over a computer network. See also [Mutual TLS](#mutualtls-mtls).
 
-</Concept>
-
-<Concept>
-
 ## Topic
 
 A topic indicates what information is contained in a message. The message broker uses topics to forward published messages to the right subscribers. Learn more about topics [on our blog](https://www.scaleway.com/en/blog/scaleway-iot-hub-introduction-to-mqtt-topics/).
-
-</Concept>
-
-<Concept>
 
 ## Twins
 
 Cloud Twins, or simply Twins, are virtual representations of your physical devices. Technically, they are JSON document sets stored in a hub, recording data received from your hub (eg data from device sensors, date/time information, desired state information and any other relevant data you wish to store). Each device can have its corresponding Cloud Twin, which you can store and retrieve data to/from at any time. For more information, refer to [our documentation about Cloud Twins](/managed-services/iot-hub/reference-content/twins/).
 
-
-</Concept>
-
-<Concept>
-
 ## WebSocket
 
 WebSocket is a way for a browser to upgrade an HTTP connection into a somewhat "raw" TCP connection. By doing so, the HTTP server is now able to send data to the HTTP client without the client having to request it.
-
-</Concept>

--- a/managed-services/transactional-email/concepts.mdx
+++ b/managed-services/transactional-email/concepts.mdx
@@ -10,25 +10,18 @@ categories:
   - managed-services
 ---
 
-<Concept opened>
 ## Deliverability
 
 Deliverability is the ability for an email to arrive in a recipient’s email inbox.
-</Concept>
 
-<Concept opened>
 ## DKIM record
 
 A Domain Keys Identified Mail (DKIM) record is an email security standard. It provides you with an encryption key and a digital signature that allows you to verify whether an email was altered.
-</Concept>
 
-<Concept>
 ## DNS propagation
 
 DNS propagation is the time a DNS change takes to be updated across the internet.
-</Concept>
 
-<Concept>
 ## Flags
 
 Scaleway uses flags to provide you with more information about your emails. Flags can let you know whether an email you have sent is considered a spam, for example.
@@ -41,17 +34,13 @@ There are seven types of flags:
 - **Send before expiration**: This indicates that you have requested to send your email before a specific date (defined by you), and that your email expires after that date. This is useful if you are sending an email containing a password renewal link, for example.
 - **Soft bounce**: This means that a non-critical error occurred while sending your email. Soft bounced emails are retried. Find out more about [soft bounces](#soft-bounce).
 - **Spam**: This means that your email has been considered spam.
-</Concept>
 
-<Concept>
 ## Hard bounce
 
 Hard bounce occurs when an email is sent to an invalid email address or an address that does not exist. Unlike [soft bounce](#soft-bounce), which is a temporary error, hard bounce is a permanent error.
 
 In this case, most emailing solutions will blacklist these email addresses.
-</Concept>
 
-<Concept>
 ## IP warming
 
 IP warming is the process of gradually increasing the volume of emails sent through a new IP or an API that has not been used in a while.
@@ -60,56 +49,35 @@ The process of warming up an IP address consists of gradually sending emails fro
 
 Internet service providers are wary of emails sent from new IP addresses with no reputation, so warming up an IP allows for better email deliverability and thus, better reputation.
 
-</Concept>
-
-<Concept>
 ## IP reputation
 
 IP reputation measures the trustworthiness of an IP address and the amount of unwanted requests it sends. An IP address that sends authentic, spam-free emails, earns a good IP reputation. An IP address that sends high amounts of spam or viruses earns a bad IP reputation. IP reputation allows you to reject requests that are coming from an IP address with a bad reputation.
-</Concept>
 
-<Concept>
 ## MX record
 
 A mail exchanger (MX) record is a DNS record that is required to deliver emails to your address. An MX record indicates which mail servers accept incoming emails for your domain and where emails sent to your domain should be routed to.
 
 Scaleway provides its **own MX server** to improve email deliverability.
 However, Scaleway’s MX server is a **blackhole**. This means that **any email sent back to it, will be lost with no possibility of recovery**. If you have no MX server, we recommend you use Scaleway’s blackhole MX to avoid getting your emails rejected.
-</Concept>
 
-<Concept>
 ## Preheader
 
 A preheader is the summary text that appears after the subject line when viewing an email in your mailbox.
-</Concept>
 
-<Concept>
 ## Pristine spam trap
 
 Pristine spam traps are email addresses created by Internet Service Providers (ISPs) and other entities, such as blacklist organizations, email providers or security companies, to monitor and track spam activity. As these addresses have never actually been used, they lack any history or reputation, making them ideal for generating spam reports.
 
-
 Scaleway provides its own MX server to improve email deliverability. <br></br> However, Scaleway's MX server is a **blackhole**. This means that **any email sent back to it, will be lost with no possibility of recovery**. If you have no MX server, we recommend you use Scaleway's blackhole MX to avoid getting your emails rejected.
-
-</Concept>
-
-<Concept>
 
 ## Priority
 
 Each MX record has a priority, or a number to designate the order in which your domain's incoming mail servers receive your emails. The MX record with the lowest number is the first, or primary mail server to which outgoing mail servers attempt to deliver your emails.
 
-</Concept>
-
-<Concept>
-
 ## RBLs
 
 Realtime Blackhole Lists are directories containing lists of IP addresses, domain names, and mail servers known to actively host, produce, send and/or forward spam or spam sources. Your emails will automatically be considered spam if you send them from an IP address, a domain name, or a mail server known to RBLs.
 
-</Concept>
-
-<Concept>
 ## Recycled spam trap
 
 Recycled spam traps are old domain registrations or email addresses that were once valid, but are no longer used by a company or an individual.
@@ -118,9 +86,6 @@ Recycled spam traps are old domain registrations or email addresses that were on
   Repeatedly sending emails to these addresses will gradually harm your sending reputation. Make sure you clean your contact list often and that there are no spelling mistakes in the email addresses you are sending emails to.
 </Message>
 
-</Concept>
-
-<Concept>
 ## Reputation score
 
 A domain's **reputation score** is similar to a grade that email providers give to your domain's online reputation. The reputation score helps them decide whether the emails sent from your domain are trustworthy and should be delivered to your recipient's mailbox, or if your emails should be blocked, classified as spam and rejected. Email providers calculate your domain reputation on a scale of 0 to 100. 
@@ -131,22 +96,15 @@ The **closer to 100** your reputation score is, the more receiving email servers
 A domain's reputation score is determined by email providers and Internet Service Providers (ISPs), which means you have a different domain reputation for each email service provider.
 </Message>
 
-</Concept>
-
-<Concept>
 ## Send API
 
 A send API is the main API that is used to send transactional emails to recipients.
-</Concept>
 
-<Concept>
 ## SMTP relay
 
 An SMTP relay is a service or server that helps in the transmission of email messages from one email server to another. They act as a bridge between the sender's mail server and the recipient's mail server.
 SMTP relays are designed to handle large volumes of emails, ensuring that emails reach the recipient's server more efficiently and reliably, without being flagged as spam.
-</Concept>
 
-<Concept>
 ## Soft bounce
 
 Soft bounce occurs when your email has been sent to a valid email address, and has reached the recipient's mail server but your email could not be delivered for multiple reasons:
@@ -157,9 +115,6 @@ Soft bounce occurs when your email has been sent to a valid email address, and h
 
 When a soft bounce occurs, the email software will try to resend the email for 72 hours (maximum) until the message is finally delivered.
 
-</Concept>
-
-<Concept>
 ## Spam trap
 
 Spam traps are email addresses that Internet Service Providers (ISPs) and blocklist operators use to detect and blacklist spammers and senders who fail to adhere to email best practices. These email addresses may look like legitimate email addresses, but they are not operated by real users. 
@@ -173,17 +128,10 @@ Any contact that has not engaged by **opening** or **clicking a link sent within
   Make sure you regularly clean up you contact lists to avoid spam traps.
 </Message>
 
-</Concept>
-
-<Concept>
 ## SPF record
 
 An SPF record specifies the mail servers that are allowed to send email for your domain. It allows you to protect senders and recipients from spam and phishing attacks. SPF also prevents spammers from sending emails on behalf of your domain.
-</Concept>
 
-
-<Concept>
 ## Transactional Email
 
 Transactional Email is a platform that allows you to send transactional emails. Unlike marketing emails (which are mass distributions of the same marketing message to multiple recipients), transactional emails are personalized emails sent to individuals in response to events they have triggered (e.g. password recovery, billing information, delivery updates, etc).
-</Concept>

--- a/managed-services/webhosting/concepts.mdx
+++ b/managed-services/webhosting/concepts.mdx
@@ -10,24 +10,13 @@ categories:
   - managed-services
 ---
 
-
-<Concept opened>
-
 ## Alias
 
 An email alias is an additional email address for an email account, with which a user can send and receive emails, or set forwards to. A single user account can have multiple email aliases, with different domains or even with the same domain.
 
-</Concept>
-
-<Concept opened>
-
 ## cPanel
 
 cPanel is a web hosting control panel that simplifies the management of websites. It provides a user-friendly graphical interface, allowing users to perform tasks such as creating email accounts, managing files, and installing applications. cPanel is widely used by website owners to streamline the administration of their web hosting services.
-
-</Concept>
-
-<Concept opened>
 
 ## Dedicated IP
 
@@ -36,64 +25,34 @@ Dedicated IP is a paid option that allows you to have a unique IP, separate from
 Opting for a dedicated IP is ideal if you intend to send emails and protect your IP reputation. This ensures that you will not be affected by the negative reputation other clients sharing the same IP may have.
 Upon activation, we automatically assign your hosting a dedicated IP after verifying it is not blacklisted. Deactivating the option triggers a similar check. If the IP is clean, it will automatically be removed from your account. Otherwise, [contact our support team](https://console.scaleway.com/support/tickets) to address any issues.
 
-</Concept>
-
-<Concept>
-
 ## Email account
 
 An email account is an email address on which mail is stored (unlike an alias / catchall). You can check your email accounts via two protocols: POP3 and IMAP.
-
-</Concept>
-
-<Concept>
 
 ## FTP account
 
 FTP, or File Transfer Protocol, is a protocol that allows you to transfer files between different computers over the internet. It allows you, as part of your Web Hosting plan, to transfer your files from your computer to Scaleway.com - e.g. to update your website. It also works the other way around: you can recover the files stored on Scaleway.com and transfer them to your personal computer, e.g. to make a backup.
 
-</Concept>
-
-<Concept>
-
 ## Filtering
 
 Filtering allows you to sort your emails depending on different criteria (the sender, the subject, the object and much more). If the email meets one or more criteria you can define different actions (delete the email, move it into a folder, etc).
-
-</Concept>
-
-<Concept>
 
 ## htaccess
 
 `.htaccess` is a simple text file containing commands for the configuration of the Apache web server. It allows you to personalize the server dynamically and per folder. The configuration values are inherited through directories. Common applications for setting up a `.htaccess` file are switching between PHP4 and PHP5, protection of a part of the site, redirecting a website to another, or customizing error messages. Once on the server, its name must be `.htaccess`, starting with a dot.
 
-</Concept>
-
-<Concept>
-
 ## PHP
 
 PHP is a server-side scripting language designed for web development but also used as a general-purpose programming language. While PHP originally stood for Personal Home Page, it now stands for PHP: Hypertext Preprocessor, which is a recursive backronym. 
-
-</Concept>
-
-<Concept>
 
 ## php.ini
 
 The `php.ini` file is the configuration file used for applications that require PHP. It contains variable configurations such as upload size, file timeout, and resource limits. For Scaleway Web Hosting, we provide PHP with the most common values preconfigured. If required, you can [customize the configuration of PHP](/dedibox-console/classic-hosting/how-to/configure-php/) to suit your needs.
 
-</Concept>
-
-<Concept>
-
 ## Plesk
 
 Plesk serves as a web hosting control panel, similar to cPanel, aiming to simplify the management of websites. Its user-friendly interface facilitates tasks such as domain management, email configuration, and database administration. Plesk can easily be extended with additional features using the [Plesk Extension Catalog](https://www.plesk.com/extensions/).
 
-</Concept>
-<Concept>
 ## Web Hosting
 
 Web Hosting is a service provided by Scaleway which offers storage space and access for your websites. Our Web Hosting plans include:
@@ -104,5 +63,3 @@ Web Hosting is a service provided by Scaleway which offers storage space and acc
 - Unlimited subdomains
 - An FTP account to upload your website
 - At least one database
-
-</Concept>

--- a/network/domains-and-dns/concepts.mdx
+++ b/network/domains-and-dns/concepts.mdx
@@ -26,136 +26,94 @@ A DNS name server stores the [DNS Records](#dns-record) for given domains. Scale
 
 <Lightbox src="scaleway-dns-nameserver.webp" alt="" />
 
-<Concept opened>
-  ## Domain name
+## Domain name
 
-  A **domain name** or **domain** is a unique alphanumeric name used to identify a computer (web or email server) on the internet. It translates the numeric address of the computer to a more legible human-readable and memorable name. A domain can consist of a single [DNS Zone](#dns-zone) or be divided into several zones.
-</Concept>
+A **domain name** or **domain** is a unique alphanumeric name used to identify a computer (web or email server) on the internet. It translates the numeric address of the computer to a more legible human-readable and memorable name. A domain can consist of a single [DNS Zone](#dns-zone) or be divided into several zones.
 
-<Concept opened>
-  ## Domain name resolution
+## Domain name resolution
 
- Domain name resolution refers to the process by which human-readable domain names, like `www.mydomain.com`, are translated into the numerical IP addresses that computers and servers use to communicate on the internet.
-</Concept>
+Domain name resolution refers to the process by which human-readable domain names, like `www.mydomain.com`, are translated into the numerical IP addresses that computers and servers use to communicate on the internet.
 
-<Concept opened>
-  ## DNS
+## DNS
 
-  The **D**omain **N**ame **S**ystem is a name management system for computing devices connected to a network, be it public (Internet) or private. It translates text-based [domain names](#domain-name) to numerical IP addresses or other services such as emails.
-</Concept>
+The **D**omain **N**ame **S**ystem is a name management system for computing devices connected to a network, be it public (Internet) or private. It translates text-based [domain names](#domain-name) to numerical IP addresses or other services such as emails.
 
-<Concept opened>
-  ## DNS record
+## DNS record
 
-  A [DNS](#dns) Record holds information translating a domain or subdomain to an IP address, mail server or other domain/subdomain. DNS records for each [DNS Zone](#dns-zone) are stored within files called [DNS zone files](#dns-zone-file). These are hosted on [DNS nameservers](#dns-name-server). DNS records act as instructions for the DNS servers, so they know which domain names and IP addresses are associated with each other. DNS records can be of multiple types, called [resource records](#resource-records). Check out our documentation on [how to manage DNS records](/network/domains-and-dns/how-to/manage-dns-records/).
-</Concept>
+A [DNS](#dns) Record holds information translating a domain or subdomain to an IP address, mail server or other domain/subdomain. DNS records for each [DNS Zone](#dns-zone) are stored within files called [DNS zone files](#dns-zone-file). These are hosted on [DNS nameservers](#dns-name-server). DNS records act as instructions for the DNS servers, so they know which domain names and IP addresses are associated with each other. DNS records can be of multiple types, called [resource records](#resource-records). Check out our documentation on [how to manage DNS records](/network/domains-and-dns/how-to/manage-dns-records/).
 
-<Concept>
-  ## DNS zone
+## DNS zone
 
-  A DNS zone hosts the DNS records for a distinct part of the global domain namespace, and is managed by a specific organization or administrator. For example with Scaleway Domains and DNS, if you are managing the external domain `example.com` with us, this is your root zone. You can [create further zones and subdomains](/network/domains-and-dns/how-to/configure-dns-zones/), e.g. `mysubdomain.example.com`.
-</Concept>
+A DNS zone hosts the DNS records for a distinct part of the global domain namespace, and is managed by a specific organization or administrator. For example with Scaleway Domains and DNS, if you are managing the external domain `example.com` with us, this is your root zone. You can [create further zones and subdomains](/network/domains-and-dns/how-to/configure-dns-zones/), e.g. `mysubdomain.example.com`.
 
-<Concept>
-  ## DNS zone file
+## DNS zone file
 
-  A DNS zone file describes a [DNS Zone](#dns-zone), containing DNS records which constitute mappings between domain names, IP addresses and other resources.
-</Concept>
+A DNS zone file describes a [DNS Zone](#dns-zone), containing DNS records which constitute mappings between domain names, IP addresses and other resources.
 
-<Concept>
-  ## External domain
+## External domain
 
-  An external domain is any domain created via an external registrar (i.e. not Scaleway). You can manage DNS zones for external domains from the Scaleway console.
-</Concept>
+An external domain is any domain created via an external registrar (i.e. not Scaleway). You can manage DNS zones for external domains from the Scaleway console.
 
-<Concept opened>
-  ## Fully qualified domain name (FQDN)
+## Fully qualified domain name (FQDN)
 
-  A fully qualified domain name, also known as **absolute domain**, is a complete domain name that allows computers and servers connected to the internet to have unique identities and a location within the internet framework.
-  A FQDN consists of a [hostname](#hostname), a [subdomain](#subdomain), a domain name comprised of a [second-level-domain](#second-level-domain) and a [top-level domain (TLD)](#top-level-domain-(tld)), and a **trailing dot**. The trailing dot is used to differentiate fully qualified domain names from [partially qualified domain names](#partially-qualified-domain-name-(pqdn)) within DNS.
+A fully qualified domain name, also known as **absolute domain**, is a complete domain name that allows computers and servers connected to the internet to have unique identities and a location within the internet framework.
 
-   <Lightbox src="scaleway-fqdn.webp" alt="" />
+A FQDN consists of a [hostname](#hostname), a [subdomain](#subdomain), a domain name comprised of a [second-level-domain](#second-level-domain) and a [top-level domain (TLD)](#top-level-domain-(tld)), and a **trailing dot**. The trailing dot is used to differentiate fully qualified domain names from [partially qualified domain names](#partially-qualified-domain-name-(pqdn)) within DNS.
 
-</Concept>
+<Lightbox src="scaleway-fqdn.webp" alt="" />
 
-<Concept>
-  ## Hostname
- When looking at a [fully qualified domain name](#fully-qualified-domain-name-(fqdn)), the hostname usually comes before the domain name or the subdomain. A hostname is a label or name assigned to a computer, device, or server on a network. It helps identify and locate a specific computer or any device connected to a network among all the others.
- An example of a hostname can be `www` for the fully qualified domain name `www.mydomain.com.`.
+## Hostname
+ 
+When looking at a [fully qualified domain name](#fully-qualified-domain-name-(fqdn)), the hostname usually comes before the domain name or the subdomain. A hostname is a label or name assigned to a computer, device, or server on a network. It helps identify and locate a specific computer or any device connected to a network among all the others.
 
-</Concept>
+An example of a hostname can be `www` for the fully qualified domain name `www.mydomain.com.`.
 
-<Concept>
-  ## Internal domain
+## Internal domain
 
-  An internal domain is any domain name registered through Scaleway Domains and DNS. Register and (auto-)renew your domains with Domains and DNS and manage them from the Scaleway console.
-</Concept>
+An internal domain is any domain name registered through Scaleway Domains and DNS. Register and (auto-)renew your domains with Domains and DNS and manage them from the Scaleway console.
 
-<Concept>
-  ## Partially qualified domain name (PQDN)
+## Partially qualified domain name (PQDN)
 
-  A partially qualified domain name or **relative domain name** is an incomplete domain name. It lacks the [top-level domain (TLD)](#top-level-domain-(tld)) and potentially even the subdomain part of the domain name.
+A partially qualified domain name or **relative domain name** is an incomplete domain name. It lacks the [top-level domain (TLD)](#top-level-domain-(tld)) and potentially even the subdomain part of the domain name.
 
-</Concept>
+## Resource records
 
-<Concept>
-  ## Resource records
+Information in [DNS zones](#dns-zone) is categorized and organized through a list of [DNS record](#dns-record) types, called Resource Records (RRs). Each of these records has a type, an expiration time (Time to Live - TTL), a name, and type-specific data for certain types of records.
 
-  Information in [DNS zones](#dns-zone) is categorized and organized through a list of [DNS record](#dns-record) types, called Resource Records (RRs). Each of these records has a type, an expiration time (Time to Live - TTL), a name, and type-specific data for certain types of records.
+The most common records are:
 
-  The most common records are:
+* **A record**: Address record, mostly used to map domain names to the IPv4 address of a specific server.
+* **AAAA record**: IPv6 Address record, returns an IPv6 address and is mostly used to map domain names to the IPv6 address of a specific server.
+* **CNAME record**: Canonical name record, an alias of one name to another. The DNS lookup will continue by looking up the new name.
+* **MX record**: Mail exchange record, maps a domain name to a list of one or several mail servers for that domain.
+* **TXT record**: Text record, often used to carry machine-readable data such as information for automated domain validation.
 
-  * **A record**: Address record, mostly used to map domain names to the IPv4 address of a specific server.
-  * **AAAA record**: IPv6 Address record, returns an IPv6 address and is mostly used to map domain names to the IPv6 address of a specific server.
-  * **CNAME record**: Canonical name record, an alias of one name to another. The DNS lookup will continue by looking up the new name.
-  * **MX record**: Mail exchange record, maps a domain name to a list of one or several mail servers for that domain.
-  * **TXT record**: Text record, often used to carry machine-readable data such as information for automated domain validation.
-</Concept>
+## Reverse DNS
 
-<Concept>
-  ## Reverse DNS
+Reverse DNS (rDNS) allows you to resolve from an IP address to a Fully Qualified Domain Name (FQDN). A FQDN consists of a complete address for a website, computer, server or similar entity that exists on the internet. Reverse DNS is the exact opposite of the classic use of DNS, which associates domain names to IP addresses. Here, it operates by creating a reverse DNS zone in which DNS PTR records (for Pointer Record) will be configured.
 
-  Reverse DNS (rDNS) allows you to resolve from an IP address to a Fully Qualified Domain Name (FQDN). A FQDN consists of a complete address for a website, computer, server or similar entity that exists on the internet. Reverse DNS is the exact opposite of the classic use of DNS, which associates domain names to IP addresses. Here, it operates by creating a reverse DNS zone in which DNS PTR records (for Pointer Record) will be configured.
-  Reverse DNS can be helpful when sending emails from your server. Indeed, many mail servers on the internet are configured to reject incoming mail from any IP address that does not have reverse DNS. For those who manage their own mail server, reverse DNS must exist for the IP address from which the outgoing email is sent.
-</Concept>
+Reverse DNS can be helpful when sending emails from your server. Indeed, many mail servers on the internet are configured to reject incoming mail from any IP address that does not have reverse DNS. For those who manage their own mail server, reverse DNS must exist for the IP address from which the outgoing email is sent.
 
+## Root server
 
-<Concept>
-  ## Root server
+Root Servers are a type of DNS name servers pertaining to [top-level domains](#top-level-domain-(tld)). They are the first step in the resolution of any domain name, since they contain information about the authoritative DNS servers for each top-level domain.
 
-  Root Servers are a type of DNS name servers pertaining to [top-level domains](#top-level-domain-(tld)). They are the first step in the resolution of any domain name, since they contain information about the authoritative DNS servers for each top-level domain.
-</Concept>
+## Scaleway Domains and DNS
 
-<Concept>
-  ## Scaleway Domains and DNS
+Scaleway Domains and DNS is a managed [DNS](#dns) service that allows you to easily configure the [DNS zones](#dns-zone) of your [domains](#domain-name). It provides support for queries via both IPv4 and IPv6, and supports all common types of [DNS records](#dns-record).
 
-  Scaleway Domains and DNS is a managed [DNS](#dns) service that allows you to easily configure the [DNS zones](#dns-zone) of your [domains](#domain-name). It provides support for queries via both IPv4 and IPv6, and supports all common types of [DNS records](#dns-record).
-</Concept>
+## Second-level domain
 
-<Concept>
-  ## Second-level domain
+A second-level domain is the part of a domain name that is located directly to the left of the [top-level domain](#top-level-domain-(tld)). For example, in the domain name `mydomain.com`, **mydomain** is the second-level domain.
 
- A second-level domain is the part of a domain name that is located directly to the left of the [top-level domain](#top-level-domain-(tld)). For example, in the domain name `mydomain.com`, **mydomain** is the second-level domain.
+## SSL/TLS certificates
 
-</Concept>
+SSL/TLS certificates are cryptographic protocols that provide secure communication over the internet. They ensure that the data transmitted between a user's browser and a website's server is encrypted and protected from unauthorized access, interception, or tampering.
 
-<Concept>
- ## SSL/TLS certificates
-
- SSL/TLS certificates are cryptographic protocols that provide secure communication over the internet. They ensure that the data transmitted between a user's browser and a website's server is encrypted and protected from unauthorized access, interception, or tampering.
-
-</Concept>
-
-<Concept>
-  ## Subdomain
+## Subdomain
   
- A subdomain is an additional piece of information added to your domain name to create separate sections or categories within your website. Subdomains help organize content and services, making it easier for users to access specific information. For example, in the domain name `blog.mydomain.com`, **blog** is the subdomain. Your users accessing `blog.mydomain.com` will thus, be directed to the blog part of your website.
+A subdomain is an additional piece of information added to your domain name to create separate sections or categories within your website. Subdomains help organize content and services, making it easier for users to access specific information. For example, in the domain name `blog.mydomain.com`, **blog** is the subdomain. Your users accessing `blog.mydomain.com` will thus, be directed to the blog part of your website.
 
-</Concept>
+## Top-level domain (TLD)
 
-<Concept>
-  ## Top-level domain (TLD)
-
-  In the [DNS](#dns) hierarchy, a top-level domain is the last part of text in a domain name. For instance, in the domain name `mydomain.com`, **.com** is the top-level domain.
-
-</Concept>
+In the [DNS](#dns) hierarchy, a top-level domain is the last part of text in a domain name. For instance, in the domain name `mydomain.com`, **.com** is the top-level domain.

--- a/network/domains-and-dns/reference-content/understanding-domains-and-dns.mdx
+++ b/network/domains-and-dns/reference-content/understanding-domains-and-dns.mdx
@@ -23,8 +23,6 @@ Domains are further divided into subdomains, that become DNS zones with their ow
 
 The term domain is used in the business functions of the entity assigned to it and the term zone is usually used for configuration of DNS services.
 
-<Concept opened>
-
 ## Example
 
 `domain_example.com` is the `domain` and has only one owner who can manage it.
@@ -52,8 +50,6 @@ example.com
 ├── dev
     └── www           # www.dev.example.com
 ```
-
-</Concept>
 
 ## Advantages of subdomains and multiple zones
 

--- a/network/load-balancer/concepts.mdx
+++ b/network/load-balancer/concepts.mdx
@@ -10,17 +10,11 @@ categories:
   - networks
 ---
 
-<Concept opened>
-
 ## ACL
 
 <Macro id="acls" />
 
  Learn how to use the ACL feature in our [dedicated how-to](/network/load-balancer/how-to/create-manage-acls) and go deeper with our [reference documentation](/network/load-balancer/reference-content/acls)
-
-</Concept>
-
-<Concept opened>
 
 ## Accessibility
 
@@ -31,33 +25,17 @@ When creating a Load Balancer, you are prompted to configure its **accessibility
 
 Accessibility cannot be modified after creation of the Load Balancer.
 
-</Concept>
-
-<Concept opened>
-
 ## Backends
 
 Each Load Balancer is configured with one or several backends. A backend represents a set of [backend servers](#backend-servers) that the Load Balancer's frontend forwards requests to using the specified configuration (port, protocol, proxy protocol etc.). Grouping backend servers into a backend allows load to be balanced between them based on a defined load-balancing algorithm configured as a backend setting. You can [add and manage backends via the console](/network/load-balancer/how-to/manage-frontends-and-backends/).
-
-</Concept>
-
-<Concept>
 
 ## Backend servers
 
 The term "backend server" designates the final-destination backend servers which the Load Balancer forwards traffic on to. Each of the Load Balancer's [backends](#backends) must specify one or more backend servers (via their IP addresses) to forward to.
 
-</Concept>
-
-<Concept>
-
 ## Backend protection
 
 Backend protection is a set of configurable values that allow you to control how load is distributed to backend servers. You can use these settings to configure the **maximum number of simultaneous requests** to a given backend server before it is considered to be at maximum capacity. You can also configure a **queue timeout** value, which defines the maximum amount of time (in ms) to queue a request or connection for a particular backend server when [stickiness](#sticky-session) is enabled. Once this value is reached, the request/connection will be directed to a different backend server.
-
-</Concept>
-
-<Concept>
 
 ## Balancing methods
 
@@ -66,13 +44,8 @@ Load Balancers support three different modes of balancing load (requests) betwee
 * **Round-robin**: Requests are sent to each backend server in turn, with the Load Balancer acting like a turnstile. This is the most frequently used balancing method, and the easiest to implement. It is well-suited to infrastructures that have identical backend servers.
 * **Least connections**: Each request is assigned to the server with the fewest active connections. This method works best when it is expected that sessions will be long, e.g. LDAP, SQL TSE. It is less well suited to protocols with typically short sessions like HTTP.
 * **First available**: Each request is directed towards the first backend server with available connection slots. Once a server reaches its limit of maximum simultaneous connections, requests are directed to the next server. This method uses the smallest number of servers at any given time, which can be useful if, for example, you sometimes want to power off extra servers during off-peak hours.
-
   
 For more information about balancing rules, refer to our [blog post "What is a load balancer"](https://www.scaleway.com/en/blog/what-is-a-load-balancer/)
-
-</Concept>
-
-<Concept>
 
 ## Certificate
 
@@ -86,43 +59,23 @@ A certificate (aka SSL certificate / TLS certificate / TLS/SSL certificate) is a
 
 You can [add a certificate](/network/load-balancer/how-to/add-certificate) to your Load Balancer's frontend to enable the Load Balancer to decrypt/encrypt traffic, necessary for [SSL bridging and SSL offloading configurations](/network/load-balancer/reference-content/ssl-bridging-offloading-passthrough/). Scaleway Load Balancer enables you to generate a Let's Encrypt certificate, or import a third-party or self-signed certificate.
 
-</Concept>
-
-<Concept>
-
 ## Connection timeout
 
 Connection timeout is a configurable value for your Load Balancer's backend. It defines the maximum time (in ms) allowed to establish a connection between a client and a backend server.
-
-</Concept>
-
-<Concept>
 
 ## First available
 
 See [balancing-methods](#balancing-methods).
 
-</Concept>
-
-<Concept>
-
 ## Frontends
 
 Each Load Balancer is configured with one or several frontends. Frontends listen on a configured port, and forward requests to one or several backends. You can [add and manage frontends via the console](/network/load-balancer/how-to/manage-frontends-and-backends/).
-
-</Concept>
-
-<Concept>
 
 ## Flexible IP address
 
 Flexible IP addresses are public IP addresses that you can hold independently of any Load Balancer. By default, each Load Balancer is created automatically with a flexible IP address, that the frontend listens to. In case of a failure of the Load Balancer, a replica Load Balancer is immediately spawned and deployed, and the flexible IP address is automatically rerouted to this replica.
 
 Find out how to create and manage flexible IP addresses in our [dedicated how-to](/network/load-balancer/how-to/create-manage-flex-ips/).
-
-</Concept>
-
-<Concept>
 
 ## Health checks
 
@@ -138,17 +91,9 @@ Various advanced settings can be configured for health checks, including:
 
 [Read more about health checks](/network/load-balancer/reference-content/configuring-health-checks/).
 
-</Concept>
-
-<Concept>
-
 ## High availability
 
 A high availability (HA) setup is an infrastructure without a single point of failure. It prevents a server failure by adding redundancy to every layer of your architecture.
-
-</Concept>
-
-<Concept>
 
 ## HTTP headers
 
@@ -156,20 +101,11 @@ HTTP headers are a list of strings in the format `header-name: value` used by th
 
 Scaleway Load Balancers can use the **Host** header field to define [routes](#routes) from a frontend to a specified HTTP backend. HTTP headers can also be used in [ACLs](#acl) to **allow**, **deny** or **redirect** traffic based on the specified header field and value.
 
-</Concept>
-
-
-<Concept>
-
 ## HTTP/2 and HTTP/3
 
 HTTP/2 and HTTP/3 are newer, improved versions of the "classic" HTTP/1 protocol. Scaleway Load Balancers support HTTP/2 connections to frontends, and HTTP/2 connections from backends to backend servers. In addition, Scaleway Load Balancers support HTTP/3 connections to frontends, but do not support HTTP/3 connections from backends to backend servers. 
 
 Read more about HTTP/2 and HTTP/3 and how they can be configured on Scaleway Load Balancers in our [dedicated documentation](/network/load-balancer/reference-content/http2-http3).
-
-</Concept>
-
-<Concept>
 
 ## Kubernetes Load Balancer
 
@@ -177,26 +113,15 @@ When you create a `LoadBalancer` service within your [Scaleway Kubernetes cluste
 
 The process for creating and managing Load Balancers for Kubernetes clusters is very specific - you **cannot** create or edit these via the Scaleway console or API. For full instructions on how to correctly create and configure a Scaleway Load Balancer for a Kubernetes cluster, see our [dedicated documentation](/containers/kubernetes/reference-content/kubernetes-load-balancer/).
 
-</Concept>
-
-<Concept>
-
 ## Least connections
 
 See [balancing-methods](#balancing-methods).
 
-</Concept>
-
-<Concept>
-
 ## Load Balancers
+
 [Load Balancers](/network/load-balancer/how-to/create-load-balancer/) are highly available and fully managed instances that allow you to distribute workload across multiple servers. They ensure the scaling of all your applications while securing their continuous availability, even in the event of heavy traffic. They are commonly used to improve the performance and reliability of websites, applications, databases and other services.
 
 <Lightbox src="scaleway-load-balancer.webp" alt="" />
-
-</Concept>
-
-<Concept>
 
 ## Private Load Balancer
 
@@ -219,49 +144,25 @@ When you attach a private Load Balancer to multiple Private Networks, it has an 
 
 <Lightbox src="scaleway-privatelb-multipn.webp" alt="" />
 
-</Concept>
-
-<Concept>
-
 ## Protocol
 
 A protocol is a standard format for communication over a network. When you configure your Load Balancer's backend, you choose a protocol (HTTP, HTTPs or TCP) which it uses to send and receive data.
-
-</Concept>
-
-<Concept>
 
 ## Proxy protocol
 
 Proxy protocol is an internet protocol used to transfer connection information from the client (e.g. the client's IP address), through the Load Balancer and on to the destination server.
 
-</Concept>
-
-<Concept>
-
 ## Round-robin
 
 See [balancing-methods](#balancing-methods).
-
-</Concept>
-
-<Concept>
 
 ## Routes
 
 Routes allow you to specify, for a given frontend, which of its backends it should direct traffic to. For [HTTP](#protocol) frontends/backends, routes are based on HTTP Host headers. For [TCP](#protocol) frontends/backends, they are based on **S**erver **N**ame **I**dentification (SNI). You can configure multiple routes on a single Load Balancer.
 
-</Concept>
-
-<Concept>
-
 ## S3 failover
 
 [S3 failover](/network/load-balancer/how-to/set-up-s3-failover/) is a feature that allows you to redirect users to a static website hosted on Scaleway Object storage, in the case that none of your Load Balancer's backends are available. 
-
-</Concept>
-
-<Concept>
 
 ## Server Name Identification (SNI)
 
@@ -269,41 +170,21 @@ SNI allows the server to host multiple [SSL/TLS certificates](#certificate) for 
 
 Scaleway Load Balancers can use SNI to define [routes](#routes) from a frontend to a specified TCP backend.
 
-</Concept>
-
-<Concept>
-
 ## Server timeout
 
 Server timeout is a configurable value for your Load Balancer's backend. It defines the maximum allowed time (in ms) that a backend server has to process a request.
-
-</Concept>
-
-<Concept>
 
 ## SSL bridging
 
 [SSL bridging](/network/load-balancer/reference-content/ssl-bridging-offloading-passthrough/) describes a configuration pattern where the Load Balancer terminates encrypted connections at the frontend (decrypting incoming traffic) before initiating a new encrypted connection to the backend before forwarding traffic.
 
-</Concept>
-
-<Concept>
-
 ## SSL offloading
 
 [SSL offloading](/network/load-balancer/reference-content/ssl-bridging-offloading-passthrough/) describes a pattern where the Load Balancer terminates encrypted connections at the frontend (decrypting incoming traffic), with the intention to forward it unencrypted to the backend servers. This effectively "offloads" the work of decrypting traffic from the backend server to the Load Balancer.
 
-</Concept>
-
-<Concept>
-
 ## SSL passthrough
 
 [SSL passthrough](/network/load-balancer/reference-content/ssl-bridging-offloading-passthrough/) is the simplest way to handle HTTPS traffic on a Load Balancer. As the name suggests, traffic is simply passed through the Load Balancer without being decrypted.
-
-</Concept>
-
-<Concept>
 
 ## Sticky session
 
@@ -314,20 +195,10 @@ A sticky session enables the Load Balancer to bind a user's session to a specifi
 
 By default, when activating sticky sessions through the console, the cookie-based method is used when HTTP protocol is selected, and the table-based method is used when TCP protocol is selected. Use the [API](https://www.scaleway.com/en/developers/api/load-balancer/zoned-api/) if you want to select table-based stickiness with HTTP protocol.
 
-</Concept>
-
-<Concept>
-
 ## Tunnel timeout
 
 Tunnel timeout is a configurable value for your Load Balancer's backend. It defines the maximum allowed tunnel inactivity time (in ms) between a client and a backend server after a Websocket is established. This value takes precedence over client and server timeout in determining when to close the connection.
 
-</Concept>
-
-<Concept>
-
 ## Verify certificate 
 
 The [Verify Certificate configuration](/network/load-balancer/reference-content/configuring-backends/#verify-certificate) is relevant to Load Balancers with backends using HTTPS protocol, and specifies whether the Load Balancer should check the backend server's [certificate](#certificate) before initiating a connection.
-
-</Concept>

--- a/network/public-gateways/concepts.mdx
+++ b/network/public-gateways/concepts.mdx
@@ -10,35 +10,21 @@ categories:
   - network
 ---
 
-<Concept opened>
-
 ## Default route
 
 The Public Gateway can advertise a default route to resources on an attached Private Network, which takes effect when the IP destination address for a packet is not known on the network itself. In effect, resources in a Private Network will know to route packets through the Public Gateway if the destination IP address is not a host on the Private Network itself.
 
 You can choose to activate the advertisement of the default route when attaching a Private Network to a Public Gateway. The default route is propagated through DHCP.
 
-</Concept>
-
-<Concept opened>
-
 ## DHCP
 
 DHCP was previously a functionality of Scaleway Public Gateways, but has now been moved and is integrated directly into Private Networks. [Read more about DHCP on Private Networks](/network/vpc/concepts#dhcp).
-
-</Concept>
-
-<Concept opened>
 
 ## DNS
 
 The **D**omain **N**ame **S**ystem (DNS) is a naming system for devices connected to the internet or Private Networks. Most prominently, DNS servers translate text-based domain names (e.g. www.scaleway.com) to numerical IP addresses (e.g. 51.158.66.220).
 
 [Private Networks](/network/vpc/concepts#private-networks) benefit from managed DNS, which resolves the hostnames of attached resources into their IP addresses. The hostname for a given device is generally the name defined when creating the resource (and which in the case of an Instance, for example, displays in the shell when connected to that resource by SSH). When a Private Network is attached to a **Public Gateway** however, the gateway's DNS takes priority over that of the Private Network, to allow host name resolution across different Private Networks.
-
-</Concept>
-
-<Concept opened>
 
 ## Flexible IP
 
@@ -48,17 +34,9 @@ Flexible IPs exist for many resources (Instances, Elastic Metal servers, Load Ba
 
 When you delete a flexible IP address, it is disassociated from your account to be used by other users.
 
-</Concept>
-
-<Concept>
-
 ## IP address
 
 An **I**nternet **P**rotocol address is a unique address that identifies a device on the internet or a local network. Written in human-readable notations, an IP address is generally shown as 4 octets of numbers, e.g. 72.16.254.1. IP addresses can be [public](#public-ip-address) or [private](#private-ip-address).
-
-</Concept>
-
-<Concept>
 
 ## IPAM
 
@@ -86,19 +64,12 @@ You cannot "migrate" a legacy Public Gateway to become an IPAM-mode gateway. Whi
 When creating a Kubernetes Kapsule cluster with [full isolation](/containers/kubernetes/reference-content/secure-cluster-with-private-network/#can-i-use-a-public-gateway-with-my-private-network-to-exit-all-outgoing-traffic-from-the-nodes) you are required to attach a Public Gateway to the cluster's Private Network, and this **cannot** be a legacy Public Gateway - it must be an IPAM-mode gateway.
 </Message>
 
-</Concept>
-
-<Concept>
-
 ## Legacy gateway
 
 See [IPAM](#ipam).
 
-</Concept>
-
-<Concept>
-
 ## NAT
+
 **N**etwork **A**ddress **T**ranslation (NAT) maps private IP addresses in a Private Network to the public IP address of the Public Gateway. Private IP addresses are not routable on the public Internet, so NAT makes it possible for them to securely communicate with the internet via the gateway. There are two types of NAT:
 
 - **Dynamic NAT** enables egress traffic from a Private Network to the public internet by dynamically, automatically mapping the outgoing traffic IP addresses and ports with the public IP address and ports of the Public Gateway. Dynamic NAT is automatically activated for all Public Gateways attached to Private Networks.
@@ -107,59 +78,30 @@ See [IPAM](#ipam).
 
 See our documentation on [reviewing and configuring NAT](/network/public-gateways/how-to/configure-a-public-gateway/#how-to-review-and-configure-nat) for more information.
 
-</Concept>
-
-<Concept opened>
-
 ## Private IP address
 
 Private [IP addresses](#ip-address) identify devices on local/Private Networks. They are not routed on the internet - if you enter the private IP address of an Instance into a random browser connected to the Internet, it will not connect to anything. This is because a private IP address is only relevant within a particular local network. Devices within a local network can communicate securely between themselves via their private IP addresses.
-
-</Concept>
-
-<Concept>
 
 ## Private Network
 
 See [the VPC documentation](/network/vpc/concepts#private-networks).
 
-</Concept>
-
-<Concept>
-
 ## Public Gateway
 
 Public Gateways sit at the border of Private Networks and provide a secure point of entry from the public internet to your infrastructure. They also offer extra functionality, including [NAT](#nat) and [SSH bastion](#ssh-bastion). You can [add a Public Gateway](/network/public-gateways/how-to/configure-a-public-gateway#how-to-attach-a-public-gateway-to-a-private-network) to each of your Private Networks.
-
-</Concept>
-
-<Concept>
 
 ## Public IP address
 
 Public [IP addresses](#ip-address) identify devices on the internet. You can enter the public IP address of an Instance into any browser connected to the Internet, and access content being served from that Instance. You can think of public IP addresses like postal addresses for buildings - they are unique, and tell the routers directing traffic through the internet where to find a particular server.
 
-</Concept>
-
-<Concept>
-
 ## Region and Availability Zone
 
 <Macro id="region-and-az" />
-
-</Concept>
-
-<Concept>
 
 ## SSH bastion
 
 [SSH bastion](/network/public-gateways/how-to/use-ssh-bastion) is a server dedicated to managing connections to the infrastructure behind your Public Gateway. When you activate SSH bastion on your Public Gateway, all the SSH keys held in your Project credentials are imported to the SSH bastion, providing a single point of entry. This makes management of your infrastructure easier and more secure.
 
-</Concept>
-
-<Concept>
-
 ## Tags
-Tags let you organize your Public Gateways. You can assign as many tags as you want to each gateway, and use this feature to identify, sort and filter them.
 
-</Concept>
+Tags let you organize your Public Gateways. You can assign as many tags as you want to each gateway, and use this feature to identify, sort and filter them.

--- a/network/vpc/concepts.mdx
+++ b/network/vpc/concepts.mdx
@@ -13,8 +13,6 @@ dates:
   posted: 2023-02-06
 ---
 
-<Concept opened>
-
 ## CIDR block
 
 A **C**lassless **I**nter-**D**omain **R**outing (CIDR) block represents a range of IP addresses. They all share the same network prefix. An example of an [IPv4](#ipv4) CIDR block is `172.16.16.0/22`, while an [IPv6](#ipv6) CIDR block looks like `fd12:3456:789a:1::/64`.
@@ -26,17 +24,10 @@ The two parts of a CIDR block are:
 An IPv4 CIDR block and an IPv6 CIDR block are defined for each Scaleway Private Network at the time of creation. When you attach a resource (e.g. an Instance, an Elastic Metal server or a Load Balancer) to the network, [DHCP](#dhcp) will assign one IPv4 and one IPv6 address from the designated blocks to that resource. This way, each resource automatically gets a private IPv4 and IPv6 address on the Private Network.
 
 IP addresses from within a given subnet (that is to say, allocated from a certain CIDR block that is used for a certain Private Network) display with a slash at the end. In the case of an IPv4 address, this could look like `172.16.16.2/22`. This format encapsulates information both about the IP address itself, and which subnet it is from. If you configure an Instance manually with this address, it sets both the correct IP and a route to the correct subnet.
-</Concept>
-
-<Concept opened>
 
 ## Default VPC
 
 Scaleway currently has three regions: Paris, Amsterdam and Warsaw. One default VPC is automatically created for each region, in each Scaleway [Project](/console/project/concepts/#project). Any new Private Networks that you create will be added to the default VPC for their region, unless you override this by specifying a different VPC. 
-
-</Concept>
-
-<Concept opened>
 
 ## DHCP
 
@@ -52,27 +43,15 @@ The IPv4 address of Private Networks' DHCP server is `169.254.169.254`. The IPv6
 While DHCP is built into all new Private Networks, it may not be automatically activated for older Private Networks. Check our [migration](/network/vpc/reference-content/vpc-migration/) documentation for more information.
 </Message>
 
-</Concept>
-
-<Concept>
-
 ## DNS
 
 The **D**omain **N**ame **S**ystem (DNS) is a naming system for devices connected to the internet or Private Networks. Most prominently, DNS servers translate text-based domain names (e.g. www.scaleway.com) to numerical IP addresses (e.g. 51.158.66.220).
 
 Private Networks benefit from managed DNS, which resolves the hostnames of attached resources into their IP addresses. The hostname for a given device is generally the name defined when creating the resource (and which in the case of an Instance, for example, displays in the shell when connected to that resource by SSH). When a Private Network is attached to a Public Gateway however, the gateway's DNS takes priority over that of the Private Network, to allow host name resolution across different Private Networks.
 
-</Concept>
-
-<Concept>
-
 ## IPAM
 
 **IP** **A**ddress **M**anagement (IPAM) is a method for planning, tracking and managing the IP address space of a network. Scaleway's IPAM acts as a single source of truth for the IP addresses of Scaleway resources. Managed products, such as Databases and Load Balancer, are fully integrated into IPAM, and Private Networks' [DHCP server](#dhcp) uses IPAM to assign static IP addresses to attached resources such as Instances and Elastic Metal server. We are starting to make some public IPAM functionality available on our IPAM API: [check out the documentation](https://www.scaleway.com/en/developers/api/ipam/) for more details.
-
-</Concept>
-
-<Concept>
 
 ## IPv4
 
@@ -80,19 +59,11 @@ Internet Protocol Version 4 is the standard protocol used for IP addresses, and 
 
 Scaleway Private Networks' [DHCP](#dhcp) functionality assigns both an IPv4 and an IPv6 address to its attached resources. Note that IPv4 addresses defined in this way display with a slash at the end, e.g. `172.16.16.2/22`, to encapsulate information both about the IP address itself and which subnet it is from. See the [CIDR](#cidr) concept for more information.
 
-</Concept>
-
-<Concept>
-
 ## IPv6
 
 Internet Protocol Version 6 is the most recent version of the IP protocol used for IP addresses. Each IPv6 address has 128 bits. Written in human-readable form, an IPv6 address can be shown as eight groups of four hexadecimal digits, each group representing 16 bits and separated by a colon, e.g. `2001:0DB8:0000:0003:0000:01FF:0000:002E`. This can also be notated as `2001:DB8::3:0:1FF:0:2E`.
 
 Scaleway Private Networks' [DHCP](#dhcp) functionality assigns both an IPv4 and an IPv6 address to its attached resources. See the [CIDR](#cidr) concept for more information.
-
-</Concept>
-
-<Concept>
 
 ## Private Networks
 
@@ -108,17 +79,9 @@ Previously, Private Networks at Scaleway were zoned. Only resources from within 
 While DHCP is built into all new Private Networks, it may not be automatically activated for older Private Networks. Check our [migration](/network/vpc/reference-content/vpc-migration/) documentation for more information.
 </Message>
 
-</Concept>
-
-<Concept>
-
 ## Region and Availability Zone
 
 <Macro id="region-and-az" />
-
-</Concept>
-
-<Concept>
 
 ## VPC
 
@@ -129,5 +92,3 @@ One default VPC for every available region is automatically created in each Scal
 VPC currently comprises the [Private Networks](#private-networks) product. Layer 2 Private Networks sit inside the layer 3 VPC. 
 
 More features and resources will be coming to VPC in the future.
-
-</Concept>

--- a/observability/cockpit/concepts.mdx
+++ b/observability/cockpit/concepts.mdx
@@ -10,23 +10,13 @@ categories:
   - observability
 ---
 
-<Concept>
-
 ## Active series
 
 Active series refer to [time series](#time-series) for which the latest [samples](#samples) received by your Cockpit are less than 10 minutes old.
 
-</Concept>
-
-<Concept opened>
-
 ## Alerting
 
 Alerting detects complex conditions defined by a rule and keeps you aware of issues in your environments. When a condition defined by a rule is met, the rule tracks it as an alert and responds by triggering one or more actions.
-
-</Concept>
-
-<Concept opened>
 
 ## Alert manager
 
@@ -36,10 +26,6 @@ Scaleway's alert manager allows you to manage and respond to alerts. It handles 
 Select **Scaleway Alerting** when choosing the Alert manager if you want to manage your alerts using Grafana.
 </Message>
 
-</Concept>
-
-<Concept>
-
 ## Alerting rules
 
 Alerting rules allow you to define criteria that determine whether an alert is triggered. The rule consists of queries and expressions, a condition, the frequency of evaluation, and the duration over which the condition is met. They act as alarm sensors: when an alert is triggered, a notification is sent to the alert manager, which forwards the notification to receivers.
@@ -48,25 +34,13 @@ Alerting rules allow you to define criteria that determine whether an alert is t
   If you plan on setting up alerting rules with Grafana, use the Mimir or Loki alerts rather than the Grafana managed alert.
 </Message>
 
-</Concept>
-
-<Concept opened>
-
 ## Cockpit
 
 A Cockpit is an instance of the Observability product that stores logs and metrics, and provides a dedicated dashboarding system on Grafana to visualize them. A Scaleway Project can have only one Cockpit.
 
-</Concept>
-
-<Concept>
-
 ## Contact points
 
 Contact points define who is notified when an alert fires. Contact points include emails, Slack, on-call systems and texts. When an alert fires, all contact points are notified.
-
-</Concept>
-
-<Concept>
 
 ## Endpoints
 
@@ -82,10 +56,6 @@ An endpoint is the point of entry in a communication channel when two systems ar
  - Sending metrics, logs and traces for Scaleway resources or personal data using an external path is a billable feature. In addition, any data that you push yourself is billed, even if you send data from Scaleway products. Refer to the [product pricing](https://www.scaleway.com/en/pricing/?tags=available,managedservices-observability-cockpit) for more information.
 </Message>
 
-</Concept>
-
-<Concept>
-
 ## Grafana users
 
 A Grafana user is any individual who can log in to [Grafana](https://grafana.com). Each user is associated with a role. There are two types of roles a user can have:
@@ -98,113 +68,57 @@ A Grafana user is any individual who can log in to [Grafana](https://grafana.com
  - The `admin` user is not yet available for creation.
 </Message>
 
-</Concept>
-
-<Concept>
-
 ## Loki
 
 Loki is the log aggregation system used by [Grafana](https://grafana.com/docs/grafana/latest/introduction/) to store and query your logs.
-
-</Concept>
-
-<Concept>
 
 ## Loki Remote Write
 
 `Loki Remote Write` is the protocol used to push your logs to your Cockpit's logs' endpoint.
 
-</Concept>
-
-<Concept>
-
 ## LogQL
 
 LogQL is [Grafana Loki’s language](https://grafana.com/docs/loki/latest/logql/) for querying logs. LogQL uses labels and operators for filtering.
-
-</Concept>
-
-<Concept>
 
 ## Logs
 
 Logs provide a record of all events and errors that take place during the lifecycle of your resources. They represent an excellent source of visibility if you want to know when a problem occurred, or which events correlate with it.
 
-</Concept>
-
-<Concept>
-
 ## Managed alerts
 
 Managed alerts are alerting rules that Scaleway defines for you. You can think of them as alarm sensors. They allow you to receive alerts for behaviors that we deem abnormal on your products. Managed alerts only apply to Scaleway products' metrics and logs.
-
-</Concept>
-
-<Concept>
 
 ## Managed dashboards
 
 A managed dashboard is a set of one or more panels that Scaleway sets up and updates for you to visualize the metrics and logs associated with your Scaleway products.
 
-</Concept>
-
-<Concept>
-
 ## Metric
 
 A metric is a lifecycle-related numerical representation of data (e.g. disk usage and CPU usage) measured over intervals of time. Metrics give you a bird's eye view of your infrastructure.
-
-</Concept>
-
-<Concept>
 
 ## Mimir
 
 [Grafana Mimir](https://github.com/grafana/mimir) is an open source software project that allows you to store your metrics by providing long-term storage for [Prometheus](https://prometheus.io/docs/introduction/overview/#what-is-prometheus).
 
-</Concept>
-
-<Concept>
-
 ## Prometheus Remote Write
 
 `Prometheus Remote Write` is the protocol used to push your metrics to your Cockpit's metrics' endpoint.
-
-</Concept>
-
-<Concept>
 
 ## PromQL
 
 PromQL, short for Prometheus Querying Language, is the main way to query metrics within Prometheus. It is designed for building queries for graphs and alerts.
 
-</Concept>
-
-<Concept>
-
 ## Receivers
 
 Receivers are hubs consisting of contacts points. You can associate one or several alerts with one or more receivers. This allows you to diversify your alerts.
-
-</Concept>
-
-<Concept>
 
 ## Recording rules
 
 Recording rules allow you to precompute frequently needed or computationally expensive expressions and save their results as a new set of time series.
 
-</Concept>
-
-<Concept>
-
 ## Samples
 
 A sample is a unique measuring point on a time series.
-
-</Concept>
-
-<Concept>
 
 ## Tempo
 
@@ -214,18 +128,9 @@ Tempo is [Grafana's open source](https://grafana.com/docs/tempo/latest/) tracing
  During the beta of the traces feature, only the [OpenTelemetry](https://opentelemetry.io/docs/what-is-opentelemetry/) HTTP push path is supported. Scaleway is working on implementing the [Open Telemetry gRPC](https://opentelemetry.io/docs/specs/semconv/rpc/grpc/), [Zipkin](https://zipkin.io/) and [Jaeger](https://www.jaegertracing.io/docs/1.50/) protocols.
 </Message>
 
-</Concept>
-
-<Concept>
-
 ## Time series
 
 A time series is a sequence of numerical data points in successive order, that tracks the value of a parameter over time. Example of parameter: the disk usage of a machine hosting a database, expressed in percentage.
-
-</Concept>
-
-<Concept>
-
 
 ## Tokens
 
@@ -236,17 +141,9 @@ Tokens are secret keys that allow you to authenticate against your Cockpit's end
 - **Rules**: allow you to configure alerting and recording rules.
 - **Alerts**: allow you to set up the alert manager.
 
-</Concept>
-
-<Concept>
-
 ## TraceQL
 
 [TraceQL](https://grafana.com/docs/tempo/latest/traceql/) is Grafana Tempo's query language designed for searching and extracting traces.
-
-</Concept>
-
-<Concept>
 
 ## Traces
 
@@ -256,4 +153,3 @@ Traces are an effective way to identify performance issues and bottlenecks in yo
  <Lightbox src="scaleway-traces-concept.webp" alt="" />
 
 Scaleway only supports the [OpenTelemetry](https://opentelemetry.io/docs/what-is-opentelemetry/) agent for pushing traces.
-</Concept>

--- a/observability/cockpit/how-to/send-metrics-logs-to-cockpit.mdx
+++ b/observability/cockpit/how-to/send-metrics-logs-to-cockpit.mdx
@@ -41,8 +41,6 @@ You can push logs with any Loki compatible agent such as the [Promtail](https://
      - The Remote Write endpoint to push your logs is the following: `https://logs.cockpit.fr-par.scw.cloud/loki/api/v1/push`
     </Message>
 
-    <Concept opened>
-
     ## Example: send Python logs to your Scaleway Cockpit on a new logs dashboard
 
     We need to install [logging_loki](https://pypi.org/project/python-logging-loki/) using the command `pip install python-logging-loki`.
@@ -86,8 +84,6 @@ You can push logs with any Loki compatible agent such as the [Promtail](https://
     * You can view your log line from the Python snippet.
 
     <Lightbox src="scaleway_cockpit_show_python_logs.webp" alt="scaleway cockpit show python logs.webp" />
-
-    </Concept>
 
 5. [Log in to your Grafana account](/observability/cockpit/how-to/access-grafana-and-managed-dashboards).
 6. Create your [Grafana dashboard](/observability/cockpit/how-to/access-grafana-and-managed-dashboards) and start monitoring your data.

--- a/serverless/containers/concepts.mdx
+++ b/serverless/containers/concepts.mdx
@@ -10,96 +10,49 @@ categories:
   - serverless
 ---
 
-<Concept opened>
-
 ## Cold Start
 
 Cold start is the time a container Instance takes to handle a request when it is called for the first time.
-
-</Concept>
-
-<Concept opened>
 
 ## Concurrency
 
 Concurrency defines the number of simultaneous requests your container can handle at the same time.
 
-</Concept>
-
-<Concept opened>
-
 ## Container 
 
 A container is a package of software that includes all dependencies: code, runtime, configuration, and system libraries so that it can run on any host system. Scaleway provides custom Docker images that are entirely handled for you in the cloud. With Containers, you can rely on your favorite technologies such as Django or Ruby on Rails.
-
-</Concept>
-
-<Concept opened>
 
 ## Container Registry 
 
 Container Registry is the place where your images are stored before being deployed.
 
-</Concept>
-
-<Concept>
-
 ## CRON trigger
 
 A CRON trigger is a mechanism used to automatically invoke a Serverless Function at a specific time on a recurring schedule. It works similarly to a traditional Linux [cron job](https://en.wikipedia.org/wiki/Cron), using the `* * * * *` format. Refer to our [cron schedules reference](/serverless/containers/reference-content/cron-schedules/) for more information.
-
-</Concept>
-
-<Concept>
 
 ## GB-s
 
 Unit used to measure the resource consumption of a container. It reflects the amount of memory consumed over time.
 
-</Concept>
-
-<Concept>
-
 ## Environment variables
 
 An environment variable is a variable whose value is set outside the program, typically through functionality built into the operating system or microservice. An environment variable is made up of a name/value pair, and any number may be created and available for reference at a point in time.
-
-</Concept>
-
-<Concept>
 
 ## Image
 
 An image is a blueprint from which an arbitrary number of brand-new containers can be started. You can start a container from an image, perform operations in it, and save another image based on the latest state of the container.
 
-</Concept>
-
-<Concept>
-
 ## JWT Token
 
 JWT (JSON Web Token) is an access token you can create from the console or API to enable an application to access your Private Container. Consult the [Developer documentation](https://www.scaleway.com/en/developers/api/serverless-containers/#path-tokens) for more details.
 
-</Concept>
-
-<Concept>
-
 ## mVCPU
 
-
 A vCPU (Virtual Central Processing Unit) is equivalent to 1000 mVCPU.
-
-</Concept>
-
-<Concept>
 
 ## Namespace
 
 A namespace is a project that allows you to [group your containers](/serverless/containers/how-to/create-a-containers-namespace/). Containers in the same Namespace can share environment variables and access tokens, defined at the namespace level.
-
-</Concept>
-
-<Concept>
 
 ## NATS trigger
 
@@ -108,57 +61,29 @@ A NATS trigger is a mechanism that connects a container to a [NATS](/serverless/
 For each message that is sent to a NATS subject, the NATS trigger reads the message and invokes the associated container with the message as the input parameter.
 The container can then process the message and perform any required actions, such as updating a database or sending a notification.
 
-</Concept>
-
-<Concept>
-
 ## Privacy policy
 
 A container's privacy policy defines whether a container may be invoked anonymously (**public**) or only via an authentication mechanism provided by the [Scaleway API](https://www.scaleway.com/en/developers/api/serverless-containers/#authentication) (**private**).
-
-</Concept>
-
-<Concept>
 
 ## Scale to zero
 
 One of the advantages of Serverless Containers is that when your container is not triggered, it does not consume any resources, which enables great savings.
 
-</Concept>
-
-<Concept>
-
 ## Scaling
 
 Serverless Containers make scaling your application transparent, up to 20 instances of your container can be run at the same time.
-
-</Concept>
-
-<Concept>
 
 ## Secrets
 
 Secrets are an extra-secure type of environment variable. They are environment variables that are injected into your container and stored securely, but not displayed in the console after initial validation.
 
-</Concept>
-
-<Concept>
-
 ## Serverless
 
 Serverless allows you to deploy your Functions (FaaS) and Containerized Applications (CaaS) in a managed infrastructure. Scaleway ensures the deployment, availability, and scalability of all your projects.
 
-</Concept>
-
-<Concept>
-
 ## Serverless Framework
 
 Serverless.com (Serverless Framework) is a tool that allows you to deploy serverless applications without having to manage Serverless Container’s API call. Write and deploy a YAML configuration file, everything else is handled automatically, even the image building.
-
-</Concept>
-
-<Concept>
 
 ## SQS trigger
 
@@ -167,36 +92,19 @@ An SQS (Simple Queue Service) trigger is a mechanism that connects a container t
 For each message that is sent to an SQS queue, the SQS trigger reads the message and invokes the associated container with the message as the input parameter.
 The container can then process the message and perform any required actions, such as updating a database or sending a notification.
 
-</Concept>
-
-<Concept>
-
 ## Stateless application
 
 A stateless application is a computer program that does not save client data between sessions. Data generated in one session is not saved for use in the next session with that client. All applications deployed on Serverless Containers are stateless.
-
-</Concept>
-
-<Concept>
 
 ## Timeout
 
 The timeout is the maximum length of time your container can spend processing a request before being stopped. This value must be in the range 10s to 900s.
 
-</Concept>
-
-<Concept>
-
 ## vCPU
 
 vCPU is the abbreviation for **v**irtual **C**entralized **P**rocessing **U**nit. A vCPU represents a portion or share of the underlying physical CPU assigned to a particular container.
 The performance of a vCPU is determined by the percentage of time spent on the physical processor's core. It is possible to allocate different resource allowances on specific vCPUs for specific containers or virtual machines.
-</Concept>
-
-<Concept>
 
 ## Protocol
 
 Serverless Containers supports **http1** (default) and **http2** (`h2c`). In some cases, for example, while deploying a container using gRPC, you may need to upgrade the protocol for it to work.
-
-</Concept>

--- a/serverless/functions/concepts.mdx
+++ b/serverless/functions/concepts.mdx
@@ -10,70 +10,37 @@ categories:
   - serverless
 ---
 
-<Concept opened>
-
 ## Cold Start
 
 Cold start is the time a function Instance takes to handle a request when it is called for the first time.
-
-</Concept>
-
-<Concept opened>
 
 ## CRON trigger
 
 A CRON trigger is a mechanism used to automatically invoke a Serverless Function at a specific time on a recurring schedule. It works similarly to a traditional Linux [cron job](https://en.wikipedia.org/wiki/Cron), using the `* * * * *` format. Refer to our [cron schedules reference](/serverless/functions/reference-content/cron-schedules/) for more information.
 
-</Concept>
-
-<Concept opened>
-
 ## Environment variables
 
 An environment variable is a variable whose value is set outside the program, typically through functionality built into the operating system or microservice. An environment variable is made up of a name/value pair, and any number may be created and available for reference at a point in time.
 
-</Concept>
-
-<Concept opened>
-
 ## Function
+
 A function defines a procedure on how to change one element into another. The function remains static, while the variables that pass through it can vary.
-
-</Concept>
-
-<Concept opened>
 
 ## GB-s
 
 Unit used to measure the resource consumption of a function. It reflects the amount of memory consumed over time.
 
-</Concept>
-
-<Concept>
-
 ## JWT Token
 
 A JWT (JSON Web Token) is an access token you can create from the console or the API to enable an application to access your Private function.
-
-</Concept>
-
-<Concept>
 
 ## Handler
 
 A handler is a routine/function/method that processes specific events. Upon invoking your function, the handler is executed and returns an output. Refer to our [code examples](/serverless/functions/reference-content/code-examples/) for more information on the structure of a handler.
 
-</Concept>
-
-<Concept>
-
 ## Namespace
 
 A namespace is a project that allows you to [group your functions](/serverless/functions/how-to/create-a-functions-namespace/). Functions in the same Namespace can share environment variables and access tokens, defined at the namespace level.
-
-</Concept>
-
-<Concept>
 
 ## NATS trigger
 
@@ -82,66 +49,33 @@ A NATS trigger is a mechanism that connects a function to a [NATS](/serverless/m
 For each message that is sent to a NATS subject, the NATS trigger reads the message and invokes the associated function with the message as the input parameter.
 The function can then process the message and perform any required actions, such as updating a database or sending a notification.
 
-</Concept>
-
-<Concept>
-
 ## Privacy policy
 
 A function's privacy policy defines whether a function may be executed anonymously (**public**) or only via an authentication mechanism provided by the [Scaleway API](https://www.scaleway.com/en/developers/api/serverless-functions/#authentication) (**private**).
-
-</Concept>
-
-<Concept>
 
 ## Runtime
 
 The runtime is the execution environment of your function. Regarding Serverless Function, it consists of the languages in which your code is written.
 
-</Concept>
-
-<Concept>
-
 ## Scale to zero
 
 One of the advantages of Serverless Function is that when your function is not triggered, it does not consume any resources, which allows great savings.
-
-</Concept>
-
-<Concept>
 
 ## Scaling
 
 Serverless Functions make scaling your application transparent, up to 20 instances of your function can be run at the same time.
 
-</Concept>
-
-<Concept>
-
 ## Secrets
 
 Secrets are an extra-secure type of environment variable. They are environment variables that are injected into your function and stored securely, but not displayed in the console after initial validation.
-
-</Concept>
-
-<Concept>
 
 ## Serverless
 
 Serverless allows you to deploy your Functions (FaaS) and Containerized Applications (CaaS) in a managed infrastructure. Scaleway ensures the deployment, availability, and scalability of all your projects.
 
-</Concept>
-
-
-<Concept>
-
 ## Serverless Framework
 
 Serverless.com (Serverless Framework) is a tool that enables the deployment of serverless applications without having to manage Serverless Function's API call. Just write your configuration in a YAML and deploy, it handles everything.
-
-</Concept>
-
-<Concept>
 
 ## Serverless Functions
 
@@ -151,10 +85,6 @@ The platform also handles function availability and manages resource allocation 
 
 You pay for the resources your functions use, and only when your functions need them.
 
-</Concept>
-
-<Concept>
-
 ## SQS trigger
 
 An SQS (Simple Queue Service) trigger is a mechanism that connects a function to an [SQS](/serverless/messaging/concepts/#sqs) queue and invokes the function automatically whenever a message is added to the queue.
@@ -162,17 +92,9 @@ An SQS (Simple Queue Service) trigger is a mechanism that connects a function to
 For each message that is sent to an SQS queue, the SQS trigger reads the message and invokes the associated function with the message as the input parameter.
 The function can then process the message and perform any required actions, such as updating a database or sending a notification.
 
-</Concept>
-
-<Concept>
-
 ## Timeout
 
 The timeout is the maximum length of time your handler can spend processing a request before being stopped. This value must be in the range 10s to 900s.
-
-</Concept>
-
-<Concept>
 
 ## Trigger
 
@@ -181,5 +103,3 @@ In a serverless architecture, a function is not running constantly, but is rathe
 A trigger is a mechanism that connects the function to an event source and enables the function to execute automatically in response to specific events.
 
 Triggers can take many forms, such as HTTP requests, messages from a queue or a stream, CRON schedules, etc.
-
-</Concept>

--- a/serverless/jobs/concepts.mdx
+++ b/serverless/jobs/concepts.mdx
@@ -10,67 +10,35 @@ categories:
   - serverless
 ---
 
-<Concept opened>
-
 ## Container image
 
 A container image is a file that includes all the requirements and instructions of a complete and executable version of an application. 
 When running a job, the selected image will be pulled to execute your workload. Images can come from public external registries or from the [Scaleway Container Registry](/containers/container-registry/concepts/#container-registry).
 
-</Concept>
-
-<Concept opened>
-
 ## Environment variables
 
 An environment variable is a variable whose value is set outside the program, typically through functionality built into the operating system. An environment variable is made up of a name/value pair, and any number may be created and available for reference at a point in time.
-
-</Concept>
-
-<Concept opened>
 
 ## Job
 
 Serverless Jobs is a fully managed solution that enables you to plan, schedule, queue and run batch processing workloads without worrying about provisioning and scaling. A job is a single instance of one of these batch processing workloads.
 
-</Concept>
-
-<Concept>
-
 ## Job definition
 
 A Job definition is a template for a Serverless Job. It contains all the information necessary to run the job, including the container image used, the resources allocated, and the command to execute. The definition acts as a blueprint for [job runs](#job-run).
-
-</Concept>
-
-<Concept>
 
 ## Job name
 
 The name of a job is part of the [job definition](#job-definition) and is used for informational purposes only.
 
-</Concept>
-
-<Concept>
-
 ## Job run
 
 A job run is the execution of a job definition. It can be in a running, succeeded, canceled, or failed status. Each job run has a unique identifier and can be individually monitored using [Cockpit](/observability/cockpit/quickstart/).
-
-</Concept>
-
-<Concept>
 
 ## Maximum duration
 
 The maximum duration option allows you to define the maximum execution time before your job is automatically killed.
 
-</Concept>
-
-<Concept>
-
 ## Startup command
 
-This optional field allows you to specify a custom command executed upon starting your job if your container image does not have one already, or if you use a public container image. 
-
-</Concept>
+This optional field allows you to specify a custom command executed upon starting your job if your container image does not have one already, or if you use a public container image.

--- a/serverless/messaging/concepts.mdx
+++ b/serverless/messaging/concepts.mdx
@@ -13,127 +13,65 @@ dates:
   posted: 2023-01-04
 ---
 
-<Concept opened>
-
 ## Content-based
 
 Content-based messaging systems are a subset of the [publish/subscribe](#publishsubscribe) model, and contrast with [topic-based](#topic-based) systems in terms of the way messages are [filtered](#filtering)/routed. In a content-based messaging system, the subscriber specifies the properties of the messages they want to receive, based on the message's attributes or content. Message delivery is therefore selective, and messages are only delivered to a subscriber if the attributes or content match the constraints they set.
-
-</Concept>
-
-<Concept opened>
 
 ## Content-based deduplication
 
 Content-based deduplication is a setting available for [FIFO](#fifo) queues and topics. Enable content-based deduplication if the message body is guaranteed to be unique for each message. A unique hash value is generated from the body of each message, which is used as its deduplication ID. This avoids the need to set a deduplication ID when sending messages. Read more in our dedicated documentation on [creating queues](/serverless/messaging/how-to/create-manage-queues/).
 
-</Concept>
-
-<Concept>
-
 ## Credentials
 
 Credentials give services and platforms access to Scaleway Messaging and Queuing, enabling them to connect to the host system. Credentials are [protocol](#messaging-protocol)-specific: for SQS and SNS, different levels of permissions can be defined to write, read, or manage queues/topics, whereas NATS credentials give full read-write-manage access. Refer to our [Messaging and Queuing Reference Content](/serverless/messaging/reference-content/) for more information.
-
-</Concept>
-
-<Concept>
 
 ## Dead Letter Queue
 
 A **D**ead **L**etter **Q**ueue (DLQ), or **undelivered-message queue**, receives and holds messages that cannot be delivered to their destination queues. You may define an existing queue as a Dead Letter Queue.
 
-</Concept>
-
-<Concept>
-
 ## Fanout
 
 Fanout is a type of messaging pattern. A fanout exchange broadcasts messages to all queues/consumers it is aware of. This allows the same published message to be consumed by different consumers, who will process it in different ways. Each message is processed in the order in which it arrives.
-
-</Concept>
-
-<Concept>
 
 ## FIFO
 
 FIFO stands for **F**irst **I**n **F**irst **O**ut, and represents a type of queue or topic where the exact order of messages is preserved, and duplicate messages are not tolerated. As well as these specificities, FIFO queues and topics support all the same features as the [Standard](#standard) type. Consider using FIFO queues and topics for any use cases where the order of messages is critical, such as e-commerce order management systems, systems where one action should not happen until another has been completed, or first-come-first-served ticketing systems.
 
-</Concept>
-
-<Concept>
-
 ## Filtering
 
 In a [topic-based](#topic-based) system, where topics handle the logic, filtering is similar to routing. Messages are sent to defined topics, which can be thought of as filters in so far as subscribers can subscribe only to the topics they are interested in. In a [content-based](#content-based) system, filtering is carried out more directly by subscribers, who define filters for messages based on the content/attributes they want to receive.
-
-</Concept>
-
-<Concept>
 
 ## Long Polling
 
 Long polling is a technology where the client requests information from the server without expecting an immediate response. In [SQS](#sqs), this enables clients to wait for the system to get messages that are not immediately available.
 
-</Concept>
-
-<Concept>
-
 ## Message broker
 
 A message broker is a piece of software that allows applications, systems and services to communicate with each other and send/receive data. It facilitates the exchange of information by receiving messages from a producer, and transmitting them to a consumer. All communication with producers and consumers uses a [protocol](#messaging-protocol). There are two basic models of communication for message brokers: [publish/subscribe](#publishsubscribe) and [queuing](#queuing).
-
-</Concept>
-
-<Concept>
 
 ## Message retention period
 
 The message retention period is a setting that can be configured for an SQS queue. It represents the length of time (in seconds) that messages are kept in the queue before being deleted. Setting a longer message retention period allows for a longer interval between a message being sent and it being received. Read more in our dedicated documentation on [creating queues](/serverless/messaging/how-to/create-manage-queues/).
 
-</Concept>
-
-<Concept>
-
 ## Messaging and Queuing
 
 Scaleway's Messaging and Queuing product is a [message broker](#message-broker) tool that allows you to transfer messages between different microservices and platforms. This enables them to "talk" to each other effectively even if they are not otherwise compatible. Messaging and Queuing enables and simplifies microservices application development and allows you to build highly scalable, reliable, distributed applications.
-
-</Concept>
-
-<Concept>
 
 ## Messaging protocol
 
 A messaging protocol defines a structured way for users / platforms / services / applications to exchange data and messages, even if normally they do not "speak the same language". Protocols also describe how messages should be processed, prioritized, managed and routed. Messaging protocols currently supported by Scaleway Messaging and Queuing include [NATS](#nats), [SQS](#sqs) and [SNS](#sns).
 
-</Concept>
-
-<Concept>
-
 ## Namespace
 
 Messaging and Queuing namespaces are now deprecated. Previously, you had to create a namespace, set to either NATS or SQS/SNS protocol, to set a scope for your queues, topics, and credentials. Now, you simply activate SQS and/or SNS and your credentials and queues are scoped to the Project it is activated in. For NATS, namespaces have been replaced by [NATS accounts](#nats-account), which set the scope for your queues and credentials.
-
-</Concept>
-
-<Concept>
 
 ## NATS
 
 The **N**eural **A**utonomic **T**ransport **S**ystem, or [NATS](https://nats.io/), is an open-source messaging system written in Go. It is part of the Cloud Native Computing Foundation (CNCF) and has more than 40 client language implementations. The application has been designed with performance, scalability, and ease of use in mind.
 
-</Concept>
-
-<Concept>
-
 ## NATS account
 
 A NATS account sets a scope for any NATS credentials, messages, queues and streams held within it. You can create one or multiple NATS accounts with Scaleway Messaging and Queuing. NATS accounts have replaced NATS [namespaces](#namespace).
-
-</Concept>
-
-<Concept>
 
 ## Protocol
 
@@ -143,66 +81,33 @@ To create a message broker configured for the NATS protocol, you must create a [
 
 For a message broker configured for the SQS or SNS protocols, you must activate the required protocol, and then create credentials for the protocol. Once activated, you get an endpoint/URL for your SQS or SNS message broker. You can activate both protocols: in this case, you must create separate credentials for each one, and they will each have a separate endpoint/URL.
 
-</Concept>
-
-<Concept>
-
 ## Publish/Subscribe
 
 Also known as "pub/sub", the publish/subscribe model provides a pattern or framework for the exchange of messages between publishers and subscribers. It contrasts with the [queuing](#queuing) model. The key feature of publish/subscribe is that messages are not sent to defined recipients. Instead, subscribers define the types of message they are interested in, and only receive messages matching their criteria. The publisher sends the message without knowing exactly who will receive it. The process of selecting which messages to receive is called [filtering](#filtering), which can be [topic-based](#topic-based) or [content-based](#content-based). The publish/subscribe model relies on a [message broker](#message-broker) to relay messages between publishers and subscribers.
-
-</Concept>
-
-<Concept>
 
 ## Queue
 
 Queues facilitate asynchronous communication between different microservices, applications, and platforms. You can create a queue, configure its delivery and message parameters, and then start sending messages to it. Messages are stored in the queue until they are processed and delivered, and deleted once consumed. [Read more about creating and configuring queues](/serverless/messaging/how-to/create-manage-queues/).
 
-</Concept>
-
-<Concept>
-
 ## Queue types
 
 When creating queues with Scaleway Messaging and Queuing SQS or SNS, two queue types are available. [Standard](#standard) queues provide at-least-once delivery, while [FIFO](#fifo) queues offer first-in-first-out delivery, and (unlike Standard queues) guarantee that messages are delivered in order and without duplication. [Content-based deduplication](#content-based-deduplication) is only available for FIFO queue types. Find out more about creating queues with our [dedicated documentation](/serverless/messaging/how-to/create-manage-queues/).
-
-</Concept>
-
-<Concept>
 
 ## Queuing
 
 The message queuing model provides a pattern or framework for sending messages, which contrasts with the [publish/subscribe](#publishsubscribe) model. Queuing is a form of asynchronous service-to-service communication. Whereas with the publish/subscribe model multiple subscribers can receive each message, with the queuing model, messages have just one destination. Messages are stored in the queue until they are processed and delivered, and they are deleted once consumed. This model is used in serverless and microservices architectures.
 
-</Concept>
-
-
-<Concept>
-
 ## Queue volume
 
 Queue volume is one of the factors affecting the billing of Scaleway Messaging and Queuing with SQS. Queue volume is calculated as the number of messages in a queue, multiplied by the message size. Or, the sum of the size of all messages in a queue.
-
-</Concept>
-
-<Concept>
 
 ## Routing
 
 In [topic-based](#topic-based) messaging, topics allow messages to be routed to the correct subscribers. Topics act as labels for each message, and the broker routes messages to subscribers who match the topic.
 
-</Concept>
-
-<Concept>
-
 ## SNS
 
 The **S**imple **N**otification **S**ervice, or SNS, is a [publish/subscribe](#publishsubscribe) notification service for the mass delivery of messages. SNS acts as a single message bus that can be sent to a variety of devices and platforms through a single code interface. It is also possible to adapt message formats to the particular needs of each platform.
-
-</Concept>
-
-<Concept>
 
 ## SQS
 
@@ -210,85 +115,42 @@ The **S**imple **Q**ueue **S**ervice, or SQS, is a distributed message [queuing]
 - **Standard** queues offer maximum throughput, best-effort ordering, and at-least-once delivery.
 - **FIFO** queues are designed to guarantee that messages are processed exactly once, in the exact order that they are sent.
 
-</Concept>
-
-<Concept>
-
 ## SQS/SNS
 
 SQS/SNS was previously a [namespace](#namespace) type available for Scaleway Messaging and Queuing. The two protocols have now been separated, and are now activated and deactivated separately.
-
-</Concept>
-
-<Concept>
 
 ## Standard
 
 Standard-type queues and topics represent the default queue/topic type, and offer an at-least-once message delivery system. Unlike [FIFO](#fifo) queues and topics, standard queues provide only best-effort attempts to deliver messages in order. At-least-once delivery means that it is possible under rare circumstances that the same message may be received more than once.
 
-</Concept>
-
-
-<Concept>
-
 ## Stream
 
 Distinct from traditional message brokers where messages are deleted once received/consumed, streams retain records of their events. A streaming broker is therefore often likened to a distributed append-only logs file, where every new message is added at the end of the persistent log. Each message can be delivered to one or more consumers.
-
-</Concept>
-
-<Concept>
 
 ## Stream volume
 
 Stream volume is one of the factors affecting the billing of Scaleway Messaging and Queuing with NATS. Stream volume is calculated as the number of messages in a stream, multiplied by the message size. Or, the sum of the size of all messages in a stream.
 
-</Concept>
-
-<Concept>
-
 ## Stream persistence
 
 Stream persistence is one of the factors affecting the billing of Scaleway Messaging and Queuing with NATS. Stream persistence is calculated as the total amount stored in a stream, multiplied by the duration it is stored for.
-
-</Concept>
-
-<Concept>
 
 ## Subscriber
 
 In [publish/subscribe](#publishsubscribe) systems such as [SNS](#sns), a subscriber is the entity (e.g. SQS queue, function, URL) that messages from topics are pushed to. Subscribers can filter messages based on their topic or content.
 
-</Concept>
-
-<Concept>
-
 ## Topic
 
 A topic is a communication channel used to send messages and notifications to subscribed endpoints or clients. Publishers send messages to topics, and those messages are received by subscribers. Subscribers can include Serverless Functions, SQS queues and HTTP/HTTPS endpoints. As such, topics decouple the publishing and the receiving of messages, allowing for flexibility and scalabilty in building loosely-coupled systems.
-
-</Concept>
-
-<Concept>
 
 ## Topic types
 
 When creating topics with Scaleway Messaging and Queuing SQS or SNS, two topic types are available. [Standard](#standard) topics provide at-least-once delivery, while [FIFO](#fifo) topics offer first-in-first-out delivery, and (unlike Standard topics) guarantee that messages are delivered in order and without duplication. [Content-based deduplication](#content-based-deduplication) is only available for FIFO topic types. Find out more about creating topics with our [dedicated documentation](/serverless/messaging/how-to/create-manage-topics/).
 
-</Concept>
-
-<Concept>
-
 ## Topic-based
 
 Topic-based messaging systems are a subset of the [publish/subscribe](#publishsubscribe) model, and contrast with [content-based](#content-based) systems. In a topic-based system, messages are published to "topics" or named logical channels. See [topic](#topic) for more information.
 
-</Concept>
-
-<Concept>
-
 ## Visibility timeout
 
 Visibility timeout is a setting that can be configured for an SQS queue. It represents the length of time (in seconds) during which, after a message is received, the queue hides it, so it cannot be received again by the same or other consumers. This is useful as the queue itself does not automatically delete messages once they are received, and so prevents consumers from receiving the same message many times before they have finished processing it. Read more in our dedicated documentation on [creating queues](/serverless/messaging/how-to/create-manage-queues/).
-
-</Concept>

--- a/serverless/sql-databases/concepts.mdx
+++ b/serverless/sql-databases/concepts.mdx
@@ -10,93 +10,62 @@ categories:
   - serverless
 ---
 
-<Concept opened>
 ## Active state
 
 A database is in an active state when it receives queries frequently (at least once every 5 minutes). If it receives no query for 5 minutes, the database switches to an idle state, and the billing for compute capacity stops.
-</Concept>
 
-<Concept opened>
- ## Autoscaling
+## Autoscaling
 
- Autoscaling can automatically scale your database resources up or down, depending on vCPU consumption.
-</Concept>
+Autoscaling can automatically scale your database resources up or down, depending on vCPU consumption.
 
-<Concept opened>
 ## Backup
 
 A database backup is a copy of the data stored in the database (including data structure, such as tables). Database backups in Serverless SQL Database are logical backups (as opposed to raw disk volume backups, also called "snapshots"). Database backups can be restored in the current database or any other PostgreSQL database and allows to recover from database crash, data corruption, or data loss.
-</Concept>
 
-<Concept opened>
 ## Cold start
 
 Cold start is the time an [idle](#idle) database takes to handle the first request. It usually takes less than five seconds.
-</Concept>
 
-<Concept>
 ## Connection pooling
 
 Connection pooling is the process of mutualizing client connections used to connect to the database. By default, connections to PostgreSQL databases use a lot of memory, which can have a significant impact on performance when hundreds of clients are connected to a database at the same time. With connection pooling, a common component (a "connection pooler", such as PgBouncer) connects to the database and maintains multiple connections to it. Clients then connect to the connection pooler instead of connecting directly to the database, allowing for better performance and more concurrent connections.  
-</Concept>
 
-<Concept>
 ## Credentials
 
 Credentials are the login and password (also called "username" and "password" in PostgreSQL vocabulary) used by a user or an application to connect to a database. With Scaleway Serverless SQL Databases, logins are [IAM principal IDs](/identity-and-access-management/iam/concepts/#principal) and passwords are [IAM secret keys](/identity-and-access-management/iam/concepts/#api-key).
-</Concept>
 
-<Concept>
 ## Database engine
 
 A database engine is the software that stores and retrieves your data from a database. Serverless SQL databases use the PostgreSQL engine.
-</Concept>
 
-<Concept>
 ## High availability
 
 Databases can become unavailable due to several issues (host crashes, disk corruption, network unavailability, etc.). High Availability ensures that databases stay available most of the time and recover quickly from issues so that applications relying on them remain available as well.
-</Concept>
 
-<Concept>
 ## Idle
 
 A database switches to an idle state if it receives no query for 5 minutes. You are not billed for compute resources while your database is in an idle state.
-</Concept>
 
-<Concept>
 ## Logs
 
 Logs register the activity of your database. They provide useful information for debugging or to know more about the behavior and activity of your databases.
-</Concept>
 
-<Concept>
 ## PostgreSQL
 
 PostgreSQL is an open source object-relational database system known for its reliability, robustness, and performance. 
-</Concept>
 
-<Concept>
 ## Region and AZ
 
 <Macro id="region-and-az" />
 
-</Concept>
-
-<Concept>
 ## Relational database
 
 A database type that relies on the relational model and that can be queried using the SQL language. In the relational model, different data objects are stored in different tables, which can be linked by common IDs, or keys. Relational databases provide an intuitive, straightforward way of representing data in tables, which favors data normalization, and provide the strongest data consistency guarantees (compared to NoSQL alternatives).
-</Concept>
 
-<Concept>
 ## Serverless database
 
 A serverless database is a fully managed database-as-a-service (DBaaS) that allocates and scales compute and storage resources automatically to match the incoming workload.
-</Concept>
 
-<Concept>
 ## Status
 
 The status of a database changes according to its activity and provides information on ongoing operations.
-</Concept>

--- a/storage/block/concepts.mdx
+++ b/storage/block/concepts.mdx
@@ -11,15 +11,9 @@ categories:
   - storage
 ---
 
-<Concept opened>
-
 ## Block device
 
 A block device is a storage volume on a network-connected storage system that is exposed to the guest operating system as if it were a physical disk.
-
-</Concept>
-
-<Concept opened>
 
 ## IOPS
 
@@ -30,28 +24,14 @@ Scaleway Block Storage Low Latency offers two IOPS limits:
 - 5000 IOPS
 - 15 000 IOPS
 
-</Concept>
-
-<Concept opened>
-
 ## Local volume
 
 The local volume of an Instance is an all SSD-based storage solution, using a RAID array for redundancy and performance, that is hosted on the local hypervisor.
-
-</Concept>
-
-<Concept opened>
 
 ## Storage Area Networks (SANs)
 
 A Storage Area Network (SAN) consists of interconnected machines, network infrastructure and storage devices designed for performance and high-availability. Unlike a Network Attached Storage (NAS) which stores all data on a [file level](https://www.scaleway.com/en/blog/understanding-the-different-types-of-storage/#what-is-file-storage), the SAN stores all data on [block level](https://www.scaleway.com/en/blog/understanding-the-different-types-of-storage/#what-is-block-storage), this makes SAN a perfect solution for business critical applications and input/output intense operations like relational databases. The SAN is a network-connected solution, that operates independently from the local hypervisor hosting the virtual Instance. The storage capacity of the block devices on the SAN can be tailored towards your requirements.
 
-</Concept>
-
-<Concept opened>
-
 ## Volumes
 
 A storage space used by your Instances. Several volumes can be [attached to an Instance](/storage/block/how-to/attach-a-volume/). In addition, they can be [snapshotted](/storage/block/how-to/create-a-snapshot/), [mounted](/storage/block/api-cli/managing-a-volume/#mounting-and-using-a-volume) or [unmounted](/storage/block/api-cli/unmounting-a-volume/).
-
-</Concept>

--- a/storage/object/concepts.mdx
+++ b/storage/object/concepts.mdx
@@ -11,23 +11,13 @@ categories:
   - object-storage
 ---
 
-<Concept opened>
-
 ## Access control list (ACL)
 
 Access control lists (ACL) are subresources attached to buckets and objects. They define which Scaleway users have access to the attached object/bucket, and the type of access they have. Whenever a user makes a request against a resource, s3 checks its ACL and verifies that they have permission to carry out the request.
 
-</Concept>
-
-<Concept opened>
-
 ## Bucket
 
 A group of objects sharing a common denominator. It can contain as many objects as you want.
-
-</Concept>
-
-<Concept opened>
 
 ## Bucket policy
 
@@ -35,17 +25,9 @@ A group of objects sharing a common denominator. It can contain as many objects 
 
 Bucket policies are assigned to [principals](#principal), who will be allowed or denied access to resources and actions.
 
-</Concept>
-
-<Concept opened>
-
 ## Bucket website
 
 A feature that allows you to [host static websites on buckets](/storage/object/how-to/use-bucket-website/).
-
-</Concept>
-
-<Concept>
 
 ## Endpoint
 
@@ -61,17 +43,9 @@ An endpoint represents one end of a communication channel. In the case of Object
     - Region: `pl-waw`
     - Endpoint: `https://s3.pl-waw.scw.cloud/`
 
-</Concept>
-
-<Concept>
-
 ## Legal hold
 
 A legal hold provides the same protection as a retention period, but it has no expiration date. It takes the form of an ON/OFF switch that can be applied to every object in a locked bucket, independently of the lock configuration, or the object retention or its age. It can be applied to objects which are locked. A legal hold remains in place until you explicitly remove it.
-
-</Concept>
-
-<Concept>
 
 ## Lifecycle configuration
 
@@ -82,10 +56,6 @@ A lifecycle configuration is a set of rules that defines actions applied to a gr
 
 Find out more in our how-to on [managing lifecycle rules from the console](/storage/object/how-to/manage-lifecycle-rules/).
 
-</Concept>
-
-<Concept>
-
 ## Metrics
 
 A feature that allows you to [monitor your Object Storage consumption](/storage/object/how-to/monitor-consumption/) with a graphical interface from your Scaleway console. Object Storage Metrics provide information about:
@@ -93,10 +63,6 @@ A feature that allows you to [monitor your Object Storage consumption](/storage/
 - the number of objects in a bucket
 - the storage used
 - the outgoing bandwidth usage of a bucket
-
-</Concept>
-
-<Concept>
 
 ## Multipart uploads
 
@@ -108,17 +74,9 @@ A multipart upload consists of three steps:
 - The different parts are uploaded
 - Object Storage constructs the object from the uploaded parts
 
-</Concept>
-
-<Concept>
-
 ## Object
 
 An object is a file and the metadata that describes it. Each object has a **key name**, which is a unique identifier (such as `images/photo01.jpg`) within a [bucket](#bucket).
-
-</Concept>
-
-<Concept>
 
 ## Object lock
 
@@ -126,27 +84,15 @@ An S3 API feature that allows users to lock objects to prevent them from being d
 
 The feature uses a write-once-read-many (WORM) data protection model. This model is generally used in cases where data cannot be altered once it has been written. It provides regulatory compliance and protection against ransomware and malicious or accidental deletion of objects.
 
-</Concept>
-
-<Concept>
-
 ## Object Storage
 
 A storage service based on the S3 protocol. It allows you to store different types of objects (documents, images, videos, etc.) and distribute them instantly, anywhere in the world. You can upload, download, and visualize stored objects.
 
 Contrary to other storage types such as block devices or file systems, Object Storage bundles the data itself along with metadata [tags](#tags) and a [prefix](#prefix), rather than a file name and a file path.
 
-</Concept>
-
-<Concept>
-
 ## Parts
 
 Parts are the chunks of data that compose multipart objects.
-
-</Concept>
-
-<Concept>
 
 ## Prefix
 
@@ -163,25 +109,13 @@ As an example, consider the following objects:
 
 Creating a [lifecycle rule](/storage/object/how-to/manage-lifecycle-rules/) based on the `images/` prefix will apply to all objects, whereas a rule based on `images/ph` will only apply to the first two objects.
 
-</Concept>
-
-<Concept>
-
 ## Principal
 
 A principal is the target of a [bucket policy](#bucket-policy). They acquire the rights and permissions defined in the policy. The principal of a bucket policy can be an IAM user or application. Bucket policies can have several principals attached to them.
 
-</Concept>
-
-<Concept>
-
 ## Region and Availability Zone
 
 <Macro id="region-and-az" />
-
-</Concept>
-
-<Concept>
 
 ## Retention modes
 
@@ -197,33 +131,17 @@ Object Lock provides two modes to manage object retention, **Compliance** and **
   >
 - When the above criteria are met, you'll be able to use delete-object --version-id to permanently delete an object.
 
-</Concept>
-
-<Concept>
-
 ## Retention period
 
 A retention period specifies a fixed period for which an object remains locked. During this period, your object is WORM-protected and cannot be overwritten or deleted.
-
-</Concept>
-
-<Concept>
 
 ## S3
 
 S3 is the de facto Object Storage protocol. Scaleway Object Storage officially supports a subset of S3. The list of supported features is described in the [Object Storage API documentation](/storage/object/api-cli/using-api-call-list/).
 
-</Concept>
-
-<Concept>
-
 ## Signature V2, Signature V4
 
 When you send HTTP requests to Object Storage, you sign the requests so that we can identify who sent them. You sign requests with your Scaleway access key, which consists of an access key and a secret key. The two main s3 protocols for authentication are Signature v2 and Signature v4. Signature v4 is more recent and it is the recommended version.
-
-</Concept>
-
-<Concept>
 
 ## Storage class
 
@@ -233,28 +151,14 @@ You can choose a storage class depending on your use case:
 - `One Zone - Infrequent Access `: the One Zone - IA class is a good choice for storing secondary backup copies or easily re-creatable data. It is available in [all regions](#region-and-availability-zone).
 - `Glacier`: Archived storage - prices are lower, but it needs to be restored first to be accessed. It is available in the `fr-par` and `nl-ams` regions.
 
-</Concept>
-
-<Concept>
-
 ## Tags
 
 Tags are key-value pairs you can assign to your buckets and objects to easily sort them, and for fine-grained access control using [bucket policies](#bucket-policy). Both the key and the value can be customized according to your needs.
-
-</Concept>
-
-<Concept>
 
 ## Visibility
 
 Bucket visibility specifies whether the list of objects in a bucket is publicly visible or not. It does not affect the visibility of objects themselves.
 
-</Concept>
-
-<Concept>
-
 ## Versioning
 
 Versioning allows you to keep multiple variants of an object in the same bucket. When [enabled](/storage/object/how-to/enable-bucket-versioning/), you can list archived versions of an object or permanently delete an archived version.
-
-</Concept>


### PR DESCRIPTION
### Description

Removed <concept> markdown from Documentation pages so it will be ready for the redesign.
