### PR TITLE
feat(changelog): kubernetes-removed-scaleway-kubernetes-products-no-long 2024-05-22

### DIFF
--- a/changelog/may2024/2024-05-22-kubernetes-removed-scaleway-kubernetes-products-no-long.mdx
+++ b/changelog/may2024/2024-05-22-kubernetes-removed-scaleway-kubernetes-products-no-long.mdx
@@ -9,7 +9,7 @@ category: containers
 product: kubernetes
 ---
 
-Clusters using the Kubernetes 1.24 version will be upgraded to the Kubernetes 1.25 version after May 15th, 2024.
+Clusters using the Kubernetes 1.24 version will be upgraded to Kubernetes 1.25 after May 15th, 2024.
 Scaleway will change the CNI configuration to `none` for clusters still running unsupported CNIs (Flannel, Weave).
 Find more details in our [version support policy](https://www.scaleway.com/en/docs/containers/kubernetes/reference-content/version-support-policy/#supported-container-network-interfaces-cni).
 

--- a/changelog/may2024/2024-05-22-kubernetes-removed-scaleway-kubernetes-products-no-long.mdx
+++ b/changelog/may2024/2024-05-22-kubernetes-removed-scaleway-kubernetes-products-no-long.mdx
@@ -1,0 +1,15 @@
+---
+title: Scaleway Kubernetes products no longer support Kubernetes 1.24
+status: removed
+author:
+    fullname: 'Join the #k8s channel on Slack.'
+    url: 'https://slack.scaleway.com'
+date: 2024-05-22
+category: containers
+product: kubernetes
+---
+
+Clusters using the Kubernetes 1.24 version will be upgraded to the Kubernetes 1.25 version after May 15th, 2024.
+Scaleway will change the CNI configuration to `none` for clusters still running unsupported CNIs (Flannel, Weave).
+Find more details in our [version support policy](https://www.scaleway.com/en/docs/containers/kubernetes/reference-content/version-support-policy/#supported-container-network-interfaces-cni).
+


### PR DESCRIPTION
Reporter: tgenaitay

This PR is a new changelog contribution. It has been created automatically.

Make sure to review it carefully before merging it.