### PR TITLE
feat(changelog): container-registry-deprecated-deprecation-of-logs-endpo 2024-02-29

### DIFF
--- a/changelog/february2024/2024-02-29-container-registry-deprecated-deprecation-of-logs-endpo.mdx
+++ b/changelog/february2024/2024-02-29-container-registry-deprecated-deprecation-of-logs-endpo.mdx
@@ -1,0 +1,19 @@
+---
+title: Deprecation of /logs endpoint
+status: deprecated
+author:
+    fullname: 'Join the #[xxx] channel on Slack.'
+    url: 'https://slack.scaleway.com'
+date: 2024-02-29
+category: containers
+product: container-registry
+---
+
+Due to a lack of usage and a change impacting the storage of users logs, the `/logs` endpoint (or `ListLogs` for our SDK users) is now deprecated.
+
+Users can still find their functions logs through their [cockpit](https://www.scaleway.com/en/docs/observability/cockpit/how-to/access-grafana-and-managed-dashboards/): a dashboard ("Serverless Functions Logs") is available there. See also [this documentation](https://www.scaleway.com/en/developers/api/serverless-functions/).
+
+Users already browsing their logs through cockpit (logs are sent to users cockpit for 6 months now) won't face any change.
+
+The `/logs` endpoint will cease to work in one month (March 12 2024).
+


### PR DESCRIPTION
Reporter: Rachid BEN SAID

This PR is a new changelog contribution. It has been created automatically.

Make sure to review it carefully before merging it.