### PR TITLE
fix(acc): update sso login docs

### DIFF
--- a/console/account/how-to/log-in-to-the-console.mdx
+++ b/console/account/how-to/log-in-to-the-console.mdx
@@ -41,6 +41,6 @@ A confirmation email is sent to your inbox, confirming that you have authenticat
 Scaleway provides Single Sign-On (SSO) options for a seamless login experience. You can use your Google or Microsoft account to log in to the console. To do so, make sure the email address associated with your Scaleway account matches the email address of your Google or Microsoft account.
 
 1. Open your web browser and go to the [Scaleway console](https://console.scaleway.com).
-2. Click the **Log in with Google** or **Log in with Microsoft** button, depending on the account you want to use.
-3. You will be redirected to the respective login page of Google or Microsoft.
+2. Click the **Log in with Google** , **Log in with Microsoft**, or **Log in with GitHub** button, depending on the account you want to use.
+3. You will be redirected to the respective login page of Google, Microsoft or GitHub.
 4. If multifactor authentication (MFA) is activated, enter the authentication code. 

--- a/console/account/troubleshooting/cannot-log-into-my-account.mdx
+++ b/console/account/troubleshooting/cannot-log-into-my-account.mdx
@@ -59,4 +59,4 @@ Once you have gathered all the required documents, the request has to be sent by
 
 ## SSO authentication is not working
 
-If the email address of your Google or Microsoft account does not match the email address associated with your Scaleway account, you will not be able to log in using SSO. Make sure both email addresses are the same.
+If the email address of your Google, Microsoft, or GitHub account does not match the email address associated with your Scaleway account, you will not be able to log in using SSO. Make sure both email addresses are the same.


### PR DESCRIPTION
Added GitHub to the list of external providers that can be used for SSO login
