### PR TITLE
docs(gitlabrunner): add GitLab registration details ext-fix-gitlabrunner

### DIFF
--- a/tutorials/easydeploy-gitlab-runner/index.mdx
+++ b/tutorials/easydeploy-gitlab-runner/index.mdx
@@ -36,11 +36,23 @@ This setup enables you to optimize resource utilization, reduce overhead, and en
         If you cannot find GitLab Runner on the first page, use the search bar or navigate through the library using the arrow buttons.
     </Message>
 7. Optionally, customize the default configuration for GitLab Runner using [Helm Charts](/tutorials/kubernetes-package-management-helm/). If you do not need any customized configuration you can skip this step.
-8. Enter a name (e.g. `gitlab-runner`) and a Kubernetes namespace for your application. If no name is entered, GitLab Runner will be installed in the default namespace of the cluster.
-9. Click **Deploy Application** to deploy GitLab Runner on your Kubernetes cluster.
-10. Verify that the GitLab Runner is successfully installed and running:
+8. **Provide GitLab Details:**
+    - **GitLab URL (`gitlabUrl`)**: Go to your GitLab project, navigate to **Settings > CI/CD > Runners**, and copy the GitLab instance URL.
+    - **Registration Token (`runnerToken`)**: Under the **Specific Runners** section in **Settings > CI/CD > Runners**, copy the registration token for your project. These are necessary to allow GitLab Runner to register correctly with your GitLab project.
+    ```yaml
+    gitlabUrl: https://your-gitlab.com
+    runnerToken: "your-token"
+    rbac:
+      create: true
+    ```
+    <Message type="info">
+        It is essential to provide these details to successfully register your GitLab Runner with your GitLab project.
+    </Message>
+9. Enter a name (e.g. `gitlab-runner`) and a Kubernetes namespace for your application. If no name is entered, GitLab Runner will be installed in the default namespace of the cluster.
+10. Click **Deploy Application** to deploy GitLab Runner on your Kubernetes cluster.
+11. Verify that the GitLab Runner is successfully installed and running:
     ```bash
-    kubectl get pods -n default # replace "default" with the name of the Kubernetes namespace in which you have installed your GitLab Runner.
+    kubectl get pods -n <namespace> # replace "<namespace>" with the name of the Kubernetes namespace in which you have installed your GitLab Runner.
     ```
     You should see a pod with a name similar to `gitlab-runner-xxxxxx-xxxxx` in the `Running` state.
 
@@ -120,7 +132,7 @@ Navigate to **CI/CD** > **Pipelines** in your GitLab project to view the status 
 <Message type="tip">
   If the pipeline fails, you can check the logs of the GitLab Runner pod for more information:
    ```bash
-   kubectl logs -n default <gitlab-runner-pod-name>
+   kubectl logs -n <namespace> <gitlab-runner-pod-name>
    ```
 </Message>
 


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

This pull request enhances the documentation for deploying a GitLab Runner on Scaleway Kubernetes clusters using the Easy Deploy feature. The modifications include:

- Added comprehensive details regarding the configuration of the GitLab URL (`gitlabUrl`) and the registration token (`runnerToken`), which are essential for properly registering the GitLab Runner with the GitLab project.
- Provided explicit instructions on how to retrieve these details from the GitLab interface, with step-by-step guidance for navigating to **Settings > CI/CD > Runners**.
- Included an example YAML configuration containing `gitlabUrl` and `runnerToken` to facilitate a clearer understanding for users on how to complete this setup.

These enhancements aim to clarify critical configuration steps, thereby minimising potential errors during the deployment of the GitLab Runner, and making the documentation more accessible and practical for new users.