### PR TITLE
fix(faq): clarify VAT exemption for french customers

### DIFF
--- a/faq/billing.mdx
+++ b/faq/billing.mdx
@@ -86,7 +86,7 @@ The appropriate VAT rate is automatically applied to your invoice, depending on 
 No other additional taxes, but European VAT is collected.
 
 If you are not located in one of the 27 member states of the European Union, no other tax will be added to your invoice, per application of EU laws.
-European B2B customers are exempted from VAT, as long as they provide a registered VAT number. Just add your VAT registry number to your profile, and your invoice will be updated accordingly.
+European B2B customers (excluding French B2B customers) are exempted from VAT, as long as they provide a registered VAT number. Just add your VAT registry number to your profile, and your invoice will be updated accordingly.
 
 If you do not provide a valid VAT number, you will be considered an individual customer (B2C), and the local rate will be applied.
 


### PR DESCRIPTION
### Your checklist for this pull request

- [X] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

Old wording could be understood as all European B2B customers are exempted from VAT, which is not the case for French customers