### PR TITLE
Update manage-allowed-ips.mdx

### DIFF
--- a/containers/kubernetes/how-to/manage-allowed-ips.mdx
+++ b/containers/kubernetes/how-to/manage-allowed-ips.mdx
@@ -24,7 +24,7 @@ The default entry `0.0.0.0/0` enables any host to establish a connection.
 - [Created](/containers/kubernetes/how-to/create-cluster) a Kubernetes Kapsule or Kosmos cluster
 
 <Message type="note">
-  Allowed IP configuration is available for public networks only.
+  Allowed IP configuration is available for [fully isolated](/containers/kubernetes/reference-content/secure-cluster-with-private-network/#what-is-the-difference-between-controlled-isolation-and-full-isolation) Kapsule clusters and Kosmos clusters.
 </Message>
 
 ## How to add an IP address


### PR DESCRIPTION
Suggested a modification to the note: "Allowed IP configuration is available for public networks only." -> "Allowed IP configuration is available for fully isolated Kapsule clusters and Kosmos clusters."

### Your checklist for this pull request

- [ ] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

Please describe what you added or changed.
