### PR TITLE
fix:known-differences.mdx

### DIFF
--- a/serverless/sql-databases/reference-content/known-differences.mdx
+++ b/serverless/sql-databases/reference-content/known-differences.mdx
@@ -19,6 +19,13 @@ If you require strict compatibility with all PostgreSQL features, you can use [M
 
 ## Unsupported SQL features
 
+- Installing extensions is not yet supported. We plan to support extensions similar to [Managed Databases for PostgreSQL available extensions](https://www.scaleway.com/en/docs/faq/databases-for-postgresql-and-mysql/#which-postgresql-extensions-are-available) in future releases.
+
+    ```sql
+    CREATE EXTENSION extension_name;
+    NOTIFY channel, 'message';
+    ```
+
 - Notifying and listening channels using the `NOTIFY` and `LISTEN` commands can be performed, but message delivery is not guaranteed. 
 
     ```sql


### PR DESCRIPTION
Added that Serverless SQL Database does not support installing PostgreSQL extensions yet.

