### PR TITLE
docs(elastic-metal): added step to persist private network configuration across reboots

### DIFF
--- a/bare-metal/elastic-metal/how-to/use-private-networks.mdx
+++ b/bare-metal/elastic-metal/how-to/use-private-networks.mdx
@@ -127,11 +127,11 @@ You must configure the virtual network interface on each Elastic Metal server yo
     network:
       version: 2
       vlans:
-        eno1.3418:
-          id: 3418
+        eno1.1234:
+          id: 1234
           link: eno1
           addresses:
-            - 10.0.0.5/22
+            - 10.10.10.10/24
     ```
     <Message type="tip">
       You might want to use the `sudo netplan try` command to test your configuration before applying it. Apply the configuration with `sudo netplan apply`.

--- a/bare-metal/elastic-metal/how-to/use-private-networks.mdx
+++ b/bare-metal/elastic-metal/how-to/use-private-networks.mdx
@@ -121,6 +121,21 @@ You must configure the virtual network interface on each Elastic Metal server yo
     ```bash
     sudo ip addr add 10.10.10.10/24 dev eno1.1234
     ```
+7. Optionally persist this configuration across reboots by creating a new netplan configuration. Make the necessary replacements for `eno1` and `1234` as you did previously.
+    ```yaml
+    # e.g.: /etc/netplan/51-private-networks.yaml
+    network:
+      version: 2
+      vlans:
+        eno1.3418:
+          id: 3418
+          link: eno1
+          addresses:
+            - 10.0.0.5/22
+    ```
+    <Message type="tip">
+      You might want to use the `sudo netplan try` command to test your configuration before applying it. Apply the configuration with `sudo netplan apply`.
+    </Message>
 ## How to configure the Private Network on Windows Server 2019
 
 1. Log into your server as `Administrateur` using the Remote Desktop client.


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

Added optional step to explain how to persist the adding of a private network configuration for elastic metal servers with netplan.

Source page: https://www.scaleway.com/en/docs/bare-metal/elastic-metal/how-to/use-private-networks/#how-to-configure-the-network-interface-on-your-elastic-metal-server-for-private-networks