### PR TITLE
fix(instances): fix typos

### DIFF
--- a/compute/instances/troubleshooting/fix-dns-routed-ipv6-only-debian-bullseye.mdx
+++ b/compute/instances/troubleshooting/fix-dns-routed-ipv6-only-debian-bullseye.mdx
@@ -86,7 +86,7 @@ In this situation, proceed with the next section to install `netplan` before app
     All steps below require super-user (`root`) privileges.
 </Message>
 
-1. *(optional)* If, **and only if**,  your Instance is already booted using a routed IPv6-only setup, you need to temporarily configure your DNS resolver so that it can reach the Debian repositories, in order to install `netplan`. The following uses Google's DNS server:
+1. *(optional)* If, **and only if**, your Instance is already booted using a routed IPv6-only setup, you need to temporarily configure your DNS resolver so that it can reach the Debian repositories, in order to install `netplan`. The following uses Google's DNS server:
     ```sh
     > /etc/resolv.conf cat <<EOF
     nameserver 2001:4860:4860::8888

--- a/compute/instances/troubleshooting/fix-dns-routed-ipv6-only-debian-bullseye.mdx
+++ b/compute/instances/troubleshooting/fix-dns-routed-ipv6-only-debian-bullseye.mdx
@@ -40,7 +40,7 @@ Due to its modern nature and active maintenance, [`netplan` is a favorable optio
 You can check whether your Debian Bullseye Instance is concerned by running the following command, where `UUID` is the identifier of your Instance:
 
 ```sh
-scw -o json Instance server get UUID | jq '.routed_ip_enabled and ([.public_ips[] | select(.family != "inet6")] == [])'
+scw -o json instance server get UUID | jq '.routed_ip_enabled and ([.public_ips[] | select(.family != "inet6")] == [])'
 ```
 
 <Message type="tip">
@@ -86,7 +86,7 @@ In this situation, proceed with the next section to install `netplan` before app
     All steps below require super-user (`root`) privileges.
 </Message>
 
-1. *(optional)** If, **and only if**,  your Instance is already booted using a routed IPv6-only setup, you need to temporarily configure your DNS resolver so that it can reach the Debian repositories, in order to install `netplan`. The following uses Google's DNS server:
+1. *(optional)* If, **and only if**,  your Instance is already booted using a routed IPv6-only setup, you need to temporarily configure your DNS resolver so that it can reach the Debian repositories, in order to install `netplan`. The following uses Google's DNS server:
     ```sh
     > /etc/resolv.conf cat <<EOF
     nameserver 2001:4860:4860::8888


### PR DESCRIPTION
### Description

Fixed some typos in troubleshooting article : [Fixing DNS resolution with a routed IPv6-only setup on Debian Bullseye](https://www.scaleway.com/en/docs/compute/instances/troubleshooting/fix-dns-routed-ipv6-only-debian-bullseye/)
