### PR TITLE
fix(sdb): update serverless-sql-databases-overview

### DIFF
--- a/serverless/sql-databases/reference-content/serverless-sql-databases-overview.mdx
+++ b/serverless/sql-databases/reference-content/serverless-sql-databases-overview.mdx
@@ -24,12 +24,12 @@ While your database is in an idle state, you will not be billed for compute reso
 
 ## Technical specifications
 
-| Specification   | Minimum | Maximum                   |
-|-----------------|---------|---------------------------|
-| vCPU            | 0 vCPU  | 15 vCPU                   |
-| RAM             | 0 GB    | 60 GB (4 GB/vCPU)         |
-| Storage\*       | 0 GB    | 1 TB (100 GB during beta) |
-| Connections\*\* | 0       | 1000                      |
+| Specification   | Minimum | Maximum                                          |
+|-----------------|---------|--------------------------------------------------|
+| vCPU            | 0 vCPU  | 15 vCPU                                          |
+| RAM             | 0 GB    | 60 GB (4 GB/vCPU)                                |
+| Storage\*       | 0 GB    | 100 GB (1 TB planned after General Availability) |
+| Connections\*\* | 0       | 1000                                             |
 
 \* The maximum storage capacity will increase with upcoming releases.
 


### PR DESCRIPTION
Since we won't be able to support database above 100 GB size right after GA, I want to correct his information. The support for up to 1 TB database sizes will be added a few weeks after General Availability.

### Your checklist for this pull request

- [ ] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

Please describe what you added or changed.
