### PR TITLE
fix(cockpit): Link to DCGM exporter tutorial

### DIFF
--- a/observability/cockpit/index.mdx
+++ b/observability/cockpit/index.mdx
@@ -63,7 +63,7 @@ meta:
     />
     <DefaultCard
         title="Monitor GPU Instances using Cockpit and the NVIDIA Data Center GPU Manager (DCGM) Exporter"
-        url="/tutorials/monitor-gpu-instance-with-cockpit/"
+        url="/tutorials/monitor-gpu-instance-cockpit/"
         label="Read more"
     />
 </Grid>


### PR DESCRIPTION
Fixing link towards DCGM exporter tutorial in Cockpit Overview Documentation page

