### PR TITLE
docs(k8s): add mention that pool scaling not available during upgrade

### DIFF
--- a/containers/kubernetes/how-to/upgrade-kubernetes-version.mdx
+++ b/containers/kubernetes/how-to/upgrade-kubernetes-version.mdx
@@ -36,7 +36,7 @@ You can either upgrade your Kubernetes Kapsule cluster [directly from the Scalew
       It is not possible to downgrade your Kubernetes version once it has been upgraded.
     </Message>
     <Message type="note">
-       Resizing cluster pools is not allowed during the upgrade, provision accordingly.
+       Cluster pools cannot be resized during the upgrade process. Provision resources accordingly.
     </Message>
 
 ## Upgrading a Kapsule cluster to the next minor version using the CLI

--- a/containers/kubernetes/how-to/upgrade-kubernetes-version.mdx
+++ b/containers/kubernetes/how-to/upgrade-kubernetes-version.mdx
@@ -35,6 +35,9 @@ You can either upgrade your Kubernetes Kapsule cluster [directly from the Scalew
     <Message type="note">
       It is not possible to downgrade your Kubernetes version once it has been upgraded.
     </Message>
+    <Message type="note">
+       Resizing cluster pools is not allowed during the upgrade, provision accordingly.
+    </Message>
 
 ## Upgrading a Kapsule cluster to the next minor version using the CLI
 


### PR DESCRIPTION
### Description

Document Kapsule API behaviour during cluster upgrade
