### PR TITLE
docs: use-dedibackup-ftp-backup: Adding Linux example

### DIFF
--- a/dedibox/dedicated-servers/how-to/use-dedibackup-ftp-backup.mdx
+++ b/dedibox/dedicated-servers/how-to/use-dedibackup-ftp-backup.mdx
@@ -101,3 +101,37 @@ ABOR, ACCT, APPE, CDUP, CWD, DELE, FEAT, LIST, MDTM, MKD, MODE, NLIST, NOOP, PAS
 In case of a failure during authentication (wrong identifier and/or password), connection failure of the access control list (ACL), or failure of the automatic login from an unauthorized IP, the connection will be systematically terminated with the message **421 Service not available**.
 
 
+### Usage on Linux
+
+- `lftp` is working well with this FTP server.
+- `curl` is not working properly since some commands are not fully handled by this FTP server and `curl` handles those FTP commands internally.
+It is why `lftp` is the best option.
+
+Usage example with `lftp` that can be integrated in automated script:
+```sh
+# Requirement
+apt install lftp
+
+# FTP Credentials
+FTP_HOST="dedibackup-dc3.online.net"
+FTP_USER="auto" # If using ACL and auto-login, login is 'auto', else use provided username
+FTP_PASS=""     # If using ACL and auto-login, password is empty, else use provided password
+
+# - Connect to FTP server
+# - Upload a file, list files, remove a file
+# - Disconnect from FTP server
+lftp -u "$FTP_USER,$FTP_PASS" "$FTP_HOST" <<EOF
+# Enable passive mode for FTP
+set ftp:passive-mode true
+# Change to the specified FTP directory
+cd "/"
+# Upload a file
+put "dedibox_file_path_here.7z"
+# List files in the folder
+ls
+# Remove a file
+rm "ftp_file_path_here.7z"
+# Exit lftp
+bye
+EOF
+```


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

Adding example for Linux in https://www.scaleway.com/en/docs/dedibox/dedicated-servers/how-to/use-dedibackup-ftp-backup/ to help user understand how to use the FTP backup server.

Indeed, this FTP server is a bit 'limited' as some basic commands like `curl` is not working properly with it.
It is therefor quite useful to have a working example (even if basic).

(