### PR TITLE
docs(block-storage): clarify quickstart

### DIFF
--- a/storage/block/quickstart.mdx
+++ b/storage/block/quickstart.mdx
@@ -14,7 +14,7 @@ categories:
   - storage
 ---
 
-Scaleway [Block Storage](/storage/block/concepts/#block-device) provides network-attached storage that can be plugged in and out of cloud products such as [Instances](/compute/instances/concepts/#instance) like a virtual hard-drive. Block Storage devices are independent of the local storage of Instances, and the fact that they are accessed over a network connection makes it easy to move them between Instances in the same [Availability Zone](/compute/instances/concepts/#availability-zone).
+Scaleway [Block Storage](/storage/block/concepts/#block-device) provides network-attached storage that can be plugged in and out of [Instances](/compute/instances/concepts/#instance) like a virtual hard-drive. Block Storage devices are independent of the local storage of Instances, and the fact that they are accessed over a network connection makes it easy to move them between Instances in the same [Availability Zone](/compute/instances/concepts/#availability-zone).
 
 From the user's point of view, once [mounted](/storage/block/api-cli/managing-a-volume/#mounting-and-using-a-volume), the block device behaves like a regular disk.
 


### PR DESCRIPTION
Specified that we can only attach volumes to Instances vs cloud products which was confusing