### PR TITLE
feat(changelog): kubernetes-security-runc-bumped-to-1112-for-cve-2024-21 2024-02-06

### DIFF
--- a/changelog/february2024/2024-02-06-kubernetes-security-runc-bumped-to-1112-for-cve-2024-21.mdx
+++ b/changelog/february2024/2024-02-06-kubernetes-security-runc-bumped-to-1112-for-cve-2024-21.mdx
@@ -1,0 +1,18 @@
+---
+title: Runc bumped to 1.1.12 for CVE-2024-21626
+status: security
+author:
+    fullname: 'Join the #k8s channel on Slack.'
+    url: 'https://slack.scaleway.com'
+date: 2024-02-06
+category: containers
+product: kubernetes
+---
+
+[CVE-2024-21626](https://snyk.io/blog/leaky-vessels-docker-runc-container-breakout-vulnerabilities/) is a recently disclosed security issue affecting the `runc` component.
+
+To apply the patch, managed Kubernetes services customers are recommended the following actions:
+ 
+- Kubernetes clusters running on 1.24: replacing nodes
+- Kubernetes clusters running on 1.25+: upgrading to the latest k8s patch release
+


### PR DESCRIPTION
Reporter: tgenaitay

This PR is a new changelog contribution. It has been created automatically.

Make sure to review it carefully before merging it.