### PR TITLE
fix(rdb): update known-differences

### DIFF
--- a/serverless/sql-databases/reference-content/known-differences.mdx
+++ b/serverless/sql-databases/reference-content/known-differences.mdx
@@ -63,6 +63,18 @@ If you require strict compatibility with all PostgreSQL features, you can use [M
     PREPARE TRANSACTION 'transactionid';
     ```
 
+- Discarding all session state using `DISCARD ALL` command can be performed, but results are not guaranteed. Specifically, some session state variable might be kept if multiple SQL clients are performing operations concurrently.
+
+    ```sql
+    DISCARD ALL;
+    ```
+
+- `pg_advisory_lock` command can be used, but lock is not guaranteed. As a consequence, third party tools using this feature (such as storing [Terraform state using pg backend](https://developer.hashicorp.com/terraform/language/settings/backends/pg)) will not guarantee state locking if multiple Terraform clients are editing the same state concurrently. 
+
+    ```sql
+    SELECT * FROM pg_advisory_lock(1);
+    ```
+
 ## Unsupported SQL client features
 
 - Grafana: Serverless SQL Databases cannot be added as a PostgreSQL data source in Grafana 10.1 and older versions, as Server Name Indication (SNI) is not supported. However, this feature is supported by Grafana 10.2 or higher.
@@ -78,6 +90,8 @@ If you require strict compatibility with all PostgreSQL features, you can use [M
     Setting the client-side encoding to a different value, such as `SQL_ASCII` when connecting with a client is not supported.
 
 - ETL tools such as Airbyte, Fivetran or Meltano cannot load data into a Serverless SQL Database, as they require `TEMPORARY TABLES`, which are currently not supported. However, data can be loaded from a Serverless SQL Database into another target, but not using Change Data Capture (CDC) options, as they require `SUBSCRIPTIONS`, which are currently not supported.
+
+- Terraform: Storing [Terraform states using pg backend](https://developer.hashicorp.com/terraform/language/settings/backends/pg) can be done, but terraform state locking when multiple Terraform clients are editing the same state concurrently is not guaranteed (since this guarantees rely on `pg_advisory_lock` command usage, which is not supported currently).
 
 ## Unsupported configuration commands
 

--- a/serverless/sql-databases/reference-content/known-differences.mdx
+++ b/serverless/sql-databases/reference-content/known-differences.mdx
@@ -63,13 +63,13 @@ If you require strict compatibility with all PostgreSQL features, you can use [M
     PREPARE TRANSACTION 'transactionid';
     ```
 
-- Discarding all session state using `DISCARD ALL` command can be performed, but results are not guaranteed. Specifically, some session state variable might be kept if multiple SQL clients are performing operations concurrently.
+- Discarding all session states using the `DISCARD ALL` command is possible, but results are not guaranteed. Specifically, some session state variables might be kept if multiple SQL clients perform operations concurrently.
 
     ```sql
     DISCARD ALL;
     ```
 
-- `pg_advisory_lock` command can be used, but lock is not guaranteed. As a consequence, third party tools using this feature (such as storing [Terraform state using pg backend](https://developer.hashicorp.com/terraform/language/settings/backends/pg)) will not guarantee state locking if multiple Terraform clients are editing the same state concurrently. 
+- `pg_advisory_lock` command can be used, but the lock is not guaranteed. As a consequence, third-party tools that use this feature, such as Terraform when storing [Terraform state using pg backend](https://developer.hashicorp.com/terraform/language/settings/backends/pg) are not fully supported. State locking is not guaranteed if multiple Terraform clients are editing the same state concurrently. 
 
     ```sql
     SELECT * FROM pg_advisory_lock(1);


### PR DESCRIPTION
Adding limitations of the product regarding pg_advisory_lock and discard all commands.


