### PR TITLE
docs(apple-silicon): removed space

### DIFF
--- a/faq/apple-silicon.mdx
+++ b/faq/apple-silicon.mdx
@@ -3,7 +3,7 @@ meta:
   title: Apple silicon FAQ
   description: Discover how to use Apple silicon for application development.
 content:
-  h1: Apple silicon 
+  h1: Apple silicon
 hero: assets/apple.webp
 dates:
   validation: 2024-02-26


### PR DESCRIPTION
### Description

Removed an unnecessary trailing space from the Apple Silicon FAQ for testing purposes. 
