### PR TITLE
fix(account): streamline section about closing an account

### DIFF
--- a/console/account/quickstart.mdx
+++ b/console/account/quickstart.mdx
@@ -30,7 +30,7 @@ Every account has an associated Organization, which in turn has an Owner. When y
 When you [close your account](/console/account/how-to/close-account/), you delete all its resources and backups. Any guests who have joined your Organization will lose access because your Organization will no longer exist.
 
 <Message type="important">
-  There is a delay of up to 10 days between the time your account is closed and the time the system deletes your resources. It is recommended to manually delete all your Organization's resources before closing your account. To reopen your account, contact support.
+  There is a delay of up to 10 days between the time your account is closed and the time the system deletes your resources. It is recommended to manually delete all your Organization's resources before closing your account. To reopen your account, [contact support](https://console.scaleway.com/support).
 </Message>
 
 <Macro id="close-account" />

--- a/console/account/quickstart.mdx
+++ b/console/account/quickstart.mdx
@@ -23,16 +23,14 @@ Scaleway is a complete cloud ecosystem, offering a single way for you to create,
 
 Once you have validated your payment method, you can start ordering resources like Instances, Kubernetes Kapsule, Object Storage and more. Find out more about [how to add resources to your Projects](/identity-and-access-management/organizations-and-projects/how-to/add-resources-project/).
 
-## How to delete your account
+## How to close an account
 
-Every account has an associated Organization, which in turn has an Owner. If you created your account (and never joined another Organization), you are the Owner of the Organization associated with your account. You can therefore use the **Deactivate Organization** button to [close your account](/console/account/how-to/close-account/) and delete all of its services and backups.
+Every account has an associated Organization, which in turn has an Owner. When you create your account, you are designated as the Owner of the Organization associated with your account.
+
+When you [close your account](/console/account/how-to/close-account/), you delete all its resources and backups. Any guests who have joined your Organization will lose access because your Organization will no longer exist.
 
 <Message type="important">
-  There is a delay of up to 10 days between the time your Organization is closed, and the time resources are effectively deleted. It is recommended to delete all your resources before you close your Organization. A deactivated Organization can be reactivated upon your request.
+  There is a delay of up to 10 days between the time your account is closed and the time the system deletes your resources. It is recommended to manually delete all your Organization's resources before closing your account. To reopen your account, contact support.
 </Message>
 
-1. Click **Organization** at the top-right of the console, then click **Organization**. The **Organization Account** page displays.
-2. Click **Deactivate Organization** which displays at the bottom of the page, once you have read and agreed with the warning message.
-3. Type **Deactivate** to confirm your decision.
-4. Select the reasons why you are deactivating your Organization.
-5. Click **Deactivate Organization** to deactivate your Organization.
+<Macro id="close-account" />


### PR DESCRIPTION
After testing in my Scaleway console, I realized the workflow changed. 

There is only one workflow now, i.e., close account. There is not a separate workflow for deactivating an Organization.

Consequently, we can embed the existing content, How To Close An Account.