### PR TITLE
fix(doc): illustrations

### DIFF
--- a/network/ipam/index.mdx
+++ b/network/ipam/index.mdx
@@ -46,7 +46,7 @@ meta:
 </Grid>
 
 <ClickableBanner
-    productLogo="console"
+    productLogo="cli"
     title="IPAM API"
     description="Use IPAM via the Scaleway API."
     url="https://www.scaleway.com/en/developers/api/ipam/"

--- a/network/load-balancer/index.mdx
+++ b/network/load-balancer/index.mdx
@@ -71,7 +71,7 @@ meta:
 </Grid>
 
 <ClickableBanner
-    productLogo="console"
+    productLogo="cli"
     title="Load Balancer API"
     description="Manage Load Balancers using the Scaleway API."
     url="https://www.scaleway.com/en/developers/api/load-balancer/zoned-api/"

--- a/network/public-gateways/index.mdx
+++ b/network/public-gateways/index.mdx
@@ -68,7 +68,7 @@ meta:
 
 
 <ClickableBanner
-    productLogo="console"
+    productLogo="cli"
     title="Public Gateways API"
     description="Manage Public Gateways using the Scaleway API."
     url="https://www.scaleway.com/en/developers/api/public-gateway/"

--- a/network/vpc/index.mdx
+++ b/network/vpc/index.mdx
@@ -75,7 +75,7 @@ meta:
 
 
 <ClickableBanner
-    productLogo="console"
+    productLogo="cli"
     title="VPC API"
     description="Manage VPC and Private Networks using the Scaleway API."
     url="https://www.scaleway.com/en/developers/api/vpc/"

--- a/serverless/messaging/index.mdx
+++ b/serverless/messaging/index.mdx
@@ -76,7 +76,7 @@ meta:
 
 
 <ClickableBanner
-    productLogo="console"
+    productLogo="cli"
     title="Messaging and Queuing API"
     description="Manage Messaging and Queuing using the Scaleway API."
     url="https://www.scaleway.com/en/developers/api/messaging-and-queuing/sqs-api/"


### PR DESCRIPTION
For some reason network products (and M&Q) were using the wrong illustration on product homepages for the API banner. This PR fixes to use the correct illustration.
