### PR TITLE
docs(container): add secure Docker login instructions int-feat-containers

### DIFF
--- a/containers/container-registry/quickstart.mdx
+++ b/containers/container-registry/quickstart.mdx
@@ -47,11 +47,11 @@ Scaleway [Container Registry](/containers/container-registry/concepts/#container
 3. Copy the push instructions. Then click **X** to close the pop-up.
 4. Open a terminal window on your local computer. Then log into the namespace by running the following command from the terminal:
     ```
-    docker login rg.fr-par.scw.cloud/mynamespace -u nologin -p [SCW_SECRET_KEY]
+    echo <SCW_SECRET_KEY> | docker login rg.fr-par.scw.cloud/<NAMESPACE> -u nologin --password-stdin
     ```
 
     <Message type="important">
-      Replace `[SCW_SECRET_KEY]` with your [API secret key](/identity-and-access-management/iam/how-to/create-api-keys/) and `mynamespace` with the name of your namespace.
+      Replace `<SCW_SECRET_KEY>` with your [API secret key](/identity-and-access-management/iam/how-to/create-api-keys/) and `<NAMESPACE>` with the name of your namespace.
     </Message>
 
     Once logged in, a confirmation is displayed:


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

It's insecure to use `docker login ... -u nologin -p SCW_SECRET_KEY` as the secret will be written to the shell history.
