### PR TITLE
feat(changelog): kubernetes-changed-routed-ips-are-now-default-on-kubern 2024-03-26

### DIFF
--- a/changelog/march2024/2024-03-26-kubernetes-changed-routed-ips-are-now-default-on-kubern.mdx
+++ b/changelog/march2024/2024-03-26-kubernetes-changed-routed-ips-are-now-default-on-kubern.mdx
@@ -1,0 +1,18 @@
+---
+title: Routed IPs are now default on Kubernetes clusters
+status: changed
+author:
+    fullname: 'Join the #k8s channel on Slack.'
+    url: 'https://slack.scaleway.com'
+date: 2024-03-26
+category: containers
+product: kubernetes
+---
+
+[Routed IPs](https://www.scaleway.com/en/news/routed-ips-are-coming-to-all-scaleway-products/) are becoming default for all Scaleway resources.
+Effective now, new Kubernetes clusters will provision nodes with public IP addresses directly routed to the Instance, without having to go through a NAT gateway to convert from public IP to a private IP.
+
+If you want to know more about the changes behind this evolution, have a look at our [blog post](https://www.scaleway.com/en/blog/ip-mobility-removing-nat/).
+
+Find out more about the manual and automatic migrations plans [on this page](https://www.scaleway.com/en/news/routed-ips-are-coming-to-all-scaleway-products/).
+

--- a/changelog/march2024/2024-03-26-kubernetes-changed-routed-ips-are-now-default-on-kubern.mdx
+++ b/changelog/march2024/2024-03-26-kubernetes-changed-routed-ips-are-now-default-on-kubern.mdx
@@ -14,5 +14,5 @@ Effective now, new Kubernetes clusters will provision nodes with public IP addre
 
 If you want to know more about the changes behind this evolution, have a look at our [blog post](https://www.scaleway.com/en/blog/ip-mobility-removing-nat/).
 
-Find out more about the manual and automatic migrations plans [on this page](https://www.scaleway.com/en/news/routed-ips-are-coming-to-all-scaleway-products/).
+[Find out more about the manual and automatic migrations plans](https://www.scaleway.com/en/news/routed-ips-are-coming-to-all-scaleway-products/).
 


### PR DESCRIPTION
Reporter: Benedikt Rollik

This PR is a new changelog contribution. It has been created automatically.

Make sure to review it carefully before merging it.