### PR TITLE
fix: correct deprecation date for kapsule 1.31

### DIFF
--- a/containers/kubernetes/reference-content/version-support-policy.mdx
+++ b/containers/kubernetes/reference-content/version-support-policy.mdx
@@ -56,7 +56,7 @@ When a minor version becomes unsupported, Scaleway operates an upgrade to the la
 
 | Kubernetes version | Official release | Official End of Life | Scaleway Release             | Deprecation      | End of Support    |
 |--------------------|------------------|----------------------|------------------------------|------------------|-------------------|
-| 1.31               | August 2024      | October 28, 2025     | December 2, 2024             | December 2, 2024 | February 2, 2026  |
+| 1.31               | August 2024      | October 28, 2025     | December 2, 2024             | December 2, 2025 | February 2, 2026  |
 | 1.30               | April 2024       | June 28, 2025        | July 9, 2024                 | July 9, 2025     | September 9, 2025 |
 | 1.29               | December 2023    | February 2025        | February 7, 2024             | February 2025    | April 7, 2025*    |
 | 1.28               | August 2023      | October 2024         | August 2023                  | February 2025*   | April 7, 2025*    |


### PR DESCRIPTION
### Description

correct deprecation date for kapsule 1.31, it is 2025 not 2024.