### PR TITLE
fix: wrong volumes field in curl examples ext-fix-instances

### DIFF
--- a/compute/instances/api-cli/attaching-a-volume.mdx
+++ b/compute/instances/api-cli/attaching-a-volume.mdx
@@ -36,6 +36,7 @@ dates:
         "0": {
     ...
           "id": "7fe25caf-0a68-46a7-aeb9-63a278d33e2b",
+          "volume_type": "l_ssd",
     ...
         }
       },
@@ -52,8 +53,14 @@ dates:
     -X PATCH \
     -d '{
             "volumes": {
-              "0": "7fe25caf-0a68-46a7-aeb9-63a278d33e2b",
-              "1": "b3a42fb1-e85c-46e9-b0a6-9adb62278295"
+              "0": {
+                "id": "7fe25caf-0a68-46a7-aeb9-63a278d33e2b",
+                "volume_type": "l_ssd"
+              },
+              "1": {
+                "id": "b3a42fb1-e85c-46e9-b0a6-9adb62278295",
+                "volume_type": "sbs_volume"
+              }
             }
         }' \
     https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/be3c50af-e8f3-4ff4-90fe-66972f06670d
@@ -83,7 +90,7 @@ dates:
           "modification_date": "2019-09-03T10:17:40.800839+00:00",
     ...
           "id": "b3a42fb1-e85c-46e9-b0a6-9adb62278295",
-          "volume_type": "b_ssd",
+          "volume_type": "sbs_volume",
           "server": {
             "id": "be3c50af-e8f3-4ff4-90fe-66972f06670d",
             "name": "scw-blissful-engelbart"


### PR DESCRIPTION
### Your checklist for this pull request

- [X] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

As explained [here](https://www.scaleway.com/en/developers/api/instance/#technical-information), the `volumes` field is
 

> a dictionary with a minimum of one key ("0") whose value is another object setting parameters for that volume. Additional keys for additional volumes should increment by 1 each time (the second volume would have a key of 1.)

Futhermore, a block storage volume (the low latency block volume, not the legacy block volume) has the type `sbs_volume`.