### PR TITLE
feat(changelog): apple-silicon-added-macos-sequoia-15-available 2024-10-09

### DIFF
--- a/changelog/october2024/2024-10-09-apple-silicon-added-macos-sequoia-15-available.mdx
+++ b/changelog/october2024/2024-10-09-apple-silicon-added-macos-sequoia-15-available.mdx
@@ -1,0 +1,14 @@
+---
+title: macOS Sequoia 15 available 
+status: added
+author:
+    fullname: 'Join the #[xxx] channel on Slack.'
+    url: 'https://slack.scaleway.com'
+date: 2024-10-09
+category: bare-metal
+product: apple-silicon
+---
+
+macOS Sequoia 15 is now available for installation on Mac min M2 pro!
+
+

--- a/changelog/october2024/2024-10-09-apple-silicon-added-macos-sequoia-15-available.mdx
+++ b/changelog/october2024/2024-10-09-apple-silicon-added-macos-sequoia-15-available.mdx
@@ -2,13 +2,13 @@
 title: macOS Sequoia 15 available 
 status: added
 author:
-    fullname: 'Join the #[xxx] channel on Slack.'
+    fullname: 'Join the #apple-silicon channel on Slack.'
     url: 'https://slack.scaleway.com'
 date: 2024-10-09
 category: bare-metal
 product: apple-silicon
 ---
 
-macOS Sequoia 15 is now available for installation on Mac min M2 pro!
+macOS Sequoia 15 is now available for installation on Mac mini M2 Pro!
 
 


### PR DESCRIPTION
Reporter: Alexia Valais

This PR is a new changelog contribution. It has been created automatically.

Make sure to review it carefully before merging it.