### PR TITLE
fix(ins): add PRO2 instance range to bandwidth overview

### DIFF
--- a/compute/gpu/reference-content/gpu-instances-bandwidth-overview.mdx
+++ b/compute/gpu/reference-content/gpu-instances-bandwidth-overview.mdx
@@ -1,0 +1,49 @@
+---
+meta:
+  title: Scaleway GPU Instances internet and Block Storage bandwidth overview
+  description: Find detailed information about the internet and Block Storage bandwidth for each GPU Instance type at Scaleway.
+content:
+  h1: Scaleway GPU Instances internet and Block Storage bandwidth overview
+  paragraph: Find detailed information about the internet and Block Storage bandwidth for each GPU Instance type at Scaleway.
+tags: instance
+dates:
+  validation: 2025-01-07
+  posted: 2025-01-07
+categories:
+  - compute
+---
+
+
+Scaleway GPU Instances are designed to deliver **high-performance computing** for AI/ML workloads, rendering, scientific simulations, and visualization tasks.
+This guide provides a detailed overview of their **internet and Block Storage bandwidth capabilities** to help you choose the right instance for your GPU-powered workloads.
+
+### Why bandwidth matters for GPU Instances  
+
+GPU workloads often involve processing large datasets, requiring high-bandwidth networking and storage access.
+- **Internet bandwidth**: Determines how fast your Instance can send or receive data from external sources, enabling smooth data transfers for model training or streaming.
+- **Block bandwidth**: Impacts data access speeds for datasets stored in Block Storage, optimizing performance for AI pipelines, rendering workflows, and other data-intensive applications.
+
+<Message type="important">
+  Bandwidth specifications listed here are for **informational purposes only**. To validate the exact bandwidth capacity of your GPU Instance, refer to the `block_bandwidth` field in the [Instances API](https://www.scaleway.com/en/developers/api/instance/#path-instance-types-list-instance-types). Use the endpoint `/instance/v1/zones/{zone}/products/servers` to retrieve GPU Instance specifications.
+</Message>
+
+<Message type="tip">
+  For AI/ML training workloads requiring high throughput, we recommend choosing GPU Instances with **at least 2–3 GiB/s** of Block bandwidth.  
+</Message>
+
+## GPU Range
+
+|   Instance Type   |   Internet Bandwidth   |   Block Bandwidth   |
+|-------------------|-------------------------|---------------------|
+| H100-1-80G        | 10 Gbit/s              | 2 GiB/s            |
+| H100-2-80G        | 20 Gbit/s              | 4 GiB/s            |
+| L40S-1-48G        | 2.5 Gbit/s             | 1 GiB/s            |
+| L40S-2-48G        | 5 Gbit/s               | 1.5 GiB/s          |
+| L40S-4-48G        | 10 Gbit/s              | 2.5 GiB/s          |
+| L40S-8-48G        | 20 Gbit/s              | 5 GiB/s            |
+| L4-1-24G          | 2.5 Gbit/s             | 1 GiB/s            |
+| L4-2-24G          | 5 Gbit/s               | 1.5 GiB/s          |
+| L4-4-24G          | 10 Gbit/s              | 2.5 GiB/s          |
+| L4-8-24G          | 20 Gbit/s              | 5 GiB/s            |
+| GPU-3070-S        | 2.5 Gbit/s             | 1 GiB/s            |
+| RENDER-S          | 2 Gbit/s               | 1 GiB/s            |

--- a/compute/gpu/reference-content/gpu-instances-bandwidth-overview.mdx
+++ b/compute/gpu/reference-content/gpu-instances-bandwidth-overview.mdx
@@ -24,11 +24,11 @@ GPU workloads often involve processing large datasets, requiring high-bandwidth 
 - **Block bandwidth**: Impacts data access speeds for datasets stored in Block Storage, optimizing performance for AI pipelines, rendering workflows, and other data-intensive applications.
 
 <Message type="important">
-  Bandwidth specifications listed here are for **informational purposes only**. To validate the exact bandwidth capacity of your GPU Instance, refer to the `block_bandwidth` field in the [Instances API](https://www.scaleway.com/en/developers/api/instance/#path-instance-types-list-instance-types). Use the endpoint `/instance/v1/zones/{zone}/products/servers` to retrieve GPU Instance specifications.
+  Bandwidth specifications listed here are for informational purposes only. To validate the exact bandwidth capacity of your GPU Instance, refer to the `block_bandwidth` field in the [Instances API](https://www.scaleway.com/en/developers/api/instance/#path-instance-types-list-instance-types). Use the endpoint `/instance/v1/zones/{zone}/products/servers` to retrieve GPU Instance specifications.
 </Message>
 
 <Message type="tip">
-  For AI/ML training workloads requiring high throughput, we recommend choosing GPU Instances with **at least 2–3 GiB/s** of Block bandwidth.  
+  To maximize compatibility with [Block Storage Low Latency 15k](/storage/block/), select an Instance with **at least 3 GiB/s** of Block bandwidth.
 </Message>
 
 ## GPU Range

--- a/compute/instances/reference-content/instances-bandwidth-overview.mdx
+++ b/compute/instances/reference-content/instances-bandwidth-overview.mdx
@@ -125,5 +125,6 @@ Bandwidth impacts how your applications perform and interact with other systems.
 
 |   Instance Type      |   Internet Bandwidth   |   Block Bandwidth   |
 |-----------------------|-------------------------|---------------------|
-| POP2-HN-3            | 3  Gbit/s            | 400 MiB/s       |
-| POP2-HN-10           | 10  Gbit/s           | 800 MiB/s       |
+| POP2-HN-3            | 3  Gbit/s              | 400 MiB/s          |
+| POP2-HN-5            | 5  Gbit/s              | 800 MiB/s          |
+| POP2-HN-10           | 10 Gbit/s              | 800 MiB/s          |

--- a/compute/instances/reference-content/instances-bandwidth-overview.mdx
+++ b/compute/instances/reference-content/instances-bandwidth-overview.mdx
@@ -7,7 +7,7 @@ content:
   paragraph: Find detailed information about the internet and Block Storage bandwidth for each Instance type at Scaleway.
 tags: instance
 dates:
-  validation: 2024-11-19
+  validation: 2025-01-07
   posted: 2024-11-19
 categories:
   - compute

--- a/compute/instances/reference-content/instances-bandwidth-overview.mdx
+++ b/compute/instances/reference-content/instances-bandwidth-overview.mdx
@@ -78,6 +78,16 @@ Bandwidth impacts how your applications perform and interact with other systems.
 | PLAY2-NANO            | 200 Mbit/s          | 80 MiB/s        |
 | PLAY2-MICRO           | 400 Mbit/s          | 160 MiB/s       |
 
+## PRO2 Range
+
+|   Instance Type      |   Internet Bandwidth   |   Block Bandwidth   |
+|-----------------------|-------------------------|---------------------|
+| PRO2-XXS              | 350 Mbit/s             | 125 MiB/s          |
+| PRO2-XS               | 700 Mbit/s             | 250 MiB/s          |
+| PRO2-S                | 1.5 Gbit/s             | 500 MiB/s          |
+| PRO2-M                | 3.0 Gbit/s             | 1 GiB/s            |
+| PRO2-L                | 6.0 Gbit/s             | 2 GiB/s            |
+
 ## POP Range
 
 |   Instance Type      |   Internet Bandwidth   |   Block Bandwidth   |

--- a/compute/instances/reference-content/instances-bandwidth-overview.mdx
+++ b/compute/instances/reference-content/instances-bandwidth-overview.mdx
@@ -85,41 +85,41 @@ Bandwidth impacts how your applications perform and interact with other systems.
 | PRO2-XXS              | 350 Mbit/s             | 125 MiB/s          |
 | PRO2-XS               | 700 Mbit/s             | 250 MiB/s          |
 | PRO2-S                | 1.5 Gbit/s             | 500 MiB/s          |
-| PRO2-M                | 3.0 Gbit/s             | 1 GiB/s            |
-| PRO2-L                | 6.0 Gbit/s             | 2 GiB/s            |
+| PRO2-M                | 3 Gbit/s               | 1 GiB/s            |
+| PRO2-L                | 6 Gbit/s               | 2 GiB/s            |
 
 ## POP Range
 
 |   Instance Type      |   Internet Bandwidth   |   Block Bandwidth   |
 |-----------------------|-------------------------|---------------------|
-| POP2-2C-8G           | 400 Mbit/s            | 400 MiB/s       |
-| POP2-4C-16G          | 800 Mbit/s            | 800 MiB/s       |
-| POP2-8C-32G          | 1.60 Gbit/s            | 1.56 GiB/s         |
-| POP2-16C-64G         | 3.20 Gbit/s            | 3.12 GiB/s         |
-| POP2-32C-128G        | 6.40 Gbit/s            | 6.25 GiB/s         |
-| POP2-64C-256G        | 12.80 Gbit/s           | 12.50 GiB/s        |
+| POP2-2C-8G           | 400 Mbit/s            | 400 MiB/s          |
+| POP2-4C-16G          | 800 Mbit/s            | 800 MiB/s          |
+| POP2-8C-32G          | 1.6 Gbit/s            | 1.56 GiB/s         |
+| POP2-16C-64G         | 3.2 Gbit/s            | 3.12 GiB/s         |
+| POP2-32C-128G        | 6.4 Gbit/s            | 6.25 GiB/s         |
+| POP2-64C-256G        | 12.8 Gbit/s           | 12.50 GiB/s        |
 
 ## POP-HC Range (High Compute)
 
 |   Instance Type      |   Internet Bandwidth   |   Block Bandwidth   |
 |-----------------------|-------------------------|---------------------|
-| POP2-HC-2C-4G        | 400 Mbit/s          | 400 MiB/s       |
-| POP2-HC-4C-8G        | 800 Mbit/s          | 800 MiB/s       |
-| POP2-HC-8C-16G       | 1.60 Gbit/s            | 1.56 GiB/s         |
-| POP2-HC-16C-32G      | 3.20 Gbit/s            | 3.12 GiB/s         |
-| POP2-HC-32C-64G      | 6.40 Gbit/s            | 6.25 GiB/s         |
-| POP2-HC-64C-128G     | 12.80 Gbit/s           | 12.50 GiB/s        |
+| POP2-HC-2C-4G        | 400 Mbit/s             | 400 MiB/s       |
+| POP2-HC-4C-8G        | 800 Mbit/s             | 800 MiB/s       |
+| POP2-HC-8C-16G       | 1.6 Gbit/s             | 1.56 GiB/s         |
+| POP2-HC-16C-32G      | 3.2 Gbit/s             | 3.12 GiB/s         |
+| POP2-HC-32C-64G      | 6.4 Gbit/s             | 6.25 GiB/s         |
+| POP2-HC-64C-128G     | 12.8 Gbit/s            | 12.50 GiB/s        |
 
 ## POP-HM Range (High Memory)
 
 |   Instance Type      |   Internet Bandwidth   |   Block Bandwidth   |
 |-----------------------|-------------------------|---------------------|
-| POP2-HM-2C-16G       | 400 Mbit/s          | 400 MiB/s       |
-| POP2-HM-4C-32G       | 800 Mbit/s          | 800 MiB/s       |
-| POP2-HM-8C-64G       | 1.60 Gbit/s            | 1.56 GiB/s         |
-| POP2-HM-16C-128G     | 3.20 Gbit/s            | 3.12 GiB/s         |
-| POP2-HM-32C-256G     | 6.40 Gbit/s            | 6.25 GiB/s         |
-| POP2-HM-64C-512G     | 12.80 Gbit/s           | 12.50 GiB/s        |
+| POP2-HM-2C-16G       | 400 Mbit/s            | 400 MiB/s       |
+| POP2-HM-4C-32G       | 800 Mbit/s            | 800 MiB/s       |
+| POP2-HM-8C-64G       | 1.6 Gbit/s            | 1.56 GiB/s         |
+| POP2-HM-16C-128G     | 3.2 Gbit/s            | 3.12 GiB/s         |
+| POP2-HM-32C-256G     | 6.4 Gbit/s            | 6.25 GiB/s         |
+| POP2-HM-64C-512G     | 12.8 Gbit/s           | 12.50 GiB/s        |
 
 ## POP-HN Range (High Network)
 

--- a/compute/instances/reference-content/instances-bandwidth-overview.mdx
+++ b/compute/instances/reference-content/instances-bandwidth-overview.mdx
@@ -66,7 +66,7 @@ Bandwidth impacts how your applications perform and interact with other systems.
 |-----------------------|-------------------------|---------------------|
 | GP1-XS                | 500 Mbit/s           | 300 MiB/s       |
 | GP1-S                 | 800 Mbit/s           | 500 MiB/s       |
-| GP1-M                 | 1.50 Gbit/s          | 800 MiB/s       |
+| GP1-M                 | 1.5 Gbit/s           | 800 MiB/s       |
 | GP1-L                 | 5 Gbit/s             | 1 GiB/s         |
 | GP1-XL                | 10 Gbit/s            | 2 GiB/s         |
 
@@ -97,7 +97,7 @@ Bandwidth impacts how your applications perform and interact with other systems.
 | POP2-8C-32G          | 1.6 Gbit/s            | 1.56 GiB/s         |
 | POP2-16C-64G         | 3.2 Gbit/s            | 3.12 GiB/s         |
 | POP2-32C-128G        | 6.4 Gbit/s            | 6.25 GiB/s         |
-| POP2-64C-256G        | 12.8 Gbit/s           | 12.50 GiB/s        |
+| POP2-64C-256G        | 12.8 Gbit/s           | 12.5 GiB/s         |
 
 ## POP-HC Range (High Compute)
 
@@ -108,7 +108,7 @@ Bandwidth impacts how your applications perform and interact with other systems.
 | POP2-HC-8C-16G       | 1.6 Gbit/s             | 1.56 GiB/s         |
 | POP2-HC-16C-32G      | 3.2 Gbit/s             | 3.12 GiB/s         |
 | POP2-HC-32C-64G      | 6.4 Gbit/s             | 6.25 GiB/s         |
-| POP2-HC-64C-128G     | 12.8 Gbit/s            | 12.50 GiB/s        |
+| POP2-HC-64C-128G     | 12.8 Gbit/s            | 12.5 GiB/s         |
 
 ## POP-HM Range (High Memory)
 
@@ -119,7 +119,7 @@ Bandwidth impacts how your applications perform and interact with other systems.
 | POP2-HM-8C-64G       | 1.6 Gbit/s            | 1.56 GiB/s         |
 | POP2-HM-16C-128G     | 3.2 Gbit/s            | 3.12 GiB/s         |
 | POP2-HM-32C-256G     | 6.4 Gbit/s            | 6.25 GiB/s         |
-| POP2-HM-64C-512G     | 12.8 Gbit/s           | 12.50 GiB/s        |
+| POP2-HM-64C-512G     | 12.8 Gbit/s           | 12.5 GiB/s         |
 
 ## POP-HN Range (High Network)
 

--- a/menu/navigation.json
+++ b/menu/navigation.json
@@ -1650,6 +1650,10 @@
                     "slug": "choosing-gpu-instance-type"
                   },
                   {
+                    "label": "GPU Instances internet and Block Storage bandwidth overview",
+                    "slug": "gpu-instances-bandwidth-overview"
+                  },
+                  {
                     "label": "GPU time-slicing with Kubernetes",
                     "slug": "kubernetes-gpu-time-slicing"
                   },


### PR DESCRIPTION
### Your checklist for this pull request

- [ ] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

Added missing PRO2 and POP2-HN-5 Instance types to bandwidth overview