### PR TITLE
chore(k8s): expanding support of GPU operator

### DIFF
--- a/containers/kubernetes/how-to/use-nvidia-gpu-operator.mdx
+++ b/containers/kubernetes/how-to/use-nvidia-gpu-operator.mdx
@@ -14,7 +14,7 @@ categories:
   - kubernetes
 ---
 
-Kubernetes Kapsule and Kosmos supports NVIDIA's official Kubernetes operator for all GPU pools.
+Kubernetes Kapsule and Kosmos support NVIDIA's official Kubernetes operator for all GPU pools.
 This operator is compatible with [RENDER-S](https://www.scaleway.com/en/gpu-instances/), [GPU-3070-S](https://www.scaleway.com/en/gpu-3070-instances/), [H100 PCIe](https://www.scaleway.com/en/h100-pcie-try-it-now/), [L40s](https://www.scaleway.com/en/l40s-gpu-instance/) and [L4](https://www.scaleway.com/en/l4-gpu-instance/) offers.
 
 The GPU operator is setup for all GPU pools created in Kubernetes Kapsule and Kosmos, providing automated installation of all required software on GPU worker nodes, such as the device plugin, container toolkit, GPU drivers etc. For more information, refer to [the GPU operator overview](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/overview.html).

--- a/containers/kubernetes/how-to/use-nvidia-gpu-operator.mdx
+++ b/containers/kubernetes/how-to/use-nvidia-gpu-operator.mdx
@@ -7,17 +7,17 @@ content:
   paragraph: This page explains how to use the NVIDIA GPU operator on Kapsule and Kosmos with GPU Instances
 tags: kubernetes kubernetes-kapsule kapsule cluster gpu-operator nvidia gpu
 dates:
-  validation: 2023-12-29
+  validation: 2024-05-22
   posted: 2023-07-18
 categories:
   - containers
   - kubernetes
 ---
 
-A new Kubernetes operator provided by NVIDIA to support all GPU pools is being introduced on Kubernetes Kapsule and Kosmos.
-This operator is compatible with both [RENDER-S](https://www.scaleway.com/en/gpu-instances/) and [GPU-3070-S](https://www.scaleway.com/en/gpu-3070-instances/) offers.
+Kubernetes Kapsule and Kosmos supports NVIDIA's official Kubernetes operator for all GPU pools.
+This operator is compatible with [RENDER-S](https://www.scaleway.com/en/gpu-instances/), [GPU-3070-S](https://www.scaleway.com/en/gpu-3070-instances/), [H100 PCIe](https://www.scaleway.com/en/h100-pcie-try-it-now/), [L40s](https://www.scaleway.com/en/l40s-gpu-instance/) and [L4](https://www.scaleway.com/en/l4-gpu-instance/) offers.
 
-The GPU operator is available for all newly created GPU pools and provides automated installation of all required software on GPU worker nodes, such as the device plugin, container toolkit, GPU drivers etc. For more information, refer to [the GPU operator overview](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/overview.html).
+The GPU operator is setup for all GPU pools created in Kubernetes Kapsule and Kosmos, providing automated installation of all required software on GPU worker nodes, such as the device plugin, container toolkit, GPU drivers etc. For more information, refer to [the GPU operator overview](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/overview.html).
 
 <Macro id="requirements" />
 
@@ -27,7 +27,7 @@ The GPU operator is available for all newly created GPU pools and provides autom
 
 ## How to get the GPU operator for a new pool?
 
-Scaleway uses Helm to automate the deployment of the GPU operator in your GPU node pools. It is installed by default on all new GPU pools.
+Scaleway uses Helm to automate the deployment of the GPU operator in your GPU node pools. It is installed by default on every GPU pools.
 
 1. Click **Kubernetes** in the Containers section of the side menu. The Kubernetes creation page displays.
 2. Select the cluster you want to add a pool to.
@@ -35,7 +35,7 @@ Scaleway uses Helm to automate the deployment of the GPU operator in your GPU no
 4. Click the **+ Add pool** button. The pool creation wizard displays.
 5. If you are using a **Kosmos** cluster, you can optionally choose a **pool type**. Select a Scaleway Kubernetes Kapsule pool.
 6. Choose the zone in which your pool will be deployed.
-7. Click the **GPU** tab and select the GPU Instance you want to add. Currently, both RENDER-S and GPU-3070-S Instances are supported by the operator.
+7. Click the **GPU** tab and select the GPU Instance you want to add.
 8. Configure the pool options for your pool.
 9. Click **Add pool** to deploy the pool. The GPU operator displays in the Easy Deploy tab of your pool and your `kube-system` namespace.
 

--- a/containers/kubernetes/how-to/use-nvidia-gpu-operator.mdx
+++ b/containers/kubernetes/how-to/use-nvidia-gpu-operator.mdx
@@ -17,7 +17,7 @@ categories:
 Kubernetes Kapsule and Kosmos support NVIDIA's official Kubernetes operator for all GPU pools.
 This operator is compatible with [RENDER-S](https://www.scaleway.com/en/gpu-instances/), [GPU-3070-S](https://www.scaleway.com/en/gpu-3070-instances/), [H100 PCIe](https://www.scaleway.com/en/h100-pcie-try-it-now/), [L40s](https://www.scaleway.com/en/l40s-gpu-instance/) and [L4](https://www.scaleway.com/en/l4-gpu-instance/) offers.
 
-The GPU operator is setup for all GPU pools created in Kubernetes Kapsule and Kosmos, providing automated installation of all required software on GPU worker nodes, such as the device plugin, container toolkit, GPU drivers etc. For more information, refer to [the GPU operator overview](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/overview.html).
+The GPU operator is set up for all GPU pools created in Kubernetes Kapsule and Kosmos, providing automated installation of all required software on GPU worker nodes, such as the device plugin, container toolkit, GPU drivers etc. For more information, refer to [the GPU operator overview](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/overview.html).
 
 <Macro id="requirements" />
 


### PR DESCRIPTION
### Your checklist for this pull request

- [X] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

The doc stated only 2 GPU types. Since end 2023, three new GPU instances have been introduced: H100 PCIe, L40s, L4. 
The revised doc clarifies the current scope.