### PR TITLE
fix(messaging): support for SNS RedrivePolicy is disabled for now

### DIFF
--- a/serverless/messaging/reference-content/sns-support.mdx
+++ b/serverless/messaging/reference-content/sns-support.mdx
@@ -271,5 +271,5 @@ SetSubscriptionAttributes requires the `CanReceive` or `CanManage` permission.
 | DeliveryPolicy      |   **N**   |            |
 | FilterPolicy        |   **N**   |            |
 | RawMessageDelivery  |   **N**   |            |
-| RedrivePolicy       |   **Y**   |            |
+| RedrivePolicy       |   **N**   |            |
 | SubscriptionRoleArn |   **N**   |            |


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

SNS RedrivePolicies are disabled for now, we will work on making them work later, after GA.
