### PR TITLE
chore(k8s): remove 1.24 from version support

### DIFF
--- a/containers/kubernetes/reference-content/version-support-policy.mdx
+++ b/containers/kubernetes/reference-content/version-support-policy.mdx
@@ -61,7 +61,6 @@ When a minor version becomes unsupported, Scaleway operates an upgrade to the la
 | 1.27               | April 2023       | June 2024            | April 2023                   | February 2025*   | April 7, 2025*    |
 | 1.26               | December 2022    | February 2024        | February 6, 2023             | February 2025    | March 6, 2025     |
 | 1.25               | August 2022      | October 2023         | February 6, 2023             | February 2025    | March 6, 2025     |
-| 1.24               | April 2022       | July 2023            | April 2022                   | April 2024       | May 15, 2024      |
 
 <Message type="important">
 * New support policy: from the release of version 1.29, Scaleway's support window has shifted to 14 months.
@@ -93,9 +92,6 @@ The following documentation only lists the main feature changes for each version
 ### 1.25
 * Official [release announcement](https://kubernetes.io/blog/2022/08/23/kubernetes-v1-25-release/)
 * 13 enhancements graduated to GA (see announcement for full list).
-
-### 1.24
-* Official [release announcement](https://kubernetes.io/blog/2022/05/03/kubernetes-1-24-release-announcement/).
 
 ## Supported Container Network Interfaces (CNI)
 


### PR DESCRIPTION
### Your checklist for this pull request

- [X] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

No more 1.24