### PR TITLE
refactor: remove navigation slug first categories WDOC-955

### DIFF
--- a/menu/navigation.json
+++ b/menu/navigation.json
@@ -235,8 +235,7 @@
             "slug": "billing"
           }
         ],
-        "label": "Account & Billing",
-        "slug": "console"
+        "label": "Account & Billing"
       },
       {
         "icon": "iam",
@@ -600,8 +599,7 @@
             "slug": "secret-manager"
           }
         ],
-        "label": "Security & Identity",
-        "slug": "identity-and-access-management"
+        "label": "Security & Identity"
       }
     ],
     "label": "Platform"
@@ -844,8 +842,7 @@
             "slug": "generative-apis"
           }
         ],
-        "label": "AI & Data",
-        "slug": "ai-data"
+        "label": "AI & Data"
       },
       {
         "icon": "baremetal",
@@ -1251,8 +1248,7 @@
             "slug": "dedibox"
           }
         ],
-        "label": "Bare Metal",
-        "slug": "bare-metal"
+        "label": "Bare Metal"
       },
       {
         "icon": "compute",
@@ -1686,8 +1682,7 @@
             "slug": "gpu"
           }
         ],
-        "label": "Compute",
-        "slug": "compute"
+        "label": "Compute"
       },
       {
         "icon": "containers",
@@ -2084,8 +2079,7 @@
             "slug": "terraform"
           }
         ],
-        "label": "Developer Tools",
-        "slug": "developer-tools"
+        "label": "Developer Tools"
       },
       {
         "icon": "database",
@@ -2419,8 +2413,7 @@
             "slug": "mongodb"
           }
         ],
-        "label": "Managed Databases",
-        "slug": "managed-databases"
+        "label": "Managed Databases"
       },
       {
         "icon": "managedServices",
@@ -2864,8 +2857,7 @@
             "slug": "data-lab"
           }
         ],
-        "label": "Managed Services",
-        "slug": "managed-services"
+        "label": "Managed Services"
       },
       {
         "icon": "network",
@@ -3602,8 +3594,7 @@
             "slug": "cockpit"
           }
         ],
-        "label": "Observability",
-        "slug": "observability"
+        "label": "Observability"
       },
       {
         "icon": "serverless",
@@ -3945,8 +3936,7 @@
                 "slug": "troubleshooting"
               }
             ],
-            "label": "Containers",
-            "slug": "containers"
+            "label": "Containers"
           },
           {
             "items": [
@@ -4313,8 +4303,7 @@
             "slug": "sql-databases"
           }
         ],
-        "label": "Serverless",
-        "slug": "serverless"
+        "label": "Serverless"
       },
       {
         "icon": "storage",
@@ -4554,8 +4543,7 @@
                 "slug": "videos"
               }
             ],
-            "label": "Object Storage",
-            "slug": "object"
+            "label": "Object Storage"
           },
           {
             "items": [
@@ -4936,8 +4924,7 @@
             "slug": "cpanel-hosting"
           }
         ],
-        "label": "Dedibox Console",
-        "slug": "dedibox-console"
+        "label": "Dedibox Console"
       },
       {
         "icon": "dedibox",
@@ -5237,8 +5224,7 @@
             "slug": "kvm-over-ip"
           }
         ],
-        "label": "Dedibox Servers",
-        "slug": "dedibox"
+        "label": "Dedibox Servers"
       },
       {
         "icon": "network",
@@ -5278,8 +5264,7 @@
                 "slug": "troubleshooting"
               }
             ],
-            "label": "Network",
-            "slug": "network"
+            "label": "Network"
           },
           {
             "items": [
@@ -5568,8 +5553,7 @@
             "slug": "dns"
           }
         ],
-        "label": "Dedibox Network",
-        "slug": "dedibox-network"
+        "label": "Dedibox Network"
       }
     ],
     "label": "Dedibox"
@@ -5624,8 +5608,7 @@
             "slug": "partner-space"
           }
         ],
-        "label": "Partners",
-        "slug": "partners"
+        "label": "Partners"
       },
       {
         "icon": "envFootprint",
@@ -5669,8 +5652,7 @@
             "slug": "environmental-footprint"
           }
         ],
-        "label": "Environmental Footprint",
-        "slug": "environmental-footprint"
+        "label": "Environmental Footprint"
       }
     ],
     "label": "Additional Services"


### PR DESCRIPTION
### Your checklist for this pull request

- [ ] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

As requested [here](https://jira.infra.online.net/browse/WDOC-949), some logic in the documentation/docs project has been changed to make 1st-level slug categories optional.

In this PR we remove the slugs of these categories which are no longer useful since the goal is to remove the 1st categories of the urls.
