### PR TITLE
fix(bare-metal): boot filesystem for RV1 was changed to FAT32

### DIFF
--- a/bare-metal/elastic-metal/reference-content/elastic-metal-understanding-rv1-usage.mdx
+++ b/bare-metal/elastic-metal/reference-content/elastic-metal-understanding-rv1-usage.mdx
@@ -19,7 +19,7 @@ EM-RV1 servers do not support standard UEFI or BIOS boot, therefore the boot
 process might slightly differ from other servers. At boot, the bootloader
 expects the eMMC to be partitioned as GPT, and will look for a `boot.itb` file
 in the first or second partition. The partition that contains this boot file
-must be formatted as EXT4.
+must be formatted as FAT32.
 
 This `boot.itb` file is in fact a [FIT
 Image](https://docs.u-boot.org/en/latest/usage/fit/source_file_format.html)


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

Recommended boot partition filesystem on RV1 was changed to FAT32 because of a bug with the bootloader on highly fragmented EXT4 partitions. EXT4 will keep working as before (incl. the bugs), so it's not a breaking change.
