### PR TITLE
Fix name of scalaway-async package

### DIFF
--- a/developer-tools/scaleway-sdk/python-sdk.mdx
+++ b/developer-tools/scaleway-sdk/python-sdk.mdx
@@ -29,7 +29,7 @@ pip install scaleway
 
 **For the asynchronous version:**
 ```bash
-pip install scaleway-asynchronous
+pip install scaleway-async
 ```
 
 <Message type="note">


### PR DESCRIPTION
This fixes the name of the [scalaway-async](https://pypi.org/project/scaleway-async) package, otherwise pip install doesn't work.

Sorry, I have not read the contributing guide, it's rather long, and this just fixes a typo.
