### PR TITLE
Serverless SQL Database: Update known-differences.mdx

### DIFF
--- a/serverless/sql-databases/reference-content/known-differences.mdx
+++ b/serverless/sql-databases/reference-content/known-differences.mdx
@@ -33,7 +33,7 @@ If you require strict compatibility with all PostgreSQL features, you can use [M
     NOTIFY channel, 'message';
     ```
 
-- Creating temporary tables or views cannot be performed.
+- It is not possible to create temporary tables or views.
 
     ```sql
     CREATE TEMPORARY TABLE table as {query};
@@ -50,7 +50,7 @@ If you require strict compatibility with all PostgreSQL features, you can use [M
     You can still refresh materialized views without the `CONCURRENTLY` option.
     </Message>
 
-- Declaring a cursor in transactions with `WITH HOLD` can be performed, but accurate cursor handling is not guaranteed, especially when using multiple connections.
+- You can declare a cursor in transactions with `WITH HOLD`, but accurate cursor handling is not guaranteed, particularly when using multiple connections.
 
     ```sql
     BEGIN;
@@ -64,7 +64,7 @@ If you require strict compatibility with all PostgreSQL features, you can use [M
     CREATE SUBSCRIPTION subscription CONNECTION 'connection' PUBLICATION publication;
     ```
 
-- Preparing transactions cannot be performed.
+- It is not possible to prepare transactions.
 
     ```sql
     PREPARE TRANSACTION 'transactionid';
@@ -117,7 +117,7 @@ If you require strict compatibility with all PostgreSQL features, you can use [M
     SET TIME ZONE 'Europe/Paris';
     RESET timezone;
     ```
-    If you require this features to work consistently for a given SQL query, we suggest you set them in transactions:
+    If you require these features to work consistently for a given SQL query, we suggest you set them in transactions:
     ```sql
     BEGIN;
       SET TIME ZONE 'Europe/Paris';

--- a/serverless/sql-databases/reference-content/known-differences.mdx
+++ b/serverless/sql-databases/reference-content/known-differences.mdx
@@ -33,7 +33,7 @@ If you require strict compatibility with all PostgreSQL features, you can use [M
     NOTIFY channel, 'message';
     ```
 
-- Creating temporary tables or views is not supported.
+- Creating temporary tables or views cannot be performed.
 
     ```sql
     CREATE TEMPORARY TABLE table as {query};
@@ -50,7 +50,7 @@ If you require strict compatibility with all PostgreSQL features, you can use [M
     You can still refresh materialized views without the `CONCURRENTLY` option.
     </Message>
 
-- Declaring a cursor in transactions with `WITH HOLD` is not supported.
+- Declaring a cursor in transactions with `WITH HOLD` can be performed, but accurate cursor handling is not guaranteed, especially when using multiple connections.
 
     ```sql
     BEGIN;
@@ -64,7 +64,7 @@ If you require strict compatibility with all PostgreSQL features, you can use [M
     CREATE SUBSCRIPTION subscription CONNECTION 'connection' PUBLICATION publication;
     ```
 
-- Preparing transactions is not supported.
+- Preparing transactions cannot be performed.
 
     ```sql
     PREPARE TRANSACTION 'transactionid';
@@ -117,6 +117,14 @@ If you require strict compatibility with all PostgreSQL features, you can use [M
     SET TIME ZONE 'Europe/Paris';
     RESET timezone;
     ```
+    If you require this features to work consistently for a given SQL query, we suggest you set them in transactions:
+    ```sql
+    BEGIN;
+      SET TIME ZONE 'Europe/Paris';
+      SHOW timezone;
+    COMMIT;
+    ```
+    In this example, `SHOW timezone` will always display `Europe/Paris` without any impact from any other connection despite connection pooling.
 
 - Security labels cannot be defined or changed.
 


### PR DESCRIPTION
Fix and align wording on PostgreSQL commands which cannot be performed. Add a workaround snippet regarding SET/RESET features inside a transaction.
