### PR TITLE
fix(serverless): remove note about protocol switching not being available in the console

### DIFF
--- a/faq/serverless-containers.mdx
+++ b/faq/serverless-containers.mdx
@@ -108,10 +108,7 @@ There are several ways to deploy containers, [this page](/serverless/containers/
 
 Serverless Containers use the **http1** protocol by default, but some services (e.g., gRPC) only support http2.
 
-Protocol switching is currently not available in the console but can be changed by using:
-
-* [CLI (doc)](https://github.com/scaleway/scaleway-cli/blob/master/docs/commands/container.md#update-an-existing-container)
-* [API (doc)](https://www.scaleway.com/en/developers/api/serverless-containers/)
+Protocol switching is available in the Console under the `Advanced options` section in the `Deployment` tab.
 
 ## Why does my gRPC container not respond?
 


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

While looking into something for a client, I noticed a section in the Serverless Containers FAQ is slightly out-of-date since it's now possible to switch the protocol via the console. See screenshot:

![image](https://github.com/user-attachments/assets/4f598166-057f-4ced-b6ca-ecb6b3ddb455)

(It's a very minor point, but I figure I might as well submit a PR to update it)

Cheers have a great day!