### PR TITLE
feat(changelog): sql-databases-changed-serverless-sql-database-is-now-in 2024-06-28

### DIFF
--- a/changelog/june2024/2024-06-28-sql-databases-changed-serverless-sql-database-is-now-in.mdx
+++ b/changelog/june2024/2024-06-28-sql-databases-changed-serverless-sql-database-is-now-in.mdx
@@ -2,12 +2,12 @@
 title: Serverless SQL Database is now in General Availability
 status: changed
 author:
-    fullname: ''
+    fullname: 'Join the #serverless-db-beta channel on Slack.'
     url: 'https://slack.scaleway.com'
 date: 2024-06-28
 category: serverless
 product: sql-databases
 ---
 
-[Serverless SQL Database](https://www.scaleway.com/en/serverless-sql-database/) is a PostgreSQL-compatible database that automatically scales up and down to zero, both in Compute and Storage. It is **now in General Availability** and suited for production-grade use cases.
+[Serverless SQL Database](https://www.scaleway.com/en/serverless-sql-database/) is a PostgreSQL-compatible database that automatically scales up and down to zero, both in Compute and Storage. It is **now in General Availability** and ready for production-grade use cases.
 

--- a/changelog/june2024/2024-06-28-sql-databases-changed-serverless-sql-database-is-now-in.mdx
+++ b/changelog/june2024/2024-06-28-sql-databases-changed-serverless-sql-database-is-now-in.mdx
@@ -1,0 +1,13 @@
+---
+title: Serverless SQL Database is now in General Availability
+status: changed
+author:
+    fullname: ''
+    url: 'https://slack.scaleway.com'
+date: 2024-06-28
+category: serverless
+product: sql-databases
+---
+
+[Serverless SQL Database](https://www.scaleway.com/en/serverless-sql-database/) is a PostgreSQL-compatible database that automatically scales up and down to zero, both in Compute and Storage. It is **now in General Availability** and suited for production-grade use cases.
+


### PR DESCRIPTION
Reporter: Franck Pagny

This PR is a new changelog contribution. It has been created automatically.

Make sure to review it carefully before merging it.