### PR TITLE
fix(tutorials): bump dagster-scaleway version and add project ID

### DIFF
--- a/tutorials/dagster-serverless-jobs/index.mdx
+++ b/tutorials/dagster-serverless-jobs/index.mdx
@@ -53,10 +53,10 @@ We will install Dagster using the `pip` package installer. Refer to the [Dagster
         "dagster",
         "dagster-cloud",
         "dagster_aws",
-        "dagster_scaleway==0.1.2",
+        "dagster_scaleway~=0.1.3",
         "dagster_postgres",
         "pandas",
-        "scaleway==1.4.1",
+        "scaleway",
         "pendulum==2.0.3",
     ],
     ```
@@ -155,11 +155,13 @@ We will install Dagster using the `pip` package installer. Refer to the [Dagster
 
 1. Retrieve the following elements:
     - your [Serverless SQL Database connection string](/serverless/sql-databases/how-to/connect-to-a-database/#how-to-set-up-credentials)
+    - the project ID of the [Scaleway project](/identity-and-access-management/organizations-and-projects/how-to/create-a-project/) you want to use
     - the [access key and secret key](/identity-and-access-management/iam/how-to/create-api-keys/) for your API key
     - the name of the [Object Storage bucket](/storage/object/how-to/create-a-bucket/) you created
 2. Export the environment variables below:
     ```bash
     export PG_CONN_STRING=<your_serverless_database_connection_string>
+    export SCW_DEFAULT_PROJECT_ID=<your_scaleway_project_id>
     export SCW_ACCESS_KEY=<your_scaleway_access_key>
     export SCW_SECRET_KEY=<your_scaleway_secret_key>
     export S3_BUCKET_NAME=<your_bucket_name>
@@ -183,6 +185,7 @@ We will install Dagster using the `pip` package installer. Refer to the [Dagster
       docker_image: rg.fr-par.scw.cloud/<your-namespace>/dagster-scaleway-example:latest
       env_vars:
       - PG_CONN_STRING
+      - SCW_DEFAULT_PROJECT_ID
       - SCW_ACCESS_KEY
       - SCW_SECRET_KEY
       - S3_BUCKET_NAME
@@ -242,8 +245,6 @@ Dagster writes small chunks of data in the Serverless SQL Database as long as th
 ## Troubleshooting
 
 - Make sure that you have exported the environment variables, as they are cleared at the end of a terminal session.
-
-- Do not reuse tags for the image, and make sure you updated the `dagster.yaml` file with the correct image.
 
 - Make sure the `assets.py` and `__init__.py` file contain the corresponding code.
 


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

Following a report on the Slack community, the projectID was missing in the tutorial. This is needed as Serverless Jobs are project-scoped resources, and we need to define a projectID to create them.

When we tested the tutorial, it most likely used the projectID from our `.config/scw/config.yaml` file.

In addition, there was a change in the Serverless Jobs API that required us to bump the custom run launcher. I've also removed the constraint on the SDK, as it will be inferred by the constraint in the run launcher (as it created some incompatibilities when testing it). 
