### PR TITLE
feat(inference): FP8 quantizations

### DIFF
--- a/ai-data/managed-inference/reference-content/llama-3-70b-instruct.mdx
+++ b/ai-data/managed-inference/reference-content/llama-3-70b-instruct.mdx
@@ -18,18 +18,18 @@ categories:
 |-----------------|------------------------------------|
 | Provider        | [Meta](https://llama.meta.com/llama3/)  |
 | Model Name      | `llama-3-70b-instruct`                 |
-| Compatible Instances | H100 (int8)    |
+| Compatible Instances | H100 (FP8)    |
 | Context size | 8192 tokens   |
 
 ## Model names
 
 ```bash
-meta/llama-3-70b-instruct:int8
+meta/llama-3-70b-instruct:fp8
 ```
 
 ## Compatible Instances
 
-- [H100 (INT8)](https://www.scaleway.com/en/h100-pcie-try-it-now/)
+- [H100 (FP8)](https://www.scaleway.com/en/h100-pcie-try-it-now/)
 
 ## Model introduction
 

--- a/ai-data/managed-inference/reference-content/llama-3-8b-instruct.mdx
+++ b/ai-data/managed-inference/reference-content/llama-3-8b-instruct.mdx
@@ -18,18 +18,20 @@ categories:
 |-----------------|------------------------------------|
 | Provider        | [Meta](https://llama.meta.com/llama3/)  |
 | Model Name      | `llama-3-8b-instruct`                 |
-| Compatible Instances | L4 (BF16)    |
+| Compatible Instances | L4 (BF16, FP8)    |
 | Context size | 8192 tokens    |
 
 ## Model names
 
 ```bash
 meta/llama-3-8b-instruct:bf16
+meta/llama-3-8b-instruct:fp8
 ```
 
 ## Compatible Instances
 
-- [L4 (BF16)](https://www.scaleway.com/en/l4-gpu-instance/)
+- [L4](https://www.scaleway.com/en/l4-gpu-instance/)
+- [H100](https://www.scaleway.com/en/h100-pcie-try-it-now/)
 
 ## Model introduction
 

--- a/ai-data/managed-inference/reference-content/llama-3-8b-instruct.mdx
+++ b/ai-data/managed-inference/reference-content/llama-3-8b-instruct.mdx
@@ -18,7 +18,7 @@ categories:
 |-----------------|------------------------------------|
 | Provider        | [Meta](https://llama.meta.com/llama3/)  |
 | Model Name      | `llama-3-8b-instruct`                 |
-| Compatible Instances | L4 (BF16, FP8)    |
+| Compatible Instances | L4, H100 |
 | Context size | 8192 tokens    |
 
 ## Model names


### PR DESCRIPTION
### Your checklist for this pull request

- [X] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

- Llama3 70B is now available in FP8 quantization, INT8 is deprecated.
- Llama3 8b is now available in FP8 quantization, BF16 remains default.
