### PR TITLE
feat(changelog): postgresql-and-mysql-added-ability-to-remove-public-end 2024-03-25

### DIFF
--- a/changelog/march2024/2024-03-25-postgresql-and-mysql-added-ability-to-remove-public-end.mdx
+++ b/changelog/march2024/2024-03-25-postgresql-and-mysql-added-ability-to-remove-public-end.mdx
@@ -1,5 +1,5 @@
 ---
-title: Ability to remove public endpoints from the console
+title: You can now remove public endpoints from the Scaleway console
 status: added
 author:
     fullname: 'Join the #database channel on Slack.'
@@ -9,7 +9,7 @@ category: databases
 product: postgresql-and-mysql
 ---
 
-Network management on Managed DB for PostgreSQL and MySQL has been improved, and you can now add/remove public endpoints directly from the Scaleway console. This includes endpoints attached to both Database Instances and Read-Replicas.
+Network management on Managed Databases for PostgreSQL and MySQL has been improved! You can now add/remove public endpoints directly from the [Scaleway console](https://console.scaleway.com). This includes endpoints attached to both Database Instances and Read-Replicas.
 
-Refer to [our documentation](https://www.scaleway.com/en/docs/managed-databases/postgresql-and-mysql/how-to/remove-public-endpoint/) for more information.
+Refer to [our documentation](/managed-databases/postgresql-and-mysql/how-to/remove-public-endpoint/) for more information.
 

--- a/changelog/march2024/2024-03-25-postgresql-and-mysql-added-ability-to-remove-public-end.mdx
+++ b/changelog/march2024/2024-03-25-postgresql-and-mysql-added-ability-to-remove-public-end.mdx
@@ -1,5 +1,5 @@
 ---
-title: Ability to remove public endpoints from Console
+title: Ability to remove public endpoints from the console
 status: added
 author:
     fullname: 'Join the #database channel on Slack.'
@@ -9,7 +9,7 @@ category: databases
 product: postgresql-and-mysql
 ---
 
-The Network management on Managed DB for PostgreSQL and MySQL has been slightly revamped and you can now add/remove public endpoints directly from your Console, may it be those attached to Database Instances or Read-Replicas.
+Network management on Managed DB for PostgreSQL and MySQL has been improved, and you can now add/remove public endpoints directly from the Scaleway console. This includes endpoints attached to both Database Instances and Read-Replicas.
 
-Refer to [this documentation](https://www.scaleway.com/en/docs/managed-databases/postgresql-and-mysql/how-to/remove-public-endpoint/) for more information.
+Refer to [our documentation](https://www.scaleway.com/en/docs/managed-databases/postgresql-and-mysql/how-to/remove-public-endpoint/) for more information.
 

--- a/changelog/march2024/2024-03-25-postgresql-and-mysql-added-ability-to-remove-public-end.mdx
+++ b/changelog/march2024/2024-03-25-postgresql-and-mysql-added-ability-to-remove-public-end.mdx
@@ -1,0 +1,15 @@
+---
+title: Ability to remove public endpoints from Console
+status: added
+author:
+    fullname: 'Join the #database channel on Slack.'
+    url: 'https://slack.scaleway.com'
+date: 2024-03-25
+category: databases
+product: postgresql-and-mysql
+---
+
+The Network management on Managed DB for PostgreSQL and MySQL has been slightly revamped and you can now add/remove public endpoints directly from your Console, may it be those attached to Database Instances or Read-Replicas.
+
+Refer to [this documentation](https://www.scaleway.com/en/docs/managed-databases/postgresql-and-mysql/how-to/remove-public-endpoint/) for more information.
+


### PR DESCRIPTION
Reporter: Walter Timmermans

This PR is a new changelog contribution. It has been created automatically.

Make sure to review it carefully before merging it.