### PR TITLE
docs(LoadBalancer): LoadBalancer and Kubernetes https error troubleshooting

### DIFF
--- a/network/load-balancer/troubleshooting/load-balancer-kubernetes-https-error.mdx
+++ b/network/load-balancer/troubleshooting/load-balancer-kubernetes-https-error.mdx
@@ -13,14 +13,14 @@ categories:
   - network
 ---
 
-If your Load Balancer is created using kubernetes services, is configured for [SSL offload](/network/load-balancer/reference-content/ssl-bridging-offloading-passthrough/#configuring-a-load-balancer-for-ssl-offloading),
+If your Load Balancer is created using Kubernetes services, is configured for [SSL offload](/network/load-balancer/reference-content/ssl-bridging-offloading-passthrough/#configuring-a-load-balancer-for-ssl-offloading),
 and you have several services behind the same Load Balancer, you will have a SSL error when trying to reach the others services using https.
 
 Example:
 - podA
-- podB (https://serviceB.example.com)
+- podB (`https://serviceB.example.com`)
 
-From the podA, you want to curl https://serviceB.example.com, you will have a SSL Error.
+From the podA, you want to curl `https://serviceB.example.com`, you will have an SSL Error.
 
 To force the Load Balancer to handle all requests using the SSL offload, enable the [use hostname annotations](https://github.com/scaleway/scaleway-cloud-controller-manager/blob/master/docs/loadbalancer-annotations.md#servicebetakubernetesioscw-loadbalancer-use-hostname)
 on your service related to your Load Balancer.

--- a/network/load-balancer/troubleshooting/load-balancer-kubernetes-https-error.mdx
+++ b/network/load-balancer/troubleshooting/load-balancer-kubernetes-https-error.mdx
@@ -1,0 +1,26 @@
+---
+meta:
+  title: Load Balancer Certificate error using SSL offload in kubernetes
+  description: Fix the SSL Certificate when using https for services on the same kubernetes
+content:
+  h1: Load Balancer Certificate error using SSL offload in kubernetes
+  paragraph: Fix the SSL Certificate when using https for services on the same kubernetes
+tags: load-balancer
+dates:
+  validation: 2024-06-23
+  posted: 2024-06-23
+categories:
+  - network
+---
+
+If your Load Balancer is created using kubernetes services, is configured for [SSL offload](/network/load-balancer/reference-content/ssl-bridging-offloading-passthrough/#configuring-a-load-balancer-for-ssl-offloading),
+and you have several services behind the same Load Balancer, you will have a SSL error when trying to reach the others services using https.
+
+Example:
+- podA
+- podB (https://serviceB.example.com)
+
+From the podA, you want to curl https://serviceB.example.com, you will have a SSL Error.
+
+To force the Load Balancer to handle all requests using the SSL offload, enable the [use hostname annotations](https://github.com/scaleway/scaleway-cloud-controller-manager/blob/master/docs/loadbalancer-annotations.md#servicebetakubernetesioscw-loadbalancer-use-hostname)
+on your service related to your Load Balancer.


### PR DESCRIPTION
# Description

When you have:
- In kubernetes, a pod wants to access a service within the same kube using https
- the https in handled by a Load Balancer configured for SSL Offload

Then a curl will not work, there will be an SSL error because the LB reroute the request before using the SSL.

