### PR TITLE
feat(changelog): apple-silicon-added-mac-mini-m4-now-available 2025-01-27

### DIFF
--- a/changelog/january2025/2025-01-27-apple-silicon-added-mac-mini-m4-now-available.mdx
+++ b/changelog/january2025/2025-01-27-apple-silicon-added-mac-mini-m4-now-available.mdx
@@ -2,14 +2,14 @@
 title: Mac mini M4 now available!
 status: added
 author:
-    fullname: 'Join the #[xxx] channel on Slack.'
+    fullname: 'Join the #apple-silicon channel on Slack.'
     url: 'https://slack.scaleway.com'
 date: 2025-01-27
 category: bare-metal
 product: apple-silicon
 ---
 
-The M4-S are ready to order on PAR-1 at €0.22/hour!
+Apple silicon M4-S have arrived in PAR-1: Experience the future of computing, priced at €0.22/hour"
 
 Here is their configuration:
 - 10 CPU cores
@@ -18,5 +18,5 @@ Here is their configuration:
 - 256GB of storage
 - and all the latest innovations from Apple.
 
-For more details: https://www.scaleway.com/en/mac-mini-m4/
+For more details and to get started, visit [Scaleway's Mac mini M4 product page](https://www.scaleway.com/en/mac-mini-m4).
 

--- a/changelog/january2025/2025-01-27-apple-silicon-added-mac-mini-m4-now-available.mdx
+++ b/changelog/january2025/2025-01-27-apple-silicon-added-mac-mini-m4-now-available.mdx
@@ -1,0 +1,22 @@
+---
+title: Mac mini M4 now available!
+status: added
+author:
+    fullname: 'Join the #[xxx] channel on Slack.'
+    url: 'https://slack.scaleway.com'
+date: 2025-01-27
+category: bare-metal
+product: apple-silicon
+---
+
+The M4-S are ready to order on PAR-1 at €0.22/hour!
+
+Here is their configuration:
+- 10 CPU cores
+- 10 GPU cores
+- 16GB of RAM
+- 256GB of storage
+- and all the latest innovations from Apple.
+
+For more details: https://www.scaleway.com/en/mac-mini-m4/
+


### PR DESCRIPTION
Reporter: Alexia Valais

This PR is a new changelog contribution. It has been created automatically.

Make sure to review it carefully before merging it.