### PR TITLE
feat(changelog): kubernetes-changed-routed-ips-now-default-on-new-kubern 2024-03-22

### DIFF
--- a/changelog/march2024/2024-03-22-kubernetes-changed-routed-ips-now-default-on-new-kubern.mdx
+++ b/changelog/march2024/2024-03-22-kubernetes-changed-routed-ips-now-default-on-new-kubern.mdx
@@ -1,0 +1,19 @@
+---
+title: Routed IPs now default on new Kubernetes clusters
+status: changed
+author:
+    fullname: 'Join the #k8s channel on Slack.'
+    url: 'https://slack.scaleway.com'
+date: 2024-03-22
+category: containers
+product: kubernetes
+---
+
+[Routed IPs](https://www.scaleway.com/en/news/routed-ips-are-coming-to-all-scaleway-products/) are coming to all Scaleway products.
+Effective now, new Kubernetes clusters will provision nodes with public IP addresses directly routed to the Instance, without having to go through a NAT gateway to convert from public IP to a private IP.
+
+If you want to know more about the changes behind this evolution, take a look at our [blog post](https://www.scaleway.com/en/blog/ip-mobility-removing-nat/).
+
+Read the manual and automatic migrations plans [on this page](https://www.scaleway.com/en/news/routed-ips-are-coming-to-all-scaleway-products/)
+
+


### PR DESCRIPTION
Reporter: tgenaitay

This PR is a new changelog contribution. It has been created automatically.

Make sure to review it carefully before merging it.