### PR TITLE
fix(riscv): xz-utils required

### DIFF
--- a/bare-metal/elastic-metal/reference-content/elastic-metal-rv1-guidelines.mdx
+++ b/bare-metal/elastic-metal/reference-content/elastic-metal-rv1-guidelines.mdx
@@ -58,7 +58,8 @@ Linux kernel.
     sudo apt install -y \
       autoconf bc bison dwarves flex gawk git make \
       libelf-dev libssl-dev \
-      u-boot-tools device-tree-compiler
+      u-boot-tools device-tree-compiler \
+      xz-utils
     ```
 3. Clone the projects to build.
     ```bash


### PR DESCRIPTION
kernel/kheaders_data.tar.xz requires xz-utils