### PR TITLE
chore(infr): introduce openai API difference

### DIFF
--- a/ai-data/managed-inference/reference-content/openai-compatibility.mdx
+++ b/ai-data/managed-inference/reference-content/openai-compatibility.mdx
@@ -151,6 +151,25 @@ curl https://<Deployment UUID>.ifr.fr-par.scw.cloud/v1/models \
   -H "Authorization: Bearer $SCW_API_KEY" \
   -H "Content-Type: application/json"
 ```
+## Differences
+
+### Token usage stats
+
+OpenAI API doesn't return usage stats (number of tokens in prompt and completion) for streaming responses.
+
+Scaleway Managed Inference endpoints returns usage stats for both streaming and non-streaming responses. 
+
+For streaming responses, the usage field is incremented in each chunk and complete in the very last chunk on the response. For example:
+
+```
+data: {...,"choices":[{"index":0,"delta":{"content":" Hello","role":"assistant","name":""},"finish_reason":null}],...,"usage":{"prompt_tokens":9,"completion_tokens":1,"total_tokens":10}}
+
+data: {...,"choices":[{"index":0,"delta":{"content":"!","role":"assistant","name":""},"finish_reason":null}],...,"usage":{"prompt_tokens":9,"completion_tokens":2,"total_tokens":11}}
+
+data: {...,"choices":[{"index":0,"delta":{"content":"","role":"assistant","name":""},"finish_reason":"stop"}],...,"usage":{"prompt_tokens":9,"completion_tokens":2,"total_tokens":11}}
+
+data: [DONE]
+```
 
 ## Future developments
 


### PR DESCRIPTION
### Your checklist for this pull request

- [X] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

We now return usage stats for both streaming and non-streaming.
This is a slight difference (and improvement) from OpenAI official specs: documenting it for the sake of transparency.