### PR TITLE
style(icon): change iam icon to match UV component

### DIFF
--- a/menu/changelogs.json
+++ b/menu/changelogs.json
@@ -82,7 +82,7 @@
     ],
     "category": "security-identity",
     "label": "Security & Identity",
-    "icon": "iam"
+    "icon": "security"
   },
   {
     "items": [


### PR DESCRIPTION
### Description

Changing the value of the "Security and Identity" icon so it fits the value of the Ultraviolet `<CategoryIcon />` component.

https://storybook.ultraviolet.scaleway.com/?path=/docs/icons-categoryicon--docs

![image](https://github.com/scaleway/docs-content/assets/121877925/9ef43a1d-b131-433e-85ce-cd00fd37d82f)

Preview of the filters in the future changelog page : 

![image](https://github.com/scaleway/docs-content/assets/121877925/f4924129-283a-44ca-89d5-12c9188f93c0)


