### PR TITLE
chore(ddx): update dns cache ips

### DIFF
--- a/dedibox-network/network/how-to/configure-network-netplan.mdx
+++ b/dedibox-network/network/how-to/configure-network-netplan.mdx
@@ -69,8 +69,12 @@ network:
       addresses: [163.172.123.123/24, 212.83.123.123/32]
       gateway4: 163.172.123.1
       nameservers:
-        addresses: [ "62.210.16.6", "62.210.16.7" ]
+        addresses: [ "51.159.47.28", "51.159.47.26" ]
 ```
+
+<Message type="tip">
+  Replace the DNS cache servers in the example above (`51.159.47.28` and `51.159.47.26`) with the nameservers [available in the same datacenter](/console/account/reference-content/scaleway-network-information/#dns-cache-servers) as your server for optimal latency.
+</Message>
 
 Once you have edited and saved the file, you can reload the configuration with the following command:
 
@@ -93,12 +97,16 @@ network:
       addresses: [fail.over.ip.address/32]
       gateway4: 62.210.0.1
       nameservers:
-        addresses: [62.210.16.6, 62.210.16.7]
+        addresses: ["51.159.47.28", "51.159.47.26"]
       routes:
       - to: 62.210.0.1/32
         via: fail.over.ip.address
         scope: link
 ```
+
+<Message type="tip">
+  Replace the DNS cache servers in the example above (`51.159.47.28` and `51.159.47.26`) with the nameservers [available in the same datacenter](/console/account/reference-content/scaleway-network-information/#dns-cache-servers) as your server for optimal latency.
+</Message>
 
 
 <Navigation title="See also">


### PR DESCRIPTION
### Description

Updated Netplan examples with new DNS cache IPs in DC5 + warning to use the ones in the same DC as the server. 