### PR TITLE
fix(lb): reformat balancing method info

### DIFF
--- a/network/load-balancer/reference-content/configuring-backends.mdx
+++ b/network/load-balancer/reference-content/configuring-backends.mdx
@@ -70,11 +70,13 @@ If you choose to activate proxy protocol, the following versions are available:
 
 ### Balancing method
 
-Load Balancers support three different modes of balancing load (requests) between backend servers:
+Load Balancers support three different modes of balancing load (requests) between backend servers. The table below shows the methods, and their advantages and use-cases.
 
-* **Round-robin**: Requests are sent to each backend server in turn, with the Load Balancer acting like a turnstile. This is the most frequently used balancing method, and the easiest to implement. It is well-suited to infrastructures that have identical backend servers.
-* **Least connections**: Each request is assigned to the server with the fewest active connections. This method works best when it is expected that sessions will be long, e.g. LDAP, SQL TSE. It is less well-suited to protocols with typically short sessions like HTTP.
-* **First available**: Each request is directed towards the first backend server with [available connection slots](#backend-protection). Once a server reaches its limit of maximum simultaneous connections, requests are directed to the next server. This method uses the smallest number of servers at any given time, which can be useful if, for example, you sometimes want to power off extra servers during off-peak hours.
+| Method             | Description                              |Suitable for                                     |
+|--------------------|----------------------------------|---------------------------------------------------------|
+| Round robin        | Requests are sent to each backend server in turn, with the Load Balancer acting like a turnstile. <br/> This is the most frequently-used balancing method, and the easiest to implement. | The majority of infrastructures, where backend servers are identical or very similar. |
+| Least connections  | Each request is assigned to the server with the fewest active connections at the time. | Infrastructures where it is expected that sessions will be long, e.g. LDAP, SQL TSE. <br/> Less well-suited to protocols with typically short sessions, like HTTP. |
+| First available    | Each request is directed towards the first backend server with available connection slots, based on the [max connections](#backend-protection) setting. <br/> Once a server reaches its limit of maximum simultaneous connections, requests are directed to the next server. | Infrastructures where you want to use the smallest number of backend servers at any given time (e.g. you want to power off extra servers during off-peak hours.) |
 
 ### Server IPs (backend servers)
 


### PR DESCRIPTION
Reformat and rephrase the existing information on balancing methods, so that it's more clear for users.

![image](https://github.com/scaleway/docs-content/assets/36301604/7f34092a-2224-4837-9bff-688233e9232c)
