### PR TITLE
feat(changelog): kubernetes-removed-scaleway-kubernetes-products-no-long 2024-02-28

### DIFF
--- a/changelog/february2024/2024-02-28-kubernetes-removed-scaleway-kubernetes-products-no-long.mdx
+++ b/changelog/february2024/2024-02-28-kubernetes-removed-scaleway-kubernetes-products-no-long.mdx
@@ -1,0 +1,15 @@
+---
+title: Scaleway Kubernetes products no longer support Kubernetes 1.23
+status: removed
+author:
+    fullname: 'Join the #k8s channel on Slack.'
+    url: 'https://slack.scaleway.com'
+date: 2024-02-28
+category: containers
+product: kubernetes
+---
+
+Clusters using the Kubernetes 1.23 version will be automatically upgraded to the Kubernetes 1.24 version after March 15th, 2023. 
+
+Find more details in our [version support policy](https://www.scaleway.com/en/docs/containers/kubernetes/reference-content/version-support-policy/).
+

--- a/changelog/february2024/2024-02-28-kubernetes-removed-scaleway-kubernetes-products-no-long.mdx
+++ b/changelog/february2024/2024-02-28-kubernetes-removed-scaleway-kubernetes-products-no-long.mdx
@@ -9,7 +9,7 @@ category: containers
 product: kubernetes
 ---
 
-Clusters using the Kubernetes 1.23 version will be automatically upgraded to the Kubernetes 1.24 version after March 15th, 2023. 
+Clusters using the Kubernetes 1.23 version will be automatically upgraded to the Kubernetes 1.24 version after March 15th, 2024. 
 
-Find more details in our [version support policy](https://www.scaleway.com/en/docs/containers/kubernetes/reference-content/version-support-policy/).
+Find more details in our [version support policy](/containers/kubernetes/reference-content/version-support-policy/).
 


### PR DESCRIPTION
Reporter: tgenaitay

This PR is a new changelog contribution. It has been created automatically.

Make sure to review it carefully before merging it.