### PR TITLE
docs(cpt): add pricing plans info

### DIFF
--- a/faq/cockpit.mdx
+++ b/faq/cockpit.mdx
@@ -76,7 +76,7 @@ Here is an example of how you would be billed for sending 52 billion custom metr
 
 From January 1st 2025, Cockpit is transitioning away from fixed pricing plans to offer you more flexibility and granularity for managing data [retention](/observability/cockpit/concepts/#retention).
 
-This change allows you to tailor retention settings to your specific needs. This evolution aims at enhancing your experience by providing more customizable options without immediate cost impact, as changing data retention period will be free during Beta.
+This change allows you to tailor retention settings to your specific needs. We hope to enhance your experience by providing more customizable options without immediate cost impact, as changing data retention period will be free during Beta.
 
 Find out [how to change data retention period](/observability/cockpit/how-to/change-data-retention/) in the dedicated documentation.
 

--- a/faq/cockpit.mdx
+++ b/faq/cockpit.mdx
@@ -5,10 +5,12 @@ meta:
 content:
   h1: Cockpit
 dates:
-  validation: 2024-09-10
+  validation: 2024-11-25
 category: observability
 productIcon: CockpitProductIcon
 ---
+
+<Macro id="cockpit-plan-deprecation" />
 
 ## What is Cockpit?
 
@@ -70,6 +72,13 @@ Here is an example of how you would be billed for sending 52 billion custom metr
 
 **Total:** €6.650 per month with volume discounts instead of €7.800 without volume discounts.
 
+## Why are Cockpit pricing plans being deprecated?
+
+From January 1st 2025, Cockpit is transitioning away from fixed pricing plans to offer you more flexibility and granularity for managing data [retention](/observability/cockpit/concepts/#retention).
+
+This change allows you to tailor retention settings to your specific needs. This evolution aims at enhancing your experience by providing more customizable options without immediate cost impact, as changing data retention period will be free during Beta.
+
+Find out [how to change data retention period](/observability/cockpit/how-to/change-data-retention/) in the dedicated documentation.
 
 ## How do I send my own data to my Cockpit?
 

--- a/macros/cockpit/plan-deprecation.mdx
+++ b/macros/cockpit/plan-deprecation.mdx
@@ -1,0 +1,12 @@
+---
+macro: cockpit-plan-deprecation
+---
+
+<Message type="important">
+
+ **Cockpit pricing plans are scheduled for deprecation on January 1st 2025** <br /><br />
+
+ The [retention](/observability/cockpit/concepts/#retention) period previously set for your Scaleway and custom logs, metrics and traces will remain the same after that date. <br /><br />
+ You will be able to change the retention period for your metrics, logs, and traces for free during Beta (starting January 1st 2025). <br /><br />
+ Find out [how to change data retention period](/observability/cockpit/how-to/change-data-retention/) in the dedicated documentation.
+</Message>

--- a/menu/navigation.json
+++ b/menu/navigation.json
@@ -3557,6 +3557,10 @@
                     "slug": "create-external-data-sources"
                   },
                   {
+                    "label": "Change data retention period",
+                    "slug": "change-data-retention"
+                  },
+                  {
                     "label": "Send metrics to Cockpit using Grafana Alloy",
                     "slug": "send-metrics-with-grafana-alloy"
                   },

--- a/observability/cockpit/concepts.mdx
+++ b/observability/cockpit/concepts.mdx
@@ -161,6 +161,18 @@ A region is the geographical area in which your Cockpit data is stored. They are
 
 You can decide in which region to enable the [alert manager](#alert-manager) and your [preconfigured alerts](#preconfigured-alerts). You can also choose the regions in which to create your [data types](#data-types), [data sources](#data-sources), and [tokens](#tokens).
 
+## Retention
+
+Retention refers to the duration for which data, such as metrics, logs, or traces, is stored before being automatically deleted. Retention allows you to manage the lifecycle of your data by selecting storage periods that align with your needs.
+
+The minimum and maximum retention periods for each data source are as follows:
+
+| Custom metrics                                 | Custom logs/traces                          | Scaleway metrics                               | Scaleway logs/traces                        |
+|------------------------------------------------|---------------------------------------------|------------------------------------------------|---------------------------------------------|
+| Minimum retention period: 1 day                | Minimum retention period: 1 day             | Minimum retention period: 31 days              | Minimum retention period: 1 day             |
+| Maximum retention period: 365 days (12 months) | Maximum retention period: 31 days (1 month) | Maximum retention period: 365 days (12 months) | Maximum retention period: 31 days (1 month) |
+| Default retention period: 31 days              | Default retention period: 7 days            | Default retention period: 31 days              | Default retention period: 7 days            |
+
 ## Samples
 
 A sample is a unique measuring point on a time series.

--- a/observability/cockpit/concepts.mdx
+++ b/observability/cockpit/concepts.mdx
@@ -163,9 +163,9 @@ You can decide in which region to enable the [alert manager](#alert-manager) and
 
 ## Retention
 
-Retention refers to the duration for which data, such as metrics, logs, or traces, is stored before being automatically deleted. Retention allows you to manage the lifecycle of your data by selecting storage periods that align with your needs.
+Retention or data retention refers to the duration for which data, such as metrics, logs, or traces, is stored before being automatically deleted. Retention allows you to manage the lifecycle of your Scaleway and custom data by selecting storage periods that align with your needs.
 
-The minimum and maximum retention periods for each data source are as follows:
+The minimum and maximum retention periods for each data source type are as follows:
 
 | Custom metrics                                 | Custom logs/traces                          | Scaleway metrics                               | Scaleway logs/traces                        |
 |------------------------------------------------|---------------------------------------------|------------------------------------------------|---------------------------------------------|

--- a/observability/cockpit/how-to/change-data-retention.mdx
+++ b/observability/cockpit/how-to/change-data-retention.mdx
@@ -1,0 +1,42 @@
+---
+meta:
+  title: How to change your data retention period
+  description: Discover how to adjust data retention settings for metrics, logs, and traces in Cockpit.
+content:
+  h1: How to change your data retention period
+  paragraph: Discover how to adjust data retention settings for metrics, logs, and traces in Cockpit.
+tags: cockpit data-retention retention-period edit-retention
+categories:
+  - observability
+dates:
+  validation: 2024-11-25
+  posted: 2024-11-25
+---
+
+This page shows you how to change the [retention](/observability/cockpit/concepts/#retention) period for your data sources. **This feature will be available only starting January 1st 2025**.
+
+<Macro id="cockpit-plan-deprecation" />
+
+<Macro id="requirements" />
+
+  - A Scaleway account logged into the [console](https://console.scaleway.com)
+  - [Owner](/identity-and-access-management/iam/concepts/#owner) status or [IAM permissions](/identity-and-access-management/iam/concepts/#permission) allowing you to perform actions in the intended Organization
+
+1. Click **Cockpit** in the Observability section of the [console](https://console.scaleway.com/) side menu. The **Cockpit** overview page displays.
+2. Click the **Data sources** tab.
+3. Click the <Icon name="more" /> icon next to the data source you want to change the retention period for.
+4. Click **More info**. The **Data source information** page displays.
+5. Click the **Edit retention** button and drag the slider to adjust the retention period:
+    - Drag the slider to the **right to increase** your retention period, or
+    - Drag the slider to the **left to decrease** the retention period.
+
+        <Message type="important">
+         - Reducing your retention period deletes observability data gathered beyond the selected timeframe.
+         - You can edit the retention period for metrics only **once an hour**
+         - You can edit the retention period for logs **only once a day**
+        </Message>
+6. Click **Edit retention period** to confirm.
+
+        <Message type="note">
+         Adjusting data retention is free of charge during Beta.
+        </Message>

--- a/observability/cockpit/how-to/change-data-retention.mdx
+++ b/observability/cockpit/how-to/change-data-retention.mdx
@@ -32,7 +32,7 @@ This page shows you how to change the [retention](/observability/cockpit/concept
 2. Click the **Data sources** tab.
 3. Click the <Icon name="more" /> icon next to the data source you want to change the retention period for.
         <Message type="tip">
-         You can change the retention period for botch Scaleway and custom data sources. Each data source can have a different retention period.
+         You can change the retention period for both Scaleway and custom data sources. Each data source can have a different retention period.
         </Message>
 4. Click **More info**. The **Data source information** page displays.
 5. Click the **Edit retention** button and drag the slider to adjust the retention period:

--- a/observability/cockpit/how-to/change-data-retention.mdx
+++ b/observability/cockpit/how-to/change-data-retention.mdx
@@ -15,7 +15,13 @@ dates:
 
 This page shows you how to change the [retention](/observability/cockpit/concepts/#retention) period for your data sources. **This feature will be available only starting January 1st 2025**.
 
-<Macro id="cockpit-plan-deprecation" />
+<Message type="important">
+
+ **Cockpit pricing plans are scheduled for deprecation on January 1st 2025** <br /><br />
+
+ The [retention](/observability/cockpit/concepts/#retention) period previously set for your Scaleway and custom logs, metrics and traces will remain the same after that date. <br /><br />
+ You will be able to change the retention period for your metrics, logs, and traces for free during Beta (starting January 1st 2025). <br /><br />
+</Message>
 
 <Macro id="requirements" />
 
@@ -25,15 +31,17 @@ This page shows you how to change the [retention](/observability/cockpit/concept
 1. Click **Cockpit** in the Observability section of the [console](https://console.scaleway.com/) side menu. The **Cockpit** overview page displays.
 2. Click the **Data sources** tab.
 3. Click the <Icon name="more" /> icon next to the data source you want to change the retention period for.
+        <Message type="tip">
+         You can change the retention period for botch Scaleway and custom data sources. Each data source can have a different retention period.
+        </Message>
 4. Click **More info**. The **Data source information** page displays.
 5. Click the **Edit retention** button and drag the slider to adjust the retention period:
     - Drag the slider to the **right to increase** your retention period, or
     - Drag the slider to the **left to decrease** the retention period.
 
         <Message type="important">
-         - Reducing your retention period deletes observability data gathered beyond the selected timeframe.
-         - You can edit the retention period for metrics only **once an hour**
-         - You can edit the retention period for logs **only once a day**
+         - Reducing the retention period of a data source will permanently delete all observability data in that data source beyond the selected timeframe. This deletion is irreversible and takes effect a few minutes after the retention period is reduced, even if the retention period is later increased.
+         - Find out about the [retention periods available for each data source type](/observability/cockpit/concepts/#retention).
         </Message>
 6. Click **Edit retention period** to confirm.
 

--- a/observability/cockpit/reference-content/cockpit-limitations.mdx
+++ b/observability/cockpit/reference-content/cockpit-limitations.mdx
@@ -7,11 +7,13 @@ content:
   paragraph: Discover the capabilities and limits of Cockpit, including retention periods, Loki and Mimir limits, and product integrations for comprehensive infrastructure monitoring and management efficiency.
 tags: observability cockpit retention metrics logs
 dates:
-  validation: 2024-11-04
+  validation: 2024-11-25
   posted: 2023-09-05
 categories:
   - observability
 ---
+
+<Macro id="cockpit-plan-deprecation" />
 
 This page provides information about the capabilities and limits of Scaleway's Observability Cockpit.
 


### PR DESCRIPTION
What changed:

- Added "retention" concept + a table with minimum, maximum and default retention time for each data source
- Added "how to change data retention" page
- Added a macro to warn about plan deprecation (that is reused in different pages)
- Added the macro about plan deprecation in the FAQ page
- Added a question in the FAQ to explain why plans are being deprecated
- Added the macro in the Cockpit Capabilities and limits page

<img width="325" alt="Capture d’écran 2024-11-26 à 15 02 18" src="https://github.com/user-attachments/assets/b25930b1-cd41-450b-857a-bc799457161c">

<img width="726" alt="Capture d’écran 2024-11-25 à 17 04 10" src="https://github.com/user-attachments/assets/f0617d28-0851-45ea-9359-2b4e963a7741">

@sfinet-scw Je viens de mettre à jour en implémentant tes commentaires, j'ai re-généré une capture de la page How-to ci-dessus ! (la typo "botch" dans la box tip après la 3ème étape vient d'être corrigée par ailleurs)