### PR TITLE
Update configure-network-netplan.mdx

### DIFF
--- a/dedibox-network/network/how-to/configure-network-netplan.mdx
+++ b/dedibox-network/network/how-to/configure-network-netplan.mdx
@@ -95,7 +95,6 @@ network:
       dhcp4: no
       dhcp6: no
       addresses: [fail.over.ip.address/32]
-      gateway4: 62.210.0.1
       nameservers:
         addresses: [ "51.159.47.28", "51.159.47.26" ]
       routes:


### PR DESCRIPTION
I think this content should be reworked because it contains deprecated features:

```
root@foobar-v1-v2:/etc/netplan# netplan apply

** (generate:79635): WARNING **: 08:27:12.718: `gateway4` has been deprecated, use default routes instead.
See the 'Default routes' section of the documentation for more details.

** (process:79634): WARNING **: 08:27:13.700: `gateway4` has been deprecated, use default routes instead.
See the 'Default routes' section of the documentation for more details.

** (process:79634): WARNING **: 08:27:14.084: `gateway4` has been deprecated, use default routes instead.
See the 'Default routes' section of the documentation for more details.
```