### PR TITLE
feat(acc): partner space doc

### DIFF
--- a/bare-metal/elastic-metal/how-to/use-private-networks.mdx
+++ b/bare-metal/elastic-metal/how-to/use-private-networks.mdx
@@ -121,6 +121,21 @@ You must configure the virtual network interface on each Elastic Metal server yo
     ```bash
     sudo ip addr add 10.10.10.10/24 dev eno1.1234
     ```
+7. Optionally persist this configuration across reboots by creating a new netplan configuration. Make the necessary replacements for `eno1` and `1234` as you did previously.
+    ```yaml
+    # e.g.: /etc/netplan/51-private-networks.yaml
+    network:
+      version: 2
+      vlans:
+        eno1.1234:
+          id: 1234
+          link: eno1
+          addresses:
+            - 10.10.10.10/24
+    ```
+    <Message type="tip">
+      You might want to use the `sudo netplan try` command to test your configuration before applying it. Apply the configuration with `sudo netplan apply`.
+    </Message>
 ## How to configure the Private Network on Windows Server 2019
 
 1. Log into your server as `Administrateur` using the Remote Desktop client.

--- a/menu/navigation.json
+++ b/menu/navigation.json
@@ -7,6 +7,54 @@
           {
             "items": [
               {
+                "label": "Partner Space Overview",
+                "slug": "../partner-space"
+              },
+              {
+                "label": "Concepts",
+                "slug": "concepts"
+              },
+              {
+                "label": "Quickstart",
+                "slug": "quickstart"
+              },
+
+              {
+                "items": [
+                  {
+                    "label": "Add a client",
+                    "slug": "add-client"
+                  },
+                  {
+                    "label": "Edit client information",
+                    "slug": "edit-client-information"
+                  },
+                  {
+                    "label": "Lock a client's Organization",
+                    "slug": "lock-client-organization"
+                  },
+                  {
+                    "label": "Unlock a client's Organization",
+                    "slug": "unlock-client-organization"
+                  }
+                ],
+                "label": "How to",
+                "slug": "how-to"
+              }
+            ],
+            "label": "Partner Space",
+            "slug": "partner-space"
+          }
+        ],
+        "label": "Partners",
+        "slug": "partners"
+      },
+      {
+        "icon": "console",
+        "items": [
+          {
+            "items": [
+              {
                 "label": "Account Overview",
                 "slug": "../account"
               },

--- a/menu/navigation.json
+++ b/menu/navigation.json
@@ -7,54 +7,6 @@
           {
             "items": [
               {
-                "label": "Partner Space Overview",
-                "slug": "../partner-space"
-              },
-              {
-                "label": "Concepts",
-                "slug": "concepts"
-              },
-              {
-                "label": "Quickstart",
-                "slug": "quickstart"
-              },
-
-              {
-                "items": [
-                  {
-                    "label": "Add a client",
-                    "slug": "add-client"
-                  },
-                  {
-                    "label": "Edit client information",
-                    "slug": "edit-client-information"
-                  },
-                  {
-                    "label": "Lock a client's Organization",
-                    "slug": "lock-client-organization"
-                  },
-                  {
-                    "label": "Unlock a client's Organization",
-                    "slug": "unlock-client-organization"
-                  }
-                ],
-                "label": "How to",
-                "slug": "how-to"
-              }
-            ],
-            "label": "Partner Space",
-            "slug": "partner-space"
-          }
-        ],
-        "label": "Partners",
-        "slug": "partners"
-      },
-      {
-        "icon": "console",
-        "items": [
-          {
-            "items": [
-              {
                 "label": "Account Overview",
                 "slug": "../account"
               },
@@ -4725,6 +4677,54 @@
         ],
         "label": "Dedibox Network",
         "slug": "dedibox-network"
+      },
+      {
+        "icon": "console",
+        "items": [
+          {
+            "items": [
+              {
+                "label": "Partner Space Overview",
+                "slug": "../partner-space"
+              },
+              {
+                "label": "Concepts",
+                "slug": "concepts"
+              },
+              {
+                "label": "Quickstart",
+                "slug": "quickstart"
+              },
+
+              {
+                "items": [
+                  {
+                    "label": "Add a client",
+                    "slug": "add-client"
+                  },
+                  {
+                    "label": "Edit client information",
+                    "slug": "edit-client-information"
+                  },
+                  {
+                    "label": "Lock a client's Organization",
+                    "slug": "lock-client-organization"
+                  },
+                  {
+                    "label": "Unlock a client's Organization",
+                    "slug": "unlock-client-organization"
+                  }
+                ],
+                "label": "How to",
+                "slug": "how-to"
+              }
+            ],
+            "label": "Partner Space",
+            "slug": "partner-space"
+          }
+        ],
+        "label": "Partners",
+        "slug": "partners"
       }
     ],
     "label": "Product Categories"

--- a/partners/index.mdx
+++ b/partners/index.mdx
@@ -1,0 +1,8 @@
+---
+meta:
+  title: Scaleway for Partners
+  description: Discover Scaleway for Partners
+content:
+  h1: Scaleway for Partners
+  paragraph: Discover Scaleway for Partners
+---

--- a/partners/partner-space/concepts.mdx
+++ b/partners/partner-space/concepts.mdx
@@ -24,7 +24,6 @@ The consumption refers to a customer's use of Scaleway resources. This value is 
 
 The Partner Space is a dedicated interface within the Scaleway console. It allows resellers to manage their clients' consumption and billing. 
 
-
 ## Reseller ID
 
 The reseller ID is your unique Scaleway identifier as a Partner. It is the same as your Organization ID.

--- a/partners/partner-space/concepts.mdx
+++ b/partners/partner-space/concepts.mdx
@@ -1,0 +1,30 @@
+---
+meta:
+  title: Partner Space - Concepts
+  description: This page explains all the concepts related to Scaleway Partner Space
+content:
+  h1: Partner Space - Concepts
+  paragraph: This page explains all the concepts related to Scaleway Partner Space
+tags: partner-space
+dates:
+  validation: 2024-05-27
+categories:
+  - partner-space
+---
+
+## Client ID
+
+The Client ID represents your client’s identifier in your own internal management tools. This ID is requested when you add a new client and allows the API to function properly. 
+
+## Consumption
+
+The consumption refers to a customer's use of Scaleway resources. This value is monthly and corresponds to a period running from the first of the month to the last day of the month. 
+
+## Partner Space
+
+The Partner Space is a dedicated interface within the Scaleway console. It allows resellers to manage their clients' consumption and billing. 
+
+
+## Reseller ID
+
+The reseller ID is your unique Scaleway identifier as a Partner. It is the same as your Organization ID.

--- a/partners/partner-space/how-to/add-client.mdx
+++ b/partners/partner-space/how-to/add-client.mdx
@@ -1,0 +1,28 @@
+---
+meta:
+  title: How to add a client
+  description: This page explains how to add a client from the Partner Space.
+content:
+  h1: How to add a client
+  paragraph: This page explains how to add a client from the Partner Space.
+tags: partner-space 
+dates:
+  validation: 2024-05-27
+  posted: 2024-05-27
+categories:
+  - partner-space
+---
+
+<Macro id="requirements" />
+
+- A Scaleway account logged into the [console](https://console.scaleway.com)
+- Scaleway Partner status
+
+1. From your Organization dashboard, click **Go to Partner Space**.
+2. Click **Add client**.
+3. Complete the following steps: 
+    - Enter your client’s **company name**. 
+    - Enter your client’s **SIREN** number. 
+    - Enter the **Client ID**. This refers to the customer ID in your internal tools. 
+    - Enter the **first name**, **last name**, **email address**, and **phone number** of a contact of your choice within the client company. Note that this person will receive an email inviting them to join the Organization that will be created. 
+4. Click **Add client** to confirm. The list of your clients displays.

--- a/partners/partner-space/how-to/edit-client-information.mdx
+++ b/partners/partner-space/how-to/edit-client-information.mdx
@@ -1,0 +1,27 @@
+---
+meta:
+  title: How to edit client information
+  description: This page explains how to edit client information the Partner Space.
+content:
+  h1: How to edit client information
+  paragraph: This page explains how to edit client information from the Partner Space.
+tags: partner-space 
+dates:
+  validation: 2024-05-27
+  posted: 2024-05-27
+categories:
+  - partner-space
+---
+
+<Macro id="requirements" />
+
+- A Scaleway account logged into the [console](https://console.scaleway.com)
+- Scaleway Partner status
+
+1. Click the **See more** button (<Icon name="more" />) to the right of the client’s creation date. 
+2. Edit the **Client ID** and/or the **email address**. 
+
+    <Message type="note">
+     You must edit the Client ID before the 25th of the current month to apply it to your next invoice.
+    </Message>
+3. Click **Apply changes** to confirm. 

--- a/partners/partner-space/how-to/index.mdx
+++ b/partners/partner-space/how-to/index.mdx
@@ -1,0 +1,8 @@
+---
+meta:
+  title: Partner Space - How Tos
+  description: Partner Space How Tos
+content:
+  h1: Partner Space - How Tos
+  paragraph: Partner Space How Tos
+---

--- a/partners/partner-space/how-to/lock-client-organization.mdx
+++ b/partners/partner-space/how-to/lock-client-organization.mdx
@@ -1,0 +1,30 @@
+---
+meta:
+  title: How to lock a client's Organization
+  description: This page explains how to lock a client's Organization from the Partner Space.
+content:
+  h1: How to lock a client's Organization
+  paragraph: This page explains how to lock a client's Organization from the Partner Space.
+tags: partner-space 
+dates:
+  validation: 2024-05-27
+  posted: 2024-05-27
+categories:
+  - partner-space
+---
+
+If you are confronted with a client who does not respect Scaleway’s Terms of Service, you can lock their Organisation. 
+
+<Macro id="requirements" />
+
+- A Scaleway account logged into the [console](https://console.scaleway.com)
+- Scaleway Partner status
+
+  <Message type="important">
+     Locking an Organization prevents its owner to order or manage resources. .
+    </Message>
+
+1. Click the **See more** button (<Icon name="more" />) to the right of the client’s creation date. 
+2. Click **Lock Organization**. A pop-up displays.
+3. Type **LOCK** in the text area.
+4. Click **Lock** to confirm. 

--- a/partners/partner-space/how-to/unlock-client-organization.mdx
+++ b/partners/partner-space/how-to/unlock-client-organization.mdx
@@ -1,0 +1,25 @@
+---
+meta:
+  title: How to unlock a client's Organization
+  description: This page explains how to unlock a client's Organization from the Partner Space.
+content:
+  h1: How to unlock a client's Organization
+  paragraph: This page explains how to unlock a client's Organization from the Partner Space.
+tags: partner-space 
+dates:
+  validation: 2024-05-27
+  posted: 2024-05-27
+categories:
+  - partner-space
+---
+
+<Macro id="requirements" />
+
+- A Scaleway account logged into the [console](https://console.scaleway.com)
+- Scaleway Partner status
+
+ 
+1. Click the **See more** button (<Icon name="more" />) to the right of the client’s creation date. 
+2. Click **Unlock Organization**. A pop-up displays.
+3. Type **UNLOCK** in the text area.
+4. Click **Unlock** to confirm. 

--- a/partners/partner-space/index.mdx
+++ b/partners/partner-space/index.mdx
@@ -1,0 +1,41 @@
+---
+meta:
+  title: Partner Space Documentation
+  description: Dive into Scaleway Partner Space with our quickstart guide, how-tos, and more.
+---
+
+<ProductHeader 
+   productName="Partner Space"
+   productLogo="iam"
+   description="As a Scaleway Partner, you benefit from a dedicated interface within the console: the Partner Space. It empowers you to manage your client efficiently, from creating their Organizations to monitoring their consumption for accurate billing."
+   url="/console/partner-space/quickstart/"
+   label="Partner Space quickstart"
+/>
+
+## Getting Started
+
+<Grid>
+    <SummaryCard
+        title="Quickstart"
+        icon="rocket"
+        description="Learn how to add your first clients and follow their consumption."
+        label="View Quickstart"
+        url="/console/partner-space/quickstart/"
+    />
+    <SummaryCard
+        title="Concepts"
+        icon="info"
+        description="Core concepts that give you a better understanding of the Partner Space."
+        label="View Concepts"
+        url="/console/partner-space/concepts/"
+    />
+    <SummaryCard
+        title="How-Tos"
+        icon="help-circle-outline"
+        description="Check our detailed guides to learn how to use the Partner Space."
+        label="View How-Tos"
+        url="/console/account/how-to/"
+    />
+</Grid>
+
+

--- a/partners/partner-space/quickstart.mdx
+++ b/partners/partner-space/quickstart.mdx
@@ -20,26 +20,23 @@ The Partner Space is a dedicated section of the Scaleway console, allowing resel
 - A Scaleway account logged into the [console](https://console.scaleway.com)
 - Scaleway Partner status
 
-
-## How to add a client 
+## How to add a client
 
 1. From your Organization dashboard, click **Go to Partner Space**.
 2. Click **Add client**.
-3. Complete the following steps: 
-    - Enter your client’s **company name**. 
-    - Enter your client’s **SIREN** number. 
-    - Enter the **Client ID**. This refers to the customer ID in your internal tools. 
-    - Enter the **first name**, **last name**, **email address**, and **phone number** of a contact of your choice within the client company. Note that this person will receive an email inviting them to join the Organization that will be created. 
+3. Complete the following steps:
+    - Enter your client’s **company name**.
+    - Enter your client’s **SIREN** number.
+    - Enter the **Client ID**. This refers to the customer ID in your internal tools.
+    - Enter the **first name**, **last name**, **email address**, and **phone number** of a contact of your choice within the client company. Note that this person will receive an email inviting them to join the Organization that will be created.
 4. Click **Add client** to confirm. The list of your clients displays.
 
+### How to edit client information
 
-
-### How to edit client information 
-
-1. Click <Icon name="more" /> to the right of the client’s creation date. 
-2. Edit the **Client ID** and/or the **email address**. 
+1. Click <Icon name="more" /> to the right of the client’s creation date.
+2. Edit the **Client ID** and/or the **email address**.
 
     <Message type="note">
      You must edit the Client ID before the 25th of the current month to apply it to your next invoice.
     </Message>
-3. Click **Apply changes** to confirm. 
+3. Click **Apply changes** to confirm.

--- a/partners/partner-space/quickstart.mdx
+++ b/partners/partner-space/quickstart.mdx
@@ -1,0 +1,45 @@
+---
+meta:
+  title: Partner Space - Quickstart
+  description: This page shows you how to get started with Scaleway Partner Space.
+content:
+  h1: Partner Space - Quickstart
+  paragraph: This page shows you how to get started with the Scaleway Partner Space.
+tags: partner-space
+dates:
+  validation: 2024-05-27
+  posted: 2024-05-27
+categories:
+  - partner-space
+---
+
+The Partner Space is a dedicated section of the Scaleway console, allowing resellers to manage their client consumption.
+
+<Macro id="requirements" />
+
+- A Scaleway account logged into the [console](https://console.scaleway.com)
+- Scaleway Partner status
+
+
+## How to add a client 
+
+1. From your Organization dashboard, click **Go to Partner Space**.
+2. Click **Add client**.
+3. Complete the following steps: 
+    - Enter your client’s **company name**. 
+    - Enter your client’s **SIREN** number. 
+    - Enter the **Client ID**. This refers to the customer ID in your internal tools. 
+    - Enter the **first name**, **last name**, **email address**, and **phone number** of a contact of your choice within the client company. Note that this person will receive an email inviting them to join the Organization that will be created. 
+4. Click **Add client** to confirm. The list of your clients displays.
+
+
+
+### How to edit client information 
+
+1. Click the **See more** button (<Icon name="more" />) to the right of the client’s creation date. 
+2. Edit the **Client ID** and/or the **email address**. 
+
+    <Message type="note">
+     You must edit the Client ID before the 25th of the current month to apply it to your next invoice.
+    </Message>
+3. Click **Apply changes** to confirm. 


### PR DESCRIPTION
Added a new category: Partners
+ Sub-category: Partner Space

This documentation explains how to use the upcoming Partner Space. In the future, this category will also include general information about Partners (e.g., how to become a Scaleway Partner). 

Do not merge until the Partner Center is released 