### PR TITLE
feat(changelog): functions-added-python-312-runtime-now-available 2024-07-02

### DIFF
--- a/changelog/july2024/2024-07-02-functions-added-python-312-runtime-now-available.mdx
+++ b/changelog/july2024/2024-07-02-functions-added-python-312-runtime-now-available.mdx
@@ -1,0 +1,13 @@
+---
+title: Python 3.12 runtime now available
+status: added
+author:
+    fullname: 'Join the #serverless-functions channel on Slack.'
+    url: 'https://slack.scaleway.com'
+date: 2024-07-02
+category: serverless
+product: functions
+---
+
+Python 3.12 is now supported on Serverless Functions.
+


### PR DESCRIPTION
Reporter: Thomas Tacquet

This PR is a new changelog contribution. It has been created automatically.

Make sure to review it carefully before merging it.