### PR TITLE
docs(inference): Mixtral 8x7B switch to FP8 quantization int-ai-fp8

### DIFF
--- a/ai-data/managed-inference/reference-content/mixtral-8x7b-instruct-v0.1.mdx
+++ b/ai-data/managed-inference/reference-content/mixtral-8x7b-instruct-v0.1.mdx
@@ -18,19 +18,19 @@ categories:
 |-----------------|------------------------------------|
 | Provider        | [Mistral](https://mistral.ai/technology/#models)                         |
 | Model Name      | `mixtral-8x7b-instruct-v0.1`       |
-| Compatible Instances | H100 (INT8) - H100-2 (FP16)                 |
+| Compatible Instances | H100 (FP8) - H100-2 (FP16)                 |
 | Context size | 32k tokens    |
 
 ## Model names
 
 ```bash
-mistral/mixtral-8x7b-instruct-v0.1:int8
+mistral/mixtral-8x7b-instruct-v0.1:fp8
 mistral/mixtral-8x7b-instruct-v0.1:fp16
 ```
 
 ## Compatible Instances
 
-- [H100-1 (INT8)](https://www.scaleway.com/en/h100-pcie-try-it-now/)
+- [H100-1 (FP8)](https://www.scaleway.com/en/h100-pcie-try-it-now/)
 - [H100-2 (FP16)](https://www.scaleway.com/en/h100-pcie-try-it-now/)
 
 ## Model introduction


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

- Mixtral 8x7B is now available in FP8 quantization, INT8 is deprecated.
