### PR TITLE
fix(bare-metal): Use iam ssh-key instead of account ssh-key

### DIFF
--- a/bare-metal/elastic-metal/api-cli/elastic-metal-with-cli.mdx
+++ b/bare-metal/elastic-metal/api-cli/elastic-metal-with-cli.mdx
@@ -99,7 +99,7 @@ The [Scaleway Command Line Interface (CLI)](https://github.com/scaleway/scaleway
 2. Write down the ID of the OS you want to install.
 3. Type the following command to display the list of your SSH key's ID:
     ```
-    scw account ssh-key list
+    scw iam ssh-key list
     ```
 
     You will see an output similar to the following:


### PR DESCRIPTION
### Description

The command `scw account ssh-key list` does not seem to exist anymore.
Therefore this commit makes use of the new `scw iam` command.