### PR TITLE
docs(components): add illustration list examples

### DIFF
--- a/components.mdx
+++ b/components.mdx
@@ -868,3 +868,10 @@ The above text come from a macro!
 
 ⚠️ Do not forget to add the `id` props on `<Tabs>`. It's needed to distinguish multiples tabs snippet on a same page ⚠️
 
+---
+
+## Ultraviolet illustrations
+
+Here is a list of current Ultraviolet illustrations available
+
+<UvIllustrations />


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

Please describe what you added or changed.

The idea of this pull request is to let docs team be able to know which product logo is available currently in docs in order to let them choose for `ProductHeader` or `ClickableBanner`
