### PR TITLE
feat(changelog): kubernetes-removed-kapsule-clusters-with-only-public-ip 2024-05-22

### DIFF
--- a/changelog/may2024/2024-05-22-kubernetes-removed-kapsule-clusters-with-only-public-ip.mdx
+++ b/changelog/may2024/2024-05-22-kubernetes-removed-kapsule-clusters-with-only-public-ip.mdx
@@ -9,5 +9,5 @@ category: containers
 product: kubernetes
 ---
 
-Ending the deprecation cycle and completing the planned migration, all Kapsule clusters are natively deployed with a [Scaleway Private Network](https://www.scaleway.com/en/docs/containers/kubernetes/reference-content/secure-cluster-with-private-network/#why-have-a-private-network-for-your-kubernetes-kapsule-cluster).
+Ending the deprecation cycle and completing the planned migration, all Kapsule clusters are natively deployed with a [Scaleway Private Network](/containers/kubernetes/reference-content/secure-cluster-with-private-network/#why-have-a-private-network-for-your-kubernetes-kapsule-cluster).
 

--- a/changelog/may2024/2024-05-22-kubernetes-removed-kapsule-clusters-with-only-public-ip.mdx
+++ b/changelog/may2024/2024-05-22-kubernetes-removed-kapsule-clusters-with-only-public-ip.mdx
@@ -1,0 +1,13 @@
+---
+title: Kapsule clusters with only public IPs
+status: removed
+author:
+    fullname: 'Join the #k8s channel on Slack.'
+    url: 'https://slack.scaleway.com'
+date: 2024-05-22
+category: containers
+product: kubernetes
+---
+
+Ending the deprecation cycle and completing the planned migration, all Kapsule clusters are natively deployed with a [Scaleway Private Network](https://www.scaleway.com/en/docs/containers/kubernetes/reference-content/secure-cluster-with-private-network/#why-have-a-private-network-for-your-kubernetes-kapsule-cluster).
+


### PR DESCRIPTION
Reporter: tgenaitay

This PR is a new changelog contribution. It has been created automatically.

Make sure to review it carefully before merging it.