### PR TITLE
fix(es): add more info about proxy protocol

### DIFF
--- a/network/load-balancer/concepts.mdx
+++ b/network/load-balancer/concepts.mdx
@@ -150,7 +150,7 @@ A protocol is a standard format for communication over a network. When you confi
 
 ## Proxy protocol
 
-Proxy protocol is an internet protocol used to transfer connection information from the client (e.g. the client's IP address), through the Load Balancer and on to the destination server.
+Proxy protocol is an internet protocol used to transfer connection information from the client (e.g. the client's IP address), through the Load Balancer and on to the destination server. For full information, see our [dedicated documentation](/network/load-balancer/reference-content/configuring-backends/#proxy-protocol).
 
 ## Round-robin
 

--- a/network/load-balancer/concepts.mdx
+++ b/network/load-balancer/concepts.mdx
@@ -27,7 +27,7 @@ Accessibility cannot be modified after creation of the Load Balancer.
 
 ## Backends
 
-Each Load Balancer is configured with one or several backends. A backend represents a set of [backend servers](#backend-servers) that the Load Balancer's frontend forwards requests to using the specified configuration (port, protocol, proxy protocol etc.). Grouping backend servers into a backend allows load to be balanced between them based on a defined load-balancing algorithm configured as a backend setting. You can [add and manage backends via the console](/network/load-balancer/how-to/manage-frontends-and-backends/).
+Each Load Balancer is configured with one or several backends. A backend represents a set of [backend servers](#backend-servers) that the Load Balancer's frontend forwards requests to using the specified configuration (port, protocol, Proxy Protocol etc.). Grouping backend servers into a backend allows load to be balanced between them based on a defined load-balancing algorithm configured as a backend setting. You can [add and manage backends via the console](/network/load-balancer/how-to/manage-frontends-and-backends/).
 
 ## Backend servers
 
@@ -148,9 +148,9 @@ When you attach a private Load Balancer to multiple Private Networks, it has an 
 
 A protocol is a standard format for communication over a network. When you configure your Load Balancer's backend, you choose a protocol (HTTP, HTTPs or TCP) which it uses to send and receive data.
 
-## Proxy protocol
+## Proxy Protocol
 
-Proxy protocol is an internet protocol used to transfer connection information from the client (e.g. the client's IP address), through the Load Balancer and on to the destination server. For full information, see our [dedicated documentation](/network/load-balancer/reference-content/configuring-backends/#proxy-protocol).
+Proxy Protocol is an internet protocol used to transfer connection information from the client (e.g. the client's IP address), through the Load Balancer and on to the destination server. For full information, see our [dedicated documentation](/network/load-balancer/reference-content/configuring-backends/#proxy-protocol).
 
 ## Round-robin
 

--- a/network/load-balancer/reference-content/configuring-backends.mdx
+++ b/network/load-balancer/reference-content/configuring-backends.mdx
@@ -64,9 +64,11 @@ Passing client connection information to the backend servers is beneficial for u
 - Applications which require the client's IP address for security measures or IP-based restrictions
 - Applications which require the client's IP address for geolocation or personalized content
 
-If none of the use cases above apply to the applications or metrics running on your backend server, it may not be necessary for you to activate Proxy Protocol.
+If none of the use cases above apply to the applications or metrics running on your backend server, it may not be necessary for you to activate Proxy Protocol. 
 
-In order to work, the backend server must support the selected Proxy Protocol. Different server softwares understand and process Proxy Protocol header information in different ways, and you may need to carry out specific configuration steps to ensure it is correctly received and processed. For example, for Nginx you might need to install and configure `ngx_http_realip_module`. Consult the documentation for your own server software.
+Also, note that Proxy Protocol is more commonly activated for Load Balancers using TCP protocol. Load Balancers using HTTP protocol already pass information about the client IP address to the backend servers via an HTTP `X-Forwarded-For` [header](https://en.wikipedia.org/wiki/X-Forwarded-For), without needing to activate Proxy Protocol. If your Load Balancer uses HTTP protocol and you do not require the standardized information in the Proxy Protocol headers at the backend server, the `X-Forwarded-For` headers may be sufficient.
+
+In order for Proxy Protocol to work, the backend server must support the selected Proxy Protocol. Different server softwares understand and process Proxy Protocol header information in different ways, and you may need to carry out specific configuration steps to ensure it is correctly received and processed. For example, for Nginx you might need to install and configure `ngx_http_realip_module`. Consult the documentation for your own server software.
 
 #### Proxy Protocol versions
 
@@ -74,8 +76,8 @@ If you choose to activate Proxy Protocol on your Load Balancer, you are prompted
 
 | Version           | Advantages                                                                                           | Disadvantages      |
 |-------------------|------------------------------------------------------------------------------------------------------|--------------------|
-| Proxy Protocol v1 | - Plain text (ASCII) human-readable headers <br /> - Widely supported <br /> - Easy to troubleshoot  | - No support for IPv6 addresses <br />- Header format not as efficient as v2 |
-| Proxy Protocol v2 | - Binary, TLV format headers <br /> - Efficient header format, reduced overhead for high throughput scenarios <br /> - IPv6 addresses supported <br /> - Extensible and future-proof <br />- Enhanced header security | - Less widely supported by backend servers <br /> - Not human-readable: harder to troubleshoot |
+| Proxy Protocol v1 | - Plain text (ASCII) human-readable headers <br /> - Widely supported <br /> - Easy to troubleshoot  | - Header format not as efficient as v2 |
+| Proxy Protocol v2 | - Binary, TLV format headers <br /> - Efficient header format, reduced overhead for high throughput scenarios <br /> - Extensible and future-proof <br />- Enhanced header security | - Less widely supported by backend servers <br /> - Not human-readable: harder to troubleshoot |
 | Proxy Protocol v2-ssl | - As for v2 <br /> - SSL information extension added: information on client's SSL connection settings | - As for v2 |
 | Proxy Protocol v2-ssl-cn | - As for v2-ssl <br /> - Common name from subject of client's certificate added (if any) | - As for v2 |
 

--- a/network/load-balancer/reference-content/configuring-backends.mdx
+++ b/network/load-balancer/reference-content/configuring-backends.mdx
@@ -16,7 +16,7 @@ dates:
 
 ## Backend overview
 
-Each Load Balancer is configured with one or several backends. A backend represents a set of backend servers that the Load Balancer’s frontend(s) forwards requests to using the specified configuration (port, protocol, proxy protocol etc.).
+Each Load Balancer is configured with one or several backends. A backend represents a set of backend servers that the Load Balancer’s frontend(s) forwards requests to using the specified configuration (port, protocol, Proxy Protocol etc.).
 
 You can create and configure frontends and backends [while creating a Load Balancer](/network/load-balancer/how-to/create-frontends-backends/#how-to-create-a-backend-during-creation-of-your-load-balancer) or choose to create an “empty” Load Balancer and [add frontends and backends](/network/load-balancer/how-to/create-frontends-backends/#how-to-create-a-backend-after-creation-of-your-load-balancer) later on.
 

--- a/network/load-balancer/reference-content/configuring-backends.mdx
+++ b/network/load-balancer/reference-content/configuring-backends.mdx
@@ -55,16 +55,33 @@ This setting mostly concerns those using self-signed certificates on the backend
 
 Note that the same Verify Certificate setting you select here will also be used for [health checks](/network/load-balancer/reference-content/configuring-health-checks/), and cannot be overridden.
 
-### Proxy protocol
+### Proxy Protocol
 
-Proxy protocol enables the original client IP address to be passed to the backend server in a standardized way. However, in order to work, the backend server must support the selected proxy protocol. 
+If you activate Proxy Protocol, the Load Balancer forwards information about the original client's connection, such as their IP address and port, to the backend servers. This is achieved by adding the information to the headers of the TCP stream. The exact information included in the header depends on the version of Proxy Protocol that is chosen (see below).
 
-If you choose to activate proxy protocol, the following versions are available:
+Passing client connection information to the backend servers is beneficial for use cases including:
+- Preserving the client's real IP address for your backend servers' logs and metrics
+- Applications which require the client's IP address for security measures or IP-based restrictions
+- Applications which require the client's IP address for geolocation or personalized content
 
-* **Proxy protocol v1**: Version one (text format).
-* **Proxy protocol v2**: Version two (binary format).
-* **Proxy protocol v2-ssl**: Version two with SSL information extension added, which provides information on SSL connection settings originally sent by the client.
-* **Proxy protocol v2-ssl-cn**:  Version two with SSL information extension added as above, as well as the common name from the subject of the client certificate (if any).
+If none of the use cases above apply to the applications or metrics running on your backend server, it may not be necessary for you to activate Proxy Protocol.
+
+In order to work, the backend server must support the selected Proxy Protocol. Different server softwares understand and process Proxy Protocol header information in different ways, and you may need to carry out specific configuration steps to ensure it is correctly received and processed. For example, for Nginx you might need to install and configure `ngx_http_realip_module`. Consult the documentation for your own server software.
+
+#### Proxy Protocol versions
+
+If you choose to activate Proxy Protocol on your Load Balancer, you are prompted to select one of the following versions:
+
+| Version           | Advantages                                                                                           | Disadvantages      |
+|-------------------|------------------------------------------------------------------------------------------------------|--------------------|
+| Proxy Protocol v1 | - Plain text (ASCII) human-readable headers <br /> - Widely supported <br /> - Easy to troubleshoot  | - No support for IPv6 addresses <br />- Header format not as efficient as v2 |
+| Proxy Protocol v2 | - Binary, TLV format headers <br /> - Efficient header format, reduced overhead for high throughput scenarios <br /> - IPv6 addresses supported <br /> - Extensible and future-proof <br />- Enhanced header security | - Less widely supported by backend servers <br /> - Not human-readable: harder to troubleshoot |
+| Proxy Protocol v2-ssl | - As for v2 <br /> - SSL information extension added: information on client's SSL connection settings | - As for v2 |
+| Proxy Protocol v2-ssl-cn | - As for v2-ssl <br /> - Common name from subject of client's certificate added (if any) | - As for v2 |
+
+For a full specification of the header formats in each case, see the [HAProxy](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt) documentation.
+
+Ensure that your backend server is correctly configured to handle whichever version of Proxy Protocol you choose.
 
 ## Configuring traffic management
 

--- a/network/load-balancer/reference-content/configuring-health-checks.mdx
+++ b/network/load-balancer/reference-content/configuring-health-checks.mdx
@@ -67,22 +67,22 @@ This setting is inherited from the [backend configuration](/network/load-balance
 
 The above also applies if you edit your backend settings after creating the backend: if you change your **Verify Certificate** setting in the backend, configuration the new setting will also be applied to the health check.
 
-## Proxy protocol
+## Proxy Protocol
 
-Proxy protocol enables the original client IP address to be passed to the backend server in a standardized way during health checks. Note that the backend server must support the selected proxy protocol. 
+Proxy Protocol enables the original client IP address to be passed to the backend server in a standardized way during health checks. Note that the backend server must support the selected Proxy Protocol. 
 
-The following versions of proxy protocol are available:
+The following versions of Proxy Protocol are available:
 
-* **Proxy protocol v1**: Version one (text format).
-* **Proxy protocol v2**: Version two (binary format).
-* **Proxy protocol v2-ssl**: Version two with SSL information extension added, which provides information on SSL connection settings originally sent by the client.
-* **Proxy protocol v2-ssl-cn**:  Version two with SSL information extension added as above, as well as the common name from the subject of the client certificate (if any).
+* **Proxy Protocol v1**: Version one (text format).
+* **Proxy Protocol v2**: Version two (binary format).
+* **Proxy Protocol v2-ssl**: Version two with SSL information extension added, which provides information on SSL connection settings originally sent by the client.
+* **Proxy Protocol v2-ssl-cn**:  Version two with SSL information extension added as above, as well as the common name from the subject of the client certificate (if any).
 
-If you activated proxy protocol on your [backend configuration](/network/load-balancer/reference-content/configuring-backends/#proxy-protocol), it will also be activated by default for your health checks. Note that:
-- You can choose to override the inherited setting and deactivate proxy protocol for health checks if you wish.
-- If you keep proxy protocol activated for health checks, the proxy protocol version is inherited from the backend configuration and cannot be overridden.
+If you activated Proxy Protocol on your [backend configuration](/network/load-balancer/reference-content/configuring-backends/#proxy-protocol), it will also be activated by default for your health checks. Note that:
+- You can choose to override the inherited setting and deactivate Proxy Protocol for health checks if you wish.
+- If you keep Proxy Protocol activated for health checks, the Proxy Protocol version is inherited from the backend configuration and cannot be overridden.
 
-If you deactivated proxy protocol on your backend, it will also be deactivated for health checks, and you cannot override this setting. That is to say, you cannot have proxy protocol deactivated on the general backend configuration, but activated for health checks.
+If you deactivated Proxy Protocol on your backend, it will also be deactivated for health checks, and you cannot override this setting. That is to say, you cannot have Proxy Protocol deactivated on the general backend configuration, but activated for health checks.
 
 ## Advanced health check settings
 


### PR DESCRIPTION
In response to user testing showing that Proxy Protocol confused users (especially the different versions, and what happens if they activate it or not), enrich the doc about Proxy Protocol.

Also, Proxy Protocol should always be capitalized as a specific named protocol - correct this in the doc.

After doc is enriched, look at how to better integrate this doc/explanation in the console.
