### PR TITLE
feat(ifr): network settings are not immutable anymore

### DIFF
--- a/ai-data/managed-inference/how-to/create-deployment.mdx
+++ b/ai-data/managed-inference/how-to/create-deployment.mdx
@@ -14,11 +14,7 @@ dates:
 1. Go to the **AI & Data** section of the [Scaleway console](https://console.scaleway.com/), and select **Managed Inference** from the side menu to access the Managed Inference dashboard.
 2. Click **Create deployment** to launch the deployment creation wizard.
 3. Provide the necessary information:
-    - Select the desired model for your deployment from the available options:
-        - [Llama-2-70b-chat](/ai-data/managed-inference/reference-content/llama-2-70b-chat/)
-        - [Llama-2-7b-chat](/ai-data/managed-inference/reference-content/llama-2-7b-chat/)
-        - [Mixtral-8x7B-Instruct-v0.1](/ai-data/managed-inference/reference-content/mixtral-8x7b-instruct-v0.1/)
-        - [WizardLM-70b-V1.0](/ai-data/managed-inference/reference-content/wizardlm-70b-v1.0/)
+    - Select the desired model and the quantization to use for your deployment [from the available options](https://www.scaleway.com/en/docs/ai-data/managed-inference/reference-content/)
         <Message type="note">
           Some models may require acceptance of an end-user license agreement. If prompted, review the terms and conditions and accept the license accordingly.
         </Message>

--- a/ai-data/managed-inference/how-to/create-deployment.mdx
+++ b/ai-data/managed-inference/how-to/create-deployment.mdx
@@ -26,10 +26,9 @@ dates:
     - Specify the GPU Instance type to be used with your deployment.
 4. Enter a **name** for the deployment, and optional tags.
 5. Configure the **network** settings for the deployment:
-    - Enable **Private Network** for secure communication and restricted availability within Private Networks. Choose an existing Private Network from the drop-down list, if applicable.
+    - Enable **Private Network** for secure communication and restricted availability within Private Networks. Choose an existing Private Network from the drop-down list, or create a new one.
     - Enable **Public Network** to access resources via the public internet. Token protection is enabled by default.
     <Message type="important">
-      - It is not possible to change network settings through the Scaleway console after the deployment creation. 
       - Enabling both private and public networks will result in two distinct endpoints (public and private) for your deployment.
       - Deployments must have at least one endpoint, either public or private.
     </Message>

--- a/ai-data/managed-inference/how-to/create-deployment.mdx
+++ b/ai-data/managed-inference/how-to/create-deployment.mdx
@@ -5,7 +5,7 @@ meta:
 content:
   h1: How to create a deployment
   paragraph: This page explains how to create a deployment
-tags: dedibox failover ip flexible-ip failover-ip
+tags: managed-inference ai-data creating dedicated
 dates:
   validation: 2024-03-23
   posted: 2024-03-06

--- a/ai-data/managed-inference/how-to/create-deployment.mdx
+++ b/ai-data/managed-inference/how-to/create-deployment.mdx
@@ -14,7 +14,7 @@ dates:
 1. Go to the **AI & Data** section of the [Scaleway console](https://console.scaleway.com/), and select **Managed Inference** from the side menu to access the Managed Inference dashboard.
 2. Click **Create deployment** to launch the deployment creation wizard.
 3. Provide the necessary information:
-    - Select the desired model and the quantization to use for your deployment [from the available options](https://www.scaleway.com/en/docs/ai-data/managed-inference/reference-content/)
+    - Select the desired model and quantization to use for your deployment [from the available options](/ai-data/managed-inference/reference-content/)
         <Message type="note">
           Some models may require acceptance of an end-user license agreement. If prompted, review the terms and conditions and accept the license accordingly.
         </Message>

--- a/ai-data/managed-inference/how-to/delete-deployment.mdx
+++ b/ai-data/managed-inference/how-to/delete-deployment.mdx
@@ -5,7 +5,7 @@ meta:
 content:
   h1: How to delete a Managed Inference deployment
   paragraph: This page explains how to delete a Managed Inference deployment
-tags: ai deleteing
+tags: managed-inference ai-data deleting
 dates:
   validation: 2024-03-06
   posted: 2024-03-06

--- a/ai-data/managed-inference/how-to/monitor-deployment.mdx
+++ b/ai-data/managed-inference/how-to/monitor-deployment.mdx
@@ -5,7 +5,7 @@ meta:
 content:
   h1: How to monitor a Managed Inference deployment
   paragraph: This page explains how to monitor a Managed Inference deployment
-tags: ai monitoring
+tags: managed-inference ai-data monitoring
 dates:
   validation: 2024-03-06
   posted: 2024-03-06

--- a/ai-data/managed-inference/quickstart.mdx
+++ b/ai-data/managed-inference/quickstart.mdx
@@ -65,7 +65,7 @@ Managed Inference deployments use dynamic tokens generated with Scaleway's Ident
 
 1. Click **Managed Inference** in the **AI & Data** section of the side menu. The Managed Inference dashboard displays.
 2. Click <Icon name="more" /> next to the deployment you want to edit. The deployment dashboard displays.
-3. Click the **Inference** tab. Code examples in various environments display. Copy and paste them in your code or terminal.
+3. Click the **Inference** tab. Code examples in various environments display. Copy and paste them in your code editor or terminal.
 
 <Message type="note">
   Prompt structure may vary from one model to another.  Refer to the specific instructions for use in our [dedicated documentation](/ai-data/managed-inference/reference-content/)

--- a/ai-data/managed-inference/quickstart.mdx
+++ b/ai-data/managed-inference/quickstart.mdx
@@ -40,10 +40,9 @@ Here are some of the key features of Scaleway Managed Inference:
     - Specify the GPU Instance type to be used with your deployment.
 4. Enter a **name** for the deployment, along with optional tags to aid in organization.
 5. Configure the **network** settings for the deployment:
-    - Enable **Private Network** for secure communication and restricted availability within Private Networks. Choose an existing Private Network from the drop-down list, if applicable.
-    - Enable **Public Network** to access resources via the public Internet. Token protection is enabled by default.
+    - Enable **Private Network** for secure communication and restricted availability within Private Networks. Choose an existing Private Network from the drop-down list, or create a new one.
+    - Enable **Public Network** to access resources via the public Internet. API key protection is enabled by default.
     <Message type="important">
-      - It is not possible to change network settings through the Scaleway console after the deployment creation. 
       - Enabling both private and public networks will result in two distinct endpoints (public and private) for your deployment.
       - Deployments must have at least one endpoint, either public or private.
     </Message>

--- a/ai-data/managed-inference/reference-content/mixtral-8x7b-instruct-v0.1.mdx
+++ b/ai-data/managed-inference/reference-content/mixtral-8x7b-instruct-v0.1.mdx
@@ -7,7 +7,7 @@ content:
   paragraph: This page provides information on the Mixtral-8x7B-Instruct-v0.1 model
 tags: 
 categories:
-  - ia
+  - ai-data
 ---
 
 ## Model overview

--- a/ai-data/managed-inference/reference-content/openai-compatibility.mdx
+++ b/ai-data/managed-inference/reference-content/openai-compatibility.mdx
@@ -5,7 +5,7 @@ meta:
 content:
   h1: Scaleway Managed Inference as drop-in replacement for the OpenAI APIs
   paragraph: This page provides information on Scaleway's managed inference compatibility with OpenAI's REST API
-tags: 
+tags: ai-data
 categories:
   - ai-data
 ---

--- a/ai-data/managed-inference/reference-content/wizardlm-70b-v1.0.mdx
+++ b/ai-data/managed-inference/reference-content/wizardlm-70b-v1.0.mdx
@@ -5,7 +5,7 @@ meta:
 content:
   h1: Understanding the WizardLM-70B-V1.0 model
   paragraph: This page provides information on the WizardLM-70B-V1.0 model
-tags: 
+tags: model-library ai-data wizardLM
 categories:
   - ai-data
 ---


### PR DESCRIPTION
### Your checklist for this pull request

- [X] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

- Since shire/console release 3.306.0, users can add and remove public or private endpoints to a deployment after creation. This was the main intent of this pull request. Users can also create a new private network if none was in their organization already.
- Noticed some odd tags or missing ones, added some here and there
- Removed hardcoded list of models because it has been, and will continue to expand fast
