### PR TITLE
fix(pgw): modify info for routed ips and pgws

### DIFF
--- a/menu/navigation.json
+++ b/menu/navigation.json
@@ -2808,10 +2808,6 @@
                     "slug": "use-flexible-ips"
                   },
                   {
-                    "label": "Move to routed IP",
-                    "slug": "move-to-routed-ip"
-                  },
-                  {
                     "label": "Delete a Public Gateway",
                     "slug": "delete-a-public-gateway"
                   }

--- a/network/public-gateways/concepts.mdx
+++ b/network/public-gateways/concepts.mdx
@@ -41,9 +41,7 @@ An **I**nternet **P**rotocol address is a unique address that identifies a devic
 
 ## IP mobility
 
-Scaleway is implementing IP mobility across its resources. This entails changing the way that we internally map public IP addresses to physical machines and the virtual resources they host. Previously, a highly available **NAT** (Network Address Translation) solution was used to make IP addresses move with the attached virtual resource between physical machines. Going forward, a more efficient and future-proof **routed** IP solution will be used. In time, this will bring new benefits such as support for IPv6 on Public Gateways.
-
-Moving to routed IPs on your Public Gateway is a simple process. Read our [dedicated how-to guide](/network/public-gateways/how-to/move-to-routed-ip/), or see our [blog post](https://www.scaleway.com/en/blog/ip-mobility-removing-nat/) for more background information on this project.
+Scaleway is implementing [IP mobility](https://www.scaleway.com/en/blog/ip-mobility-removing-nat/) across its resources. This entails changing the way that we internally map public IP addresses to physical machines and the virtual resources they host. Previously, a highly available **NAT** (Network Address Translation) solution was used to make IP addresses move with the attached Public Gateway between physical machines. Now, all Public Gateways use a more efficient and future-proof **routed** IP solution. In time, this will bring new benefits such as support for IPv6 on Public Gateways.
 
 ## IPAM
 

--- a/network/public-gateways/how-to/move-to-routed-ip.mdx
+++ b/network/public-gateways/how-to/move-to-routed-ip.mdx
@@ -13,58 +13,11 @@ categories:
   - network
 ---
 
-Public Gateways have a [public flexible IP address ](/network/public-gateways/concepts/#flexible-ip) which makes the Public Gateway accessible over the internet. Internally at Scaleway, these IP addresses have so far been implemented via a NAT (Network Address Translation) solution. Going forward, we are moving to a more efficient routed IP solution.
+Public Gateways have a [public flexible IP address ](/network/public-gateways/concepts/#flexible-ip) which makes the Public Gateway accessible over the internet. Internally at Scaleway, these IP addresses were originally implemented via a NAT (Network Address Translation) solution. We have now moved to a more efficient routed IP solution. 
 
-You can move your Public Gateway from NAT to routed IP addressing by following the simple steps outlined on this page. **Your IP address itself will not change**. This is purely a backend modification to the method Scaleway uses to map IP addresses to the physical hypervisors hosting your resources. Moving to routed IP will simply update your current network interface for a new one, while keeping your attached IP address.
+Scaleway users were invited to manually move their Public Gateways from NAT to routed at a time that suited them. Between the 27th and 31st May 2024, all remaining Public Gateways will NAT IPs were then automatically moved to routed IPs.  
 
-In this first phase, you may choose when to move your Public Gateway from NAT to routed by following the steps below at a time best suited to you. In a future phase, scheduled for 27th - 31st May 2024, all Public Gateways that still have NAT IPs will be automatically moved to routed IPs. We strongly recommend that you move your gateway to routed IP yourself, before automatic migration.
+Moving to routed IP is purely a backend modification to the method Scaleway uses to map IP addresses to the physical hypervisors hosting your resources. It updates your current network interface for a new one, while keeping your attached IP address.
 
-Note the following when moving a Public Gateway from NAT IP to routed IP:
-- There should be only a few seconds of service interruption
-- Your IP address will not change, and no additional configuration should be necessary
-- Once done, this action cannot be undone
-- Via the Scaleway console, you can only move Public Gateways one at a time to routed IP
-- Via the [API](https://www.scaleway.com/en/developers/api/vpc/), you can move multiple Public Gateways at a time to routed IP.
-
-Moving your Public Gateway to routed IPs will ensure that when features such as IPv6 are released in the future, your gateway will be compatible. The move from NAT to routed IPs is part of Scaleway's overarching IP mobility project. Read our blog post for [full information](https://www.scaleway.com/en/blog/ip-mobility-removing-nat/).
-
-<Macro id="requirements" />
-
-- A Scaleway account logged into the [console](https://console.scaleway.com)
-- A Public Gateway created before 20 March 2024 which is not yet moved to routed IP
-
-## How to move a Public Gateway to routed IP
-
-When you move a Public Gateway to routed IP, it will become unavailable for a few seconds while the move is carried out. Choose the best time to carry out the following steps accordingly.
-
-1. Click **Public Gateways** in the **Network** section of the side menu. A list of your Public Gateways displays.
-
-    <Lightbox src="scaleway-move-pgw-ip.webp" alt="" />
-
-2. Click **Move IP** next to the gateway you are ready to move to routed IP. A pop-up displays:
-
-    <Lightbox src="scaleway-confirm-p0.0.0.0/0gw-ip-move.webp" alt="" />
-
-    Remember that:
-    - Moving to routed IP affects only the underlying addressing technique
-    - Your IP address will not change
-    - You should experience only a few seconds of service unavailability while the move is carried out
-
-3. Type **MOVE** in the box to confirm, and click **Move to routed IP**.
-
-    The move is carried out and you are returned to the list of your Public Gateways, where a green `running` status dot indicates that your gateway is in service and has been successfully moved to routed IP.
-
-    <Message type="tip">
-    You can also access the `Move IP` button from an individual Public Gateway's **Overview** page.
-    </Message>
-
-## How to troubleshoot problems
-
-If there are any problems in moving your Public Gateway to routed IP, your gateway will remain in a `Configuring` state, indicated by a blue status dot next to its name in the list of gateways. If this persists and your gateway does not return to a `Running` state with a green dot, open a [support ticket](https://console.scaleway.com/support/tickets/create).
-
-## Additional information
-
-From now on: 
-- When you create a new Public Gateway, it will be automatically created with routed IP addressing. This is the case whether you choose to create a new flexible IP address for the gateway, or attach an existing IP address.
-- When you create a new flexible IP address and attach it to an existing Public Gateway, the gateway will automatically be moved to routed IP (if not already moved).
+Having routed IPs ensures that when features such as IPv6 are released in the future, your gateway will be compatible. The move from NAT to routed IPs is part of Scaleway's overarching IP mobility project. Read our blog post for [full information](https://www.scaleway.com/en/blog/ip-mobility-removing-nat/).
 


### PR DESCRIPTION
Update PGW documentation re: moving from NAT IP to routed IP.

The automatic migration has now been carried out, so the "How to move to routed IP" doc is no longer necessary, hence it is removed from the menu. 

We should keep the page up for a little bit as a record of what happened, because the link was sent to a lot of users in the warning emails. 

At the next 6 month review of this document, we can delete the page.
