### PR TITLE
feat(ai): changed domain from scw.cloud to scaleway.com

### DIFF
--- a/ai-data/managed-inference/reference-content/llama-3-70b-instruct.mdx
+++ b/ai-data/managed-inference/reference-content/llama-3-70b-instruct.mdx
@@ -61,7 +61,7 @@ curl -s \
 -H "Authorization: Bearer <IAM API key>" \
 -H "Content-Type: application/json" \
 --request POST \
---url "https://<Deployment UUID>.ifr.fr-par.scw.cloud/v1/chat/completions" \
+--url "https://<Deployment UUID>.ifr.fr-par.scaleway.com/v1/chat/completions" \
 --data '{"model":"llama-3-70b-instruct", "messages":[{"role": "user","content": "Sing me a song about Xavier Niel"}], "max_tokens": 500, "top_p": 1, "temperature": 0.7, "stream": false}'
 ```
 

--- a/ai-data/managed-inference/reference-content/llama-3-8b-instruct.mdx
+++ b/ai-data/managed-inference/reference-content/llama-3-8b-instruct.mdx
@@ -65,7 +65,7 @@ curl -s \
 -H "Authorization: Bearer <IAM API key>" \
 -H "Content-Type: application/json" \
 --request POST \
---url "https://<Deployment UUID>.ifr.fr-par.scw.cloud/v1/chat/completions" \
+--url "https://<Deployment UUID>.ifr.fr-par.scaleway.com/v1/chat/completions" \
 --data '{"model":"llama-3-8b-instruct", "messages":[{"role": "user","content": "There is a llama in my garden, what should I do?"}], "max_tokens": 500, "top_p": 1, "temperature": 0.7, "stream": false}'
 ```
 

--- a/ai-data/managed-inference/reference-content/llama-3.1-70b-instruct.mdx
+++ b/ai-data/managed-inference/reference-content/llama-3.1-70b-instruct.mdx
@@ -60,7 +60,7 @@ curl -s \
 -H "Authorization: Bearer <IAM API key>" \
 -H "Content-Type: application/json" \
 --request POST \
---url "https://<Deployment UUID>.ifr.fr-par.scw.cloud/v1/chat/completions" \
+--url "https://<Deployment UUID>.ifr.fr-par.scaleway.com/v1/chat/completions" \
 --data '{"model":"llama-3.1-70b-instruct", "messages":[{"role": "user","content": "There is a llama in my garden, what should I do?"}], "max_tokens": 500, "temperature": 0.7, "stream": false}'
 ```
 

--- a/ai-data/managed-inference/reference-content/llama-3.1-8b-instruct.mdx
+++ b/ai-data/managed-inference/reference-content/llama-3.1-8b-instruct.mdx
@@ -61,7 +61,7 @@ curl -s \
 -H "Authorization: Bearer <IAM API key>" \
 -H "Content-Type: application/json" \
 --request POST \
---url "https://<Deployment UUID>.ifr.fr-par.scw.cloud/v1/chat/completions" \
+--url "https://<Deployment UUID>.ifr.fr-par.scaleway.com/v1/chat/completions" \
 --data '{"model":"llama-3.1-8b-instruct", "messages":[{"role": "user","content": "There is a llama in my garden, what should I do?"}], "max_tokens": 500, "temperature": 0.7, "stream": false}'
 ```
 

--- a/ai-data/managed-inference/reference-content/mistral-7b-instruct-v0.3.mdx
+++ b/ai-data/managed-inference/reference-content/mistral-7b-instruct-v0.3.mdx
@@ -54,7 +54,7 @@ curl -s \
 -H "Authorization: Bearer <IAM API key>" \
 -H "Content-Type: application/json" \
 --request POST \
---url "https://<Deployment UUID>.ifr.fr-par.scw.cloud/v1/chat/completions" \
+--url "https://<Deployment UUID>.ifr.fr-par.scaleway.com/v1/chat/completions" \
 --data '{"model":"mistral-7b-instruct-v0.3", "messages":[{"role": "user","content": "Explain Public Cloud in a nutshell."}], "top_p": 1, "temperature": 0.7, "stream": false}'
 ```
 

--- a/ai-data/managed-inference/reference-content/mistral-nemo-instruct-2407.mdx
+++ b/ai-data/managed-inference/reference-content/mistral-nemo-instruct-2407.mdx
@@ -60,7 +60,7 @@ curl -s \
 -H "Authorization: Bearer <IAM API key>" \
 -H "Content-Type: application/json" \
 --request POST \
---url "https://<Deployment UUID>.ifr.fr-par.scw.cloud/v1/chat/completions" \
+--url "https://<Deployment UUID>.ifr.fr-par.scaleway.com/v1/chat/completions" \
 --data '{"model":"mistral-nemo-instruct-2407", "messages":[{"role": "user","content": "Sing me a song about Xavier Niel"}], "top_p": 1, "temperature": 0.35, "stream": false}'
 ```
 

--- a/ai-data/managed-inference/reference-content/mixtral-8x7b-instruct-v0.1.mdx
+++ b/ai-data/managed-inference/reference-content/mixtral-8x7b-instruct-v0.1.mdx
@@ -56,7 +56,7 @@ curl -s \
 -H "Authorization: Bearer <IAM API key>" \
 -H "Content-Type: application/json" \
 --request POST \
