### PR TITLE
docs(cockpit): remove mention of new pricing plans

### DIFF
--- a/faq/cockpit.mdx
+++ b/faq/cockpit.mdx
@@ -24,7 +24,7 @@ Extended storage is available for €29 per month and entails 12 months of stora
 
 Pricing plans are scoped per [Project](/identity-and-access-management/organizations-and-projects/concepts/#project).
 
-### How am I billed for using Cockpit with external data?
+## How am I billed for using Cockpit with external data?
 
 Cockpit’s pricing is based on two dimensions: the volume of external logs and metrics ingested and the duration of storage.
 

--- a/faq/cockpit.mdx
+++ b/faq/cockpit.mdx
@@ -18,29 +18,13 @@ Cockpit integrates seamlessly with Scaleway’s ecosystem. It provides pre-built
 
 ## How am I billed for using Cockpit with my Scaleway data?
 
-### Current pricing for using Cockpit with Scaleway data
-
 Scaleway’s monitoring is included for free for a period of 30 days for metrics and 7 days for logs.
 
 Extended storage is available for €29 per month and entails 12 months of storage for metrics and 1 month of storage for logs.
 
 Pricing plans are scoped per [Project](/identity-and-access-management/organizations-and-projects/concepts/#project).
 
-### Future pricing for using Cockpit with Scaleway data (effective March 2024)
-
-**Starting March 2024**, Cockpit's **pricing will be evolving**. Three pricing plans will be available according to your data retention needs:
-
-| Plan type | What does the plan include?                                                                                           | Cost           |
-|-----------|-----------------------------------------------------------------------------------------------------------------------|----------------|
-| Free      | Free storage for a period of **3 days for metrics** and **1 day for logs and traces**. | Free           |
-| Premium   | **31 days of storage for metrics**, and **7 days for logs and traces**.                                               | €29 per month  |
-| Expert    | **365 days of storage for metrics**, and **31 days for logs and traces**.                                             | €129 per month |
-
-Pricing plans are scoped per [Project](/identity-and-access-management/organizations-and-projects/concepts/#project).
-
 ### How am I billed for using Cockpit with external data?
-
-### Current pricing for using Cockpit with external data
 
 Cockpit’s pricing is based on two dimensions: the volume of external logs and metrics ingested and the duration of storage.
 
@@ -49,20 +33,10 @@ Logs are billed €0.35 per GB ingested.
 Traces are free of charge during the public beta. Traces data is retained for 14 days. After this period, data older than 14 days is deleted.
 You will not be charged for querying external data and the monitoring of your Scaleway resources is included for free for a period of 30 days.
 
-### Future pricing for using Cockpit with external data
-
-**Starting March 2024**, Cockpit's **pricing will be evolving**.
-
-- External metrics will be billed €0.15 per million of samples ingested, per month.
-- External logs will be billed €0.35 per GB ingested, per month.
-- External traces will be billed €0.35 per GB ingested, per month.
-
-You will not be charged for querying external data.
-
 ## How do I send my own data to my Cockpit?
 
-You can send your data using our [dedicated documentation](/observability/cockpit/how-to/send-metrics-logs-to-cockpit/).
-If you have not set up any agent, check out our [documentation on how to configure a Grafana agent](/observability/cockpit/api-cli/configuring-grafana-agent/).
+If you have set up an agent, you can send your data using our [dedicated documentation](/observability/cockpit/how-to/send-metrics-logs-to-cockpit/).
+If you have not set up any agent, check out our [documentation to find out how to configure the Grafana agent, push your data, and visualize it in Grafana](/observability/cockpit/api-cli/configuring-grafana-agent/).
 
 ## Which Scaleway products are integrated into Cockpit?
 


### PR DESCRIPTION
New pricing plans were announced for March 19th for Cockpit. They have been postponed.
Updated documentation accordingly.