### PR TITLE
chore(k8s): delayed 1.23 EOS

### DIFF
--- a/containers/kubernetes/reference-content/version-support-policy.mdx
+++ b/containers/kubernetes/reference-content/version-support-policy.mdx
@@ -61,7 +61,7 @@ When a minor version becomes unsupported, Scaleway operates an upgrade to the la
 | 1.26               | December 2022    | February 2024        | February 6, 2023             | February 2025    | March 6, 2025     |
 | 1.25               | August 2022      | October 2023         | February 6, 2023             | February 2025    | March 6, 2025     |
 | 1.24               | April 2022       | July 2023            | April 2022                   | April 2024       | May 15, 2024      |
-| 1.23               | December 8, 2021 | February 2023        | December 9, 2021             | December 2023    | February 15, 2024 |
+| 1.23               | December 8, 2021 | February 2023        | December 9, 2021             | December 2023    | March 15, 2024    |
 
 <Message type="important">
 * New support policy: from the release of version 1.29, Scaleway's support window has shifted to 14 months.


### PR DESCRIPTION
### Description

Delayed 1.23 EOS due to temp upgrade deactivation.
