### PR TITLE
feat(changelog): apple-silicon-changed-macos14-sonoma-is-now-available 2024-04-26

### DIFF
--- a/changelog/april2024/2024-04-26-apple-silicon-changed-macos14-sonoma-is-now-available.mdx
+++ b/changelog/april2024/2024-04-26-apple-silicon-changed-macos14-sonoma-is-now-available.mdx
@@ -9,7 +9,7 @@ category: bare-metal
 product: apple-silicon
 ---
 
-The macOS 14 Sonoma version is now installed by default on Scaleway Mac mini M2 (M2-M) and Mac mini M2 pro (M2-L). 
+macOS 14 Sonoma is now installed by default on Scaleway Mac mini M2 (M2-M) and Mac mini M2 pro (M2-L). 
 
 The Mac mini M1 (M1-M) range will stay on macOS 13 by default for now. If you want to enjoy a smooth macOS 14 migration you can opt-in to our latest macOS configuration improvements by reinstalling your server through the console, then performing a manual upgrade using `softwareupdate`.
 

--- a/changelog/april2024/2024-04-26-apple-silicon-changed-macos14-sonoma-is-now-available.mdx
+++ b/changelog/april2024/2024-04-26-apple-silicon-changed-macos14-sonoma-is-now-available.mdx
@@ -2,14 +2,14 @@
 title: macOS14 Sonoma is now available!
 status: changed
 author:
-    fullname: 'Join the #[xxx] channel on Slahttps://scaleway-community.slack.com/channels/apple-siliconck.'
+    fullname: 'Join the #apple-silicon channel on Slack.'
     url: 'https://slack.scaleway.com'
 date: 2024-04-26
 category: bare-metal
 product: apple-silicon
 ---
 
-The version macOS 14 Sonoma is now installed by default on Mac mini M2 (M2-M) and Mac mini M2 pro (M2-L). 
+The macOS 14 Sonoma version is now installed by default on Scaleway Mac mini M2 (M2-M) and Mac mini M2 pro (M2-L). 
 
-The Mac mini M1 (M1-M) range will stay on macOS 13 by default for now. If you want to enjoy a smooth macOS 14 migration you can opt-in to our latest macOS configuration improvements by reinstalling your server through the console, then performing a manual upgrade using softwareupdate.
+The Mac mini M1 (M1-M) range will stay on macOS 13 by default for now. If you want to enjoy a smooth macOS 14 migration you can opt-in to our latest macOS configuration improvements by reinstalling your server through the console, then performing a manual upgrade using `softwareupdate`.
 

--- a/changelog/april2024/2024-04-26-apple-silicon-changed-macos14-sonoma-is-now-available.mdx
+++ b/changelog/april2024/2024-04-26-apple-silicon-changed-macos14-sonoma-is-now-available.mdx
@@ -1,0 +1,15 @@
+---
+title: macOS14 Sonoma is now available!
+status: changed
+author:
+    fullname: 'Join the #[xxx] channel on Slahttps://scaleway-community.slack.com/channels/apple-siliconck.'
+    url: 'https://slack.scaleway.com'
+date: 2024-04-26
+category: bare-metal
+product: apple-silicon
+---
+
+The version macOS 14 Sonoma is now installed by default on Mac mini M2 (M2-M) and Mac mini M2 pro (M2-L). 
+
+The Mac mini M1 (M1-M) range will stay on macOS 13 by default for now. If you want to enjoy a smooth macOS 14 migration you can opt-in to our latest macOS configuration improvements by reinstalling your server through the console, then performing a manual upgrade using softwareupdate.
+


### PR DESCRIPTION
Reporter: Alexia Valais

This PR is a new changelog contribution. It has been created automatically.

Make sure to review it carefully before merging it.