### PR TITLE
feat(changelog): load-balancers-removed-static-attachment-is-no-longer-a 2024-12-05

### DIFF
--- a/changelog/december2024/2024-12-05-load-balancers-removed-static-attachment-is-no-longer-a.mdx
+++ b/changelog/december2024/2024-12-05-load-balancers-removed-static-attachment-is-no-longer-a.mdx
@@ -9,5 +9,4 @@ category: network
 product: load-balancers
 ---
 
-The static attachment of a private network to a Loadbalancer, that was deprecated in September 2023, will be removed from the api on January 2025. To achieve similar functionnality, use the ipam_ids parameters of the private network attachment endpoint.
-
+The feature to statically attach a Private Network to a Load Balancer (deprecated in September 2023) will be removed from the API in January 2025. To achieve similar functionality, use the `ipam_ids` parameter with the Private Network attachment endpoint.

--- a/changelog/december2024/2024-12-05-load-balancers-removed-static-attachment-is-no-longer-a.mdx
+++ b/changelog/december2024/2024-12-05-load-balancers-removed-static-attachment-is-no-longer-a.mdx
@@ -1,0 +1,13 @@
+---
+title: Static attachment is no longer available
+status: removed
+author:
+    fullname: '#lb'
+    url: 'https://slack.scaleway.com'
+date: 2024-12-05
+category: network
+product: load-balancers
+---
+
+The static attachment of a private network to a Loadbalancer, that was deprecated in September 2023, will be removed from the api on January 2025. To achieve similar functionnality, use the ipam_ids parameters of the private network attachment endpoint.
+


### PR DESCRIPTION
Reporter: Matth

This PR is a new changelog contribution. It has been created automatically.

Make sure to review it carefully before merging it.