### PR TITLE
feat(changelog): jobs-added-serverless-jobs-max-timeout-increased-to-24h 2024-05-14

### DIFF
--- a/changelog/may2024/2024-05-14-jobs-added-serverless-jobs-max-timeout-increased-to-24h.mdx
+++ b/changelog/may2024/2024-05-14-jobs-added-serverless-jobs-max-timeout-increased-to-24h.mdx
@@ -1,0 +1,13 @@
+---
+title: Serverless Jobs max timeout increased to 24h
+status: added
+author:
+    fullname: 'Join the #serverless-jobs channel on Slack.'
+    url: 'https://slack.scaleway.com'
+date: 2024-05-14
+category: serverless
+product: jobs
+---
+
+Long running Jobs are welcome on our infrastructure ! Max timeout is now of 24 hours instead of 6 hours
+

--- a/changelog/may2024/2024-05-14-jobs-added-serverless-jobs-max-timeout-increased-to-24h.mdx
+++ b/changelog/may2024/2024-05-14-jobs-added-serverless-jobs-max-timeout-increased-to-24h.mdx
@@ -9,5 +9,5 @@ category: serverless
 product: jobs
 ---
 
-Long running Jobs are welcome on our infrastructure ! Max timeout is now of 24 hours instead of 6 hours
+Long running Jobs are welcome on our infrastructure! Max timeout has now increased to 24 hours, from the previous limit of 6 hours.
 


### PR DESCRIPTION
Reporter: Thomas Tacquet

This PR is a new changelog contribution. It has been created automatically.

Make sure to review it carefully before merging it.