### PR TITLE
add(cockpit): added info on pricing plan pricing

### DIFF
--- a/faq/cockpit.mdx
+++ b/faq/cockpit.mdx
@@ -24,6 +24,8 @@ Scaleway’s monitoring is included for free for a period of 30 days for metrics
 
 Extended storage is available for €29 per month and entails 12 months of storage for metrics and 1 month of storage for logs.
 
+Pricing plans are scoped per [Project](/console/project/concepts/#project).
+
 ### Future pricing for using Cockpit with Scaleway data (effective March 2024)
 
 **Starting March 2024**, Cockpit's **pricing will be evolving**. Three pricing plans will be available according to your data retention needs:
@@ -34,6 +36,7 @@ Extended storage is available for €29 per month and entails 12 months of stora
 | Premium   | **31 days of storage for metrics**, and **7 days for logs and traces**.                                               | €29 per month  |
 | Expert    | **365 days of storage for metrics**, and **31 days for logs and traces**.                                             | €129 per month |
 
+Pricing plans are scoped per [Project](/console/project/concepts/#project).
 
 ### How am I billed for using Cockpit with external data?
 


### PR DESCRIPTION
A user has raised a question about whether pricing plans are scoped per Project or Organization. I have added the relevant information in the documentation.

