### PR TITLE
feat(changelog): apple-silicon-changed-macos-14-is-now-available-on-all- 2024-05-17

### DIFF
--- a/changelog/may2024/2024-05-17-apple-silicon-changed-macos-14-is-now-available-on-all-.mdx
+++ b/changelog/may2024/2024-05-17-apple-silicon-changed-macos-14-is-now-available-on-all-.mdx
@@ -9,5 +9,5 @@ category: bare-metal
 product: apple-silicon
 ---
 
-macOS Sonoma 14 is now also installed by default on Scaleway Mac mini M1 (M1-M). Enjoy Sonoma on the entire Mac mini line!
+macOS Sonoma 14 now comes pre-installed by default on Scaleway's Mac mini M1 (M1-M). Enjoy Sonoma across the entire Mac mini lineup!
 

--- a/changelog/may2024/2024-05-17-apple-silicon-changed-macos-14-is-now-available-on-all-.mdx
+++ b/changelog/may2024/2024-05-17-apple-silicon-changed-macos-14-is-now-available-on-all-.mdx
@@ -1,0 +1,13 @@
+---
+title: macOS 14 is now available on all Mac minis
+status: changed
+author:
+    fullname: 'Join the #apple-silicon channel on Slack.'
+    url: 'https://slack.scaleway.com'
+date: 2024-05-17
+category: bare-metal
+product: apple-silicon
+---
+
+macOS Sonoma 14 is now also installed by default on Scaleway Mac mini M1 (M1-M). Enjoy Sonoma on the entire Mac mini line!
+


### PR DESCRIPTION
Reporter: Alexia Valais

This PR is a new changelog contribution. It has been created automatically.

Make sure to review it carefully before merging it.