### PR TITLE
feat(cockpit): add information about the alert manager

### DIFF
--- a/observability/cockpit/concepts.mdx
+++ b/observability/cockpit/concepts.mdx
@@ -18,12 +18,16 @@ Active series refer to [time series](#time-series) for which the latest [samples
 
 Alerting detects complex conditions defined by a rule and keeps you aware of issues in your environments. When a condition defined by a rule is met, the rule tracks it as an alert and responds by triggering one or more actions.
 
+<Message type="important">
+ The **Grafana alert manager** on the Grafana interface is inactive. We strongly recommend that you select the **Scaleway Alerting** alert manager.
+</Message>
+
 ## Alert manager
 
 Scaleway's alert manager allows you to manage and respond to alerts. It handles alerts sent when the alerting rules we run are firing. The alert manager triggers alerts (e.g. emails or texts) if a criteria you have configured on your applications' metrics and logs is activated.
 
-<Message type="tip">
-Select **Scaleway Alerting** when choosing the Alert manager if you want to manage your alerts using Grafana.
+<Message type="important">
+ The **Grafana alert manager** on the Grafana interface is inactive. We strongly recommend that you select the **Scaleway Alerting** alert manager if you want to manage your alerts using Grafana.
 </Message>
 
 ## Alerting rules

--- a/observability/cockpit/concepts.mdx
+++ b/observability/cockpit/concepts.mdx
@@ -19,7 +19,7 @@ Active series refer to [time series](#time-series) for which the latest [samples
 Alerting detects complex conditions defined by a rule and keeps you aware of issues in your environments. When a condition defined by a rule is met, the rule tracks it as an alert and responds by triggering one or more actions.
 
 <Message type="important">
- The **Grafana alert manager** on the Grafana interface is inactive. We strongly recommend that you select the **Scaleway Alerting** alert manager.
+ The **Grafana alert manager** on the Grafana interface is inactive. We strongly recommend that you select the **Scaleway Alerting** alert manager if you want to manage your alerts using Grafana.
 </Message>
 
 ## Alert manager

--- a/observability/cockpit/how-to/configure-alerts-for-scw-resources.mdx
+++ b/observability/cockpit/how-to/configure-alerts-for-scw-resources.mdx
@@ -20,6 +20,7 @@ This page shows you how to configure managed alerts for Scaleway resources using
   - You have created Scaleway resources to monitor
   - You have [created your Grafana credentials](/observability/cockpit/how-to/retrieve-grafana-credentials/) and selected the **Editor** role
   - You have [activated managed alerts and created at least one contact point](/observability/cockpit/how-to/activate-managed-alerts/)
+  - You are using the **Scaleway Alerting** alert manager
 </Message>
 
 1. Click **Cockpit** in the Observability section of the [console](https://console.scaleway.com/) side menu. The **Cockpit** overview page displays.
@@ -28,11 +29,11 @@ This page shows you how to configure managed alerts for Scaleway resources using
 4. Click the **Toggle menu** then click **Alerting**.
 5. Click **Alert rules** and **+ New alert rule**.
 6. Scroll down to the **Define query and alert condition** section and click **Switch to data source-managed alert rule**.
-    <Message type="note">
-     This allows you to configure alert rules managed by the data source of your choice, instead of using Grafana's managed alert rules.
+    <Message type="important">
+     - This allows you to configure alert rules managed by the data source of your choice, instead of using Grafana's managed alert rules.
     </Message>
 7. Type in the name for your alert.
-8. Select the data source you want to configure alerts for. For the sake of this documentation we are choosing the **Scaleway Metrics** data source.
+8. Select the data source you want to configure alerts for. For the sake of this documentation, we are choosing the **Scaleway Metrics** data source.
 9. In the **Metrics browser** drop-down, select the metric you want to configure an alert for. For the sake of this documentation, we are choosing the `instance_server_cpu_seconds_total` metric.
 10. Select labels that apply to the metric you have selected in the previous step, to target your desired resources and fine-tune your alert.
 11. Select one or more values fo your labels.

--- a/observability/cockpit/how-to/configure-alerts-for-scw-resources.mdx
+++ b/observability/cockpit/how-to/configure-alerts-for-scw-resources.mdx
@@ -20,7 +20,7 @@ This page shows you how to configure managed alerts for Scaleway resources using
   - You have created Scaleway resources to monitor
   - You have [created your Grafana credentials](/observability/cockpit/how-to/retrieve-grafana-credentials/) and selected the **Editor** role
   - You have [activated managed alerts and created at least one contact point](/observability/cockpit/how-to/activate-managed-alerts/)
-  - You are using the **Scaleway Alerting** alert manager
+  - You are using the **Scaleway Alerting** alert manager in Grafana
 </Message>
 
 1. Click **Cockpit** in the Observability section of the [console](https://console.scaleway.com/) side menu. The **Cockpit** overview page displays.


### PR DESCRIPTION
The Grafana alert manager is inactive in Grafana, and users should select the **Scaleway Alerting** alert manager. I have added this information in the relevant documentation pages 
