### PR TITLE
fix(docs): modify changelog vpc category

### DIFF
--- a/changelog/july2023/2023-07-18-private-networks-changed-virtual-private-cloud-is.mdx
+++ b/changelog/july2023/2023-07-18-private-networks-changed-virtual-private-cloud-is.mdx
@@ -6,7 +6,7 @@ author:
     url: 'https://slack.scaleway.com'
 date: 2023-07-18
 category: network
-product: private-networks
+product: vpc
 ---
 
 VPC allows you to quickly and seamlessly secure all your application architecture's resources from external networks. Additionally, your infrastructure will benefit from improved resiliency as VPC is now regionalized across the Availability Zones by default.

--- a/changelog/march2023/2023-03-30-private-networks-added-regional-private-networks-is.mdx
+++ b/changelog/march2023/2023-03-30-private-networks-added-regional-private-networks-is.mdx
@@ -6,7 +6,7 @@ author:
     url: 'https://slack.scaleway.com/'
 date: 2023-03-30
 category: network
-product: private-networks
+product: vpc
 ---
 
 Regional Private Networks allow you to connect resources across multiple AZs within the same region and are currently only available in the PAR region. 

--- a/changelog/network/june2022/2022-06-13-private-networks-added-smtp-public-gw.mdx
+++ b/changelog/network/june2022/2022-06-13-private-networks-added-smtp-public-gw.mdx
@@ -6,7 +6,7 @@ author:
     url: 'https://slack.scaleway.com'
 date: 2022-06-13
 category: network
-product: private-networks
+product: vpc
 ---
 
 Enable SMTP traffic on VPC Public Gateway to allow sending emails from resources located inside your VPC (ports `25`, `465`, `587`, and `2525`).

--- a/menu/changelogs.json
+++ b/menu/changelogs.json
@@ -163,8 +163,8 @@
   {
     "items": [
       {
-        "category": "private-networks",
-        "label": "Private Networks"
+        "category": "vpc",
+        "label": "VPC"
       },
       {
         "category": "public-gateways",

--- a/network/vpc/index.mdx
+++ b/network/vpc/index.mdx
@@ -85,6 +85,6 @@ meta:
 ## Changelog
 
 <ChangelogList
-    productName="private-networks"
+    productName="vpc"
     numberOfChanges={3}
 />


### PR DESCRIPTION
Modify the changelog category so that it's "VPC" (vpc) instead of "Private Networks" (private-networks)
