### PR TITLE
fix(ai): moving command from RSA to ED key

### DIFF
--- a/ai-data/managed-inference/how-to/managed-inference-with-private-network.mdx
+++ b/ai-data/managed-inference/how-to/managed-inference-with-private-network.mdx
@@ -67,14 +67,14 @@ Using a Private Network for communications between your Instances hosting your a
 3. Transfer the TLS certificate to the Instance using the `scp` (secure copy) command to securely transfer the certificate from your local machine to the Scaleway Instance.
    - Example command:
      ```bash
-     scp -i ~/.ssh/id_rsa /home/user/certs/cert_file.pem root@51.115.xxx.yyy:/root
+     scp -i ~/.ssh/id_ed25519 /home/user/certs/cert_file.pem root@51.115.xxx.yyy:/root
      ```
    - Replace placeholders in the command above as follows:
-     - `-i ~/.ssh/id_rsa`: Path to your private SSH key.
-     - `/home/user/certs/cert_file.pem`: Path to the certificate file.
+     - `-i ~/.ssh/id_ed25519`: Path to your private SSH key.
+     - `/home/user/certs/cert_file.pem`: Path to the certificate file on your local machine.
      - `root`: Your Scaleway Instance username (`root` for default configuration).
      - `51.115.xxx.yyy`: Public IP address of your Scaleway Instance.
-     - `/root`: Destination directory on the Scaleway Instance.
+     - `:/root`: Destination directory on the Scaleway Instance.
     <Message type="note">
       Ensure the destination directory exists and you have write permissions. Create the directory if necessary.
     </Message>


### PR DESCRIPTION
### Your checklist for this pull request

- [X] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

Nitpick: a user told me most of our product docs refer to ED keys and not RSA type, for the sake of consistency, switching to this type.