### PR TITLE
feat(changelog): managed-inference-changed-models-now-support-longer-and 2024-07-23

### DIFF
--- a/changelog/july2024/2024-07-23-managed-inference-changed-models-now-support-longer-and.mdx
+++ b/changelog/july2024/2024-07-23-managed-inference-changed-models-now-support-longer-and.mdx
@@ -1,0 +1,15 @@
+---
+title: Models now support longer and better conversations
+status: changed
+author:
+    fullname: 'Join the #inference-beta channel on Slack.'
+    url: 'https://slack.scaleway.com'
+date: 2024-07-23
+category: ai-data
+product: managed-inference
+---
+
+- All models on catalog now support conversations to their full context window (e.g Mixtral-8x7b up to 32K tokens, Llama3 up to 8k tokens).
+- Llama3 70B is now available in FP8 quantization, INT8 is deprecated.
+- Llama3 8b is now available in FP8 quantization, BF16 remains default.
+


### PR DESCRIPTION
Reporter: tgenaitay

This PR is a new changelog contribution. It has been created automatically.

Make sure to review it carefully before merging it.