### PR TITLE
fix(header): fix header link to scaleway-learning

### DIFF
--- a/blocks/header.json
+++ b/blocks/header.json
@@ -17,7 +17,7 @@
   {
     "to": "/",
     "label": "Scaleway Learning",
-    "package": "learning"
+    "package": "scaleway-learning"
   },
   {
     "to": "/changelog/",


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

Please describe what you added or changed.

- Link in mobile navigation to Scaleway Learning is not correct
- This MR change link in a configuration JSON
