### PR TITLE
feat(changelog): edge-services-changed-edge-services-redirects-http-to-h 2024-11-07

### DIFF
--- a/changelog/november2024/2024-11-07-edge-services-changed-edge-services-redirects-http-to-h.mdx
+++ b/changelog/november2024/2024-11-07-edge-services-changed-edge-services-redirects-http-to-h.mdx
@@ -1,5 +1,5 @@
 ---
-title: Edge Services redirects HTTP to HTTPS for Object Storage Integration
+title: Edge Services redirects HTTP to HTTPS for Object Storage integration
 status: changed
 author:
     fullname: 'Join the #edge-services channel on Slack.'

--- a/changelog/november2024/2024-11-07-edge-services-changed-edge-services-redirects-http-to-h.mdx
+++ b/changelog/november2024/2024-11-07-edge-services-changed-edge-services-redirects-http-to-h.mdx
@@ -1,0 +1,13 @@
+---
+title: Edge Services redirects HTTP to HTTPS for Object Storage Integration
+status: changed
+author:
+    fullname: 'Join the #edge-services channel on Slack.'
+    url: 'https://slack.scaleway.com'
+date: 2024-11-07
+category: network
+product: edge-services
+---
+
+Starting November 13, 2024, Edge Services cache servers will change how they handle HTTP (`port 80`) requests. Instead of serving content over HTTP, they will issue an `HTTP 302` redirect to HTTPS (`port 443`), keeping the rest of the URL unchanged. This update applies only to Edge Services integrations with Object Storage.
+


### PR DESCRIPTION
Reporter: Doc team

This PR is a new changelog contribution. It has been created automatically.

Make sure to review it carefully before merging it.