---url "https://<Deployment UUID>.ifr.fr-par.scw.cloud/v1/chat/completions" \
+--url "https://<Deployment UUID>.ifr.fr-par.scaleway.com/v1/chat/completions" \
 --data '{"model":"mixtral-8x7b-instruct-v0.1", "messages":[{"role": "user","content": "Sing me a song about Scaleway"}], "max_tokens": 200, "top_p": 1, "temperature": 1, "stream": false}'
 ```
 

--- a/ai-data/managed-inference/reference-content/openai-compatibility.mdx
+++ b/ai-data/managed-inference/reference-content/openai-compatibility.mdx
@@ -23,7 +23,7 @@ The Chat Completions API is designed for models fine-tuned for conversational ta
 
 To invoke Scaleway Managed Inference's OpenAI-compatible Chat API, simply edit your dedicated endpoints with a suffix `/v1/chat/completions`:
 ```
-https://<Deployment UUID>.ifr.fr-par.scw.cloud/v1/chat/completions
+https://<Deployment UUID>.ifr.fr-par.scaleway.com/v1/chat/completions
 ```
 
 ### OpenAI Python client library
@@ -34,7 +34,7 @@ Use OpenAI's SDK how you normally would.
 from openai import OpenAI
 
 client = OpenAI(
-    base_url='https://<Deployment UUID>.ifr.fr-par.scw.cloud/v1/',
+    base_url='https://<Deployment UUID>.ifr.fr-par.scaleway.com/v1/',
     api_key='<IAM API key>'
 )
 
@@ -94,11 +94,11 @@ The Embeddings API is designed to get a vector representation of an input that c
 
 Use your dedicated endpoints as follows:
 ```
-https://<Deployment UUID>.ifr.fr-par.scw.cloud/v1/embeddings
+https://<Deployment UUID>.ifr.fr-par.scaleway.com/v1/embeddings
 ```
 
 ```
-curl https://<Deployment UUID>.ifr.fr-par.scw.cloud/v1/embeddings \
+curl https://<Deployment UUID>.ifr.fr-par.scaleway.com/v1/embeddings \
   -H "Authorization: Bearer $SCW_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -114,7 +114,7 @@ curl https://<Deployment UUID>.ifr.fr-par.scw.cloud/v1/embeddings \
 from openai import OpenAI
 
 client = OpenAI(
-    base_url='https://<Deployment UUID>.ifr.fr-par.scw.cloud/v1/',
+    base_url='https://<Deployment UUID>.ifr.fr-par.scaleway.com/v1/',
     api_key='<IAM API key>'
 )
 
@@ -143,11 +143,11 @@ The Models API returns the model(s) available for inferencing.
 In the context of a Scaleway Managed Inference deployment, it returns the name of the current model being served.
 
 ```
-https://<Deployment UUID>.ifr.fr-par.scw.cloud/v1/models
+https://<Deployment UUID>.ifr.fr-par.scaleway.com/v1/models
 ```
 
 ```
-curl https://<Deployment UUID>.ifr.fr-par.scw.cloud/v1/models \
+curl https://<Deployment UUID>.ifr.fr-par.scaleway.com/v1/models \
   -H "Authorization: Bearer $SCW_API_KEY" \
   -H "Content-Type: application/json"
 ```

--- a/ai-data/managed-inference/reference-content/sentence-t5-xxl.mdx
+++ b/ai-data/managed-inference/reference-content/sentence-t5-xxl.mdx
@@ -51,7 +51,7 @@ The Sentence-T5-XXL model is highly ranked on the [MTEB leaderboard](https://hug
 To perform inference tasks with your Embedding model deployed at Scaleway, use the following command:
 
 ```bash
-curl https://<Deployment UUID>.ifr.fr-par.scw.cloud/v1/embeddings \
+curl https://<Deployment UUID>.ifr.fr-par.scaleway.com/v1/embeddings \
   -H "Authorization: Bearer <IAM API key>" \
   -H "Content-Type: application/json" \
   -d '{

--- a/ai-data/managed-inference/reference-content/wizardlm-70b-v1.0.mdx
+++ b/ai-data/managed-inference/reference-content/wizardlm-70b-v1.0.mdx
@@ -54,7 +54,7 @@ curl -s \
 -H "Authorization: Bearer <IAM API key>" \
 -H "Content-Type: application/json" \
 --request POST \
---url "https://<Deployment UUID>.ifr.fr-par.scw.cloud/v1/chat/completions" \
+--url "https://<Deployment UUID>.ifr.fr-par.scaleway.com/v1/chat/completions" \
 --data '{"model":"wizardlm-70B-V1.0", "messages":[{"role": "user","content": "Say hello to Scaleway's Inference"}], "max_tokens": 200, "top_p": 1, "temperature": 1, "stream": false}'
 ```
 


### PR DESCRIPTION
### Your checklist for this pull request

- [X] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

In order to enable a playground UI we change the domain name we use for public endpoints in all new deployments starting from today October 30th 2024.
This change is backwards compatible with deployments using a public endpoint in scw.cloud.