### PR TITLE
fix(em): add info for reserved IP

### DIFF
--- a/bare-metal/elastic-metal/how-to/use-private-networks.mdx
+++ b/bare-metal/elastic-metal/how-to/use-private-networks.mdx
@@ -66,7 +66,8 @@ You can attach/detach Elastic Metal servers to a Private Network from either the
       - It is created in your [default VPC](/network/vpc/concepts/#default-vpc) for the region
       - It has an auto-generated [CIDR block](/network/vpc/concepts/#cidr-block) used to allocate private IP addresses to servers attached to the network. Each attached Elastic Metal server will get an IPv4 and an IPv6 address on the Private Network.
     </Message>
-6. Click **Attach Private Network** to confirm.
+6. Choose whether to auto-allocate an available IP from the pool (the [CIDR block](/network/vpc/concepts/#cidr-block) defined at the time of creating the Private Network), or use a [reserved IP address](/network/ipam/concepts/#reserved-ip-address) for the attachment. You must make this choice for both the IPv4 and IPv6 address that the Elastic Metal server will have on this Private Network.
+7. Click **Attach Private Network** to confirm.
 
 ### From the VPC section of the console
 

--- a/bare-metal/elastic-metal/how-to/use-private-networks.mdx
+++ b/bare-metal/elastic-metal/how-to/use-private-networks.mdx
@@ -67,7 +67,7 @@ You can attach/detach Elastic Metal servers to a Private Network from either the
       - It has an auto-generated [CIDR block](/network/vpc/concepts/#cidr-block) used to allocate private IP addresses to servers attached to the network. Each attached Elastic Metal server will get an IPv4 and an IPv6 address on the Private Network.
     </Message>
 6. Choose whether to auto-allocate an available IP from the pool (the [CIDR block](/network/vpc/concepts/#cidr-block) defined at the time of creating the Private Network), or use a [reserved IP address](/network/ipam/concepts/#reserved-ip-address) for the attachment. You must make this choice for both the IPv4 and IPv6 address that the Elastic Metal server will have on this Private Network.
-7. Click **Attach Private Network** to confirm.
+7. Click **Attach to Private Network** to confirm.
 
 ### From the VPC section of the console
 

--- a/bare-metal/elastic-metal/how-to/use-private-networks.mdx
+++ b/bare-metal/elastic-metal/how-to/use-private-networks.mdx
@@ -66,7 +66,7 @@ You can attach/detach Elastic Metal servers to a Private Network from either the
       - It is created in your [default VPC](/network/vpc/concepts/#default-vpc) for the region
       - It has an auto-generated [CIDR block](/network/vpc/concepts/#cidr-block) used to allocate private IP addresses to servers attached to the network. Each attached Elastic Metal server will get an IPv4 and an IPv6 address on the Private Network.
     </Message>
-6. Choose whether to auto-allocate an available IP from the pool (the [CIDR block](/network/vpc/concepts/#cidr-block) defined at the time of creating the Private Network), or use a [reserved IP address](/network/ipam/concepts/#reserved-ip-address) for the attachment. You must make this choice for both the IPv4 and IPv6 address that the Elastic Metal server will have on this Private Network.
+6. Choose whether to **auto-allocate an available IP from the pool** (the [CIDR block](/network/vpc/concepts/#cidr-block) defined at the time of creating the Private Network), or use a [reserved IP address](/network/ipam/concepts/#reserved-ip-address) for the attachment. You must make this choice for both the IPv4 and IPv6 address that the Elastic Metal server will have on this Private Network.
 7. Click **Attach to Private Network** to confirm.
 
 ### From the VPC section of the console


### PR DESCRIPTION
You can now use a reserved IP address when attaching an EM server to a Private Network.
