### PR TITLE
fix(billing): fix links

### DIFF
--- a/console/billing/index.mdx
+++ b/console/billing/index.mdx
@@ -27,14 +27,14 @@ meta:
         icon="information-circle-outline"
         description="Core concepts that give you a better understanding of Scaleway billing."
         label="View Concepts"
-        url="/console/billing/quickstart"
+        url="/console/billing/concepts"
     />
     <SummaryCard
         title="How-tos"
         icon="help-circle-outline"
         description="Check our guides to add and manage billing information"
         label="View How-tos"
-        url="/console/billing/quickstart"
+        url="/console/billing/how-to/"
     />
 
 </Grid>


### PR DESCRIPTION
The wrong links were displaying on the billing homepage, this PR corrects them.
