### PR TITLE
feat(changelog): kubernetes-added-kubernetes-version-131-is-now-availabl 2024-11-29

### DIFF
--- a/changelog/november2024/2024-11-29-kubernetes-added-kubernetes-version-131-is-now-availabl.mdx
+++ b/changelog/november2024/2024-11-29-kubernetes-added-kubernetes-version-131-is-now-availabl.mdx
@@ -2,14 +2,15 @@
 title: Kubernetes version 1.31 is now available!
 status: added
 author:
-    fullname: ''
+    fullname: 'Join the #k8s channel on Slack.'
     url: 'https://slack.scaleway.com'
 date: 2024-11-29
 category: containers
 product: kubernetes
 ---
 
-Scaleway managed Kubernetes products will support the latest minor version 1.31 Elli until February 2026.
-In addition to patch versions 1.31.0, 1.31.1, 1.31.2, 1.31.3, releases 1.30.1, 1.30.2, 1.30.3, 1.29.2 to 1.29.6, 1.28.8 to 1.28.11, 1.27.11 to 1.27.15, and 1.26.14 to 1.26.15 are also available.
-Read our [version support policy](https://www.scaleway.com/en/docs/containers/kubernetes/reference-content/version-support-policy/) for more details on the 14-month support timeline.
+Scaleway managed Kubernetes products will support the latest minor version `1.31` Elli until February 2026.
+
+In addition to patch versions `1.31.0`, `1.31.1`, `1.31.2`, `1.31.3`, releases `1.30.1`, `1.30.2`, `1.30.3`, `1.29.2` to `1.29.6`, `1.28.8` to `1.28.11`, `1.27.11` to `1.27.15`, and `1.26.14` to `1.26.15` are also available.
+Read our [version support policy](/containers/kubernetes/reference-content/version-support-policy/) for more details on the 14-month support timeline.
 


### PR DESCRIPTION
Reporter: Galem Kayo

This PR is a new changelog contribution. It has been created automatically.

Make sure to review it carefully before merging it.