### PR TITLE
docs(gen): update landing page keywords

### DIFF
--- a/containers/kubernetes/api-cli/creating-managing-kubernetes-lifecycle-cliv2.mdx
+++ b/containers/kubernetes/api-cli/creating-managing-kubernetes-lifecycle-cliv2.mdx
@@ -153,7 +153,7 @@ You can [create](/containers/kubernetes/how-to/create-cluster/) and [manage](/co
     </Message>
 2. Write down the ID of your cluster, as you will need it in the next steps.
 
-## Installing a KubeConfig configuration file
+## Installing a Kubeconfig configuration file
 
 Type the following command in your terminal and replace `your-cluster-ID` with the ID of your previously generated cluster:
 
@@ -319,5 +319,3 @@ UsernameClaim   -
 UsernamePrefix  -
 GroupsPrefix    -
 ```
-
-

--- a/containers/kubernetes/concepts.mdx
+++ b/containers/kubernetes/concepts.mdx
@@ -74,7 +74,7 @@ Ingress is an API object that manages external access to the services in a clust
 
 Kubernetes supports a high-level abstraction called Ingress, which allows simple host or URL-based HTTP routing. Ingress is a core concept (in beta) of Kubernetes, but is always implemented by a third-party proxy. These implementations are known as ingress controllers. An ingress controller is responsible for reading the Ingress Resource information and processing that data accordingly. Different ingress controllers have extended the specification in different ways to support additional use cases. For more information, see our [dedicated how-to](/containers/kubernetes/how-to/deploy-ingress-controller/) on deploying ingress controllers.
 
-## KubeConfig
+## Kubeconfig
 
 `kubeconfig` is a file provided by Scaleway when creating a Kubernetes cluster. It allows you to manage your cluster from your local computer by using kubectl.
 

--- a/index.mdx
+++ b/index.mdx
@@ -7,7 +7,7 @@ meta:
 <HomepageHeader
     title="Scaleway Documentation"
     description="Everything you need to make the most of Scaleway’s products."
-    searchSuggestion={['rpn', 'ipv6', 'proxmox']}
+    searchSuggestion={['smtp', 'ssh', 'rpn']}
 />
 
 ## Getting started


### PR DESCRIPTION
### Description

- Updated suggested keywords from the landing page, based on past trimester's data. 
- Fixed a casing error for `kubeconfig`.
