### PR TITLE
docs(ins): fixed titles

### DIFF
--- a/compute/instances/reference-content/identify-devices.mdx
+++ b/compute/instances/reference-content/identify-devices.mdx
@@ -17,9 +17,9 @@ An Instance is composed of a multitude of devices. Some of them can be configure
 
 On a Linux host, devices are named by the kernel in the order they are discovered. The order in which devices are discovered is dependent on things such as the topology of the PCI hierarchy which are *not* guaranteed to be stable across power off/power on/reboot actions.
 
-This guide aims to provide tips to help you identify devices in a stable manner on a Linux host.
+This guide aims to provide tips to help you stably identify devices on a Linux host.
 
-# Identifying Instance Block Storage volumes (b_ssd)
+## Identifying Instance Block Storage volumes (b_ssd)
 
 Instance Block Storage (`b_ssd`) volumes are connected to the Instance as SCSI disks. They will therefore appear as devices handled by the sd driver in the dev file system, i.e. as `/dev/sd{a,b,c...}` devices.
 
@@ -96,7 +96,7 @@ Note that this rule relies on `ID_VENDOR` and `ID_SERIAL_SHORT` being in the env
 
 For more details on writing `udev` rules, please see `man 7 udev`.
 
-# Identifying Block Storage volumes (SBS)
+## Identifying Block Storage volumes (SBS)
 
 Block Storage devices are similar to Instance Block Storage devices. They are also connected to the Instance as SCSI devices and thus all explanations from the above section are also valid.
 
@@ -117,7 +117,7 @@ sdb  0:0:1:0    disk SCW      b_ssd  v42 volume-03e206f6-2a3b-4223-bb56-3d7f1495
 
 Here, the first volume has been created through the Block Storage API with class `sbs`. The second volume is an Instance Block Storage (`b_ssd`) volume which has been migrated to Block Storage, and is now a Block Storage volume with class `bssd`.
 
-# Identifying VPC Private Network interfaces
+## Identifying VPC Private Network interfaces
 
 VPC Private Networks to which the Instance is connected will appear as virtio PCI network devices, handled by the `virtio-net` driver.
 
@@ -151,7 +151,7 @@ root@test-instance:~# ip link show
     altname enp0s6
 ```
 
-Here, four interfaces are listed, one of which (`lo`) is the virtual loopback interface and can be disregarded. The three other correspond to the aforementioned public network interface, and VPC Private Network interfaces.
+Here, four interfaces are listed, one of which (`lo`) is the virtual loopback interface and can be disregarded. The three others correspond to the aforementioned public network interface and VPC Private Network interfaces.
 
 A simple and effective way to distinguish the public network interface from the VPC Private Network interfaces is the MAC address prefix. VPC Private Network interfaces always have a MAC address starting with `02:00:00`.
 
@@ -195,7 +195,7 @@ For example, querying `/instances/v1/<zone>/servers/<uuid>/private_nics`, where 
 }
 ```
 
-Two entries are listed, which correspond to the interfaces given by the output of `ip link show` above. The output contains the ID of the VPC Private Network, which helps distinguishing between the two.
+Two entries are listed, which correspond to the interfaces given by the output of `ip link show` above. The output contains the ID of the VPC Private Network, which helps distinguish between the two.
 
 Through the use of `udev` rules, it is possible to rename the interfaces if desired. For example, the following rule would assign the static name `priv0` to the interface with MAC address `02:00:00:b7:c8:a5`:
 
@@ -209,5 +209,5 @@ If a more complex scheme is desired, such as including part of the name of the c
 SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="02:00:00:*", ENV{SYSTEMD_WANTS}="my-vpc-script@$env{ID_NET_NAME}.service"
 ```
 
-This rule would start the systemd service `my-vpc-service@<ifname>` when a new interface with name `<ifname>` is added and has a MAC address matching the VPC Private Network prefix.
-The systemd service can then execute complex operations (retrieving the server's `private_nics` informations, the VPC Private Network information through the VPC API, applying custom logic, etc.).
+This rule would start the systemd service `my-vpc-service@<ifname>` when a new interface with the name `<ifname>` is added and has a MAC address matching the VPC Private Network prefix.
+The systemd service can then execute complex operations (retrieving the server's `private_nics` information, the VPC Private Network information through the VPC API, applying custom logic, etc.).


### PR DESCRIPTION
### Description

Changing section titles from H1s to H2s so they are featured on the 'Jump to' menu.
Fixed some typos.
