### PR TITLE
chore(cockpit): use alloy extension for alloy agent

### DIFF
--- a/observability/cockpit/how-to/send-metrics-with-grafana-alloy.mdx
+++ b/observability/cockpit/how-to/send-metrics-with-grafana-alloy.mdx
@@ -38,8 +38,8 @@ For the sake of this documentation, we are using Grafana Alloy on macOS. Refer t
 ## Configuring Grafana Alloy
 
 1. Create a folder named `config` on your local machine.
-2. Create a file named `cockpit.river` inside the `config` folder.
-3. Paste the following template inside `cockpit.river`:
+2. Create a file named `cockpit.alloy` inside the `config` folder.
+3. Paste the following template inside `cockpit.alloy`:
         ```
         prometheus.exporter.unix "node" {
             set_collectors = [
@@ -81,7 +81,7 @@ For the sake of this documentation, we are using Grafana Alloy on macOS. Refer t
         ```
 6. In the same terminal, run the following command.
         ```
-        alloy run config/cockpit.river
+        alloy run config/cockpit.alloy
         ```
         The two last lines of your output should look similar to the following.
         ```


### PR DESCRIPTION
The standard extension for alloy configuration file is now .alloy

### Your checklist for this pull request

- [ ] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

Please describe what you added or changed.
