### PR TITLE
fix(gpu): correction of index page links

### DIFF
--- a/compute/gpu/index.mdx
+++ b/compute/gpu/index.mdx
@@ -1,14 +1,14 @@
 ---
 meta:
   title: GPU Instances Documentation
-  description: Dive into Scaleway GPU Instances with our quickstart guides, how-tos, tutorials and more.
+  description: Dive into Scaleway GPU Instances with our quickstart guides, how-tos, tutorials, and more.
 ---
 
 <ProductHeader
    productName="GPU Instances"
    productLogo="instance"
    description="Scaleway GPU Instances are equipped with dedicated high-end NVIDIA GPUs and offer the speed and efficiency you need to run your most demanding workloads."
-   url="/compute/instances/quickstart"
+   url="/compute/gpu/quickstart/"
    label="Instances Quickstart"
 />
 
@@ -20,28 +20,28 @@ meta:
         icon="rocket"
         description="Learn how to create, connect to, and delete a GPU Instance in a few steps."
         label="View Quickstart"
-        url="/compute/instances/quickstart/"
+        url="/compute/gpu/quickstart/"
     />
     <SummaryCard
         title="Concepts"
         icon="information-circle-outline"
         description="Core concepts that give you a better understanding of Scaleway GPU Instances."
         label="View concepts"
-        url="/compute/instances/concepts/"
+        url="/compute/gpu/concepts/"
     />
     <SummaryCard
         title="How-tos"
         icon="help-circle-outline"
         description="Check our guides to creating and managing GPU Instances and their features."
         label="View how-tos"
-        url="/compute/instances/how-to/"
+        url="/compute/gpu/how-to/"
     />
     <SummaryCard
         title="Additional content"
         icon="book-open-outline"
         description="Guides to help you choose a GPU Instance, understand pricing and advanced configuration."
         label="View additional content"
-        url="/compute/instances/reference-content/"
+        url="/compute/gpu/reference-content/"
     />
 </Grid>
 
@@ -62,7 +62,7 @@ meta:
 
 <ClickableBanner
     productLogo="cli"
-    title="Instance API"
+    title="Instances API"
     description="Learn how to create and manage your Scaleway GPU Instances through the API."
     url="https://www.scaleway.com/en/developers/api/instance/"
     label="Go to Instances API"


### PR DESCRIPTION
### Description

The links of the index page of GPU Instances were all leading to Instances pages. Links updated to lead users to GPU Instances content.
