### PR TITLE
fix(iam): preferred project fix

### DIFF
--- a/pages/iam/how-to/create-api-keys.mdx
+++ b/pages/iam/how-to/create-api-keys.mdx
@@ -49,7 +49,7 @@ API keys always inherit the permissions of their bearer (the IAM user or IAM app
     <Message type="note">
       Preferred Projects for Object Storage - When creating and/or listing Object Storage buckets via the API, there is no available parameter to specify the Project in which you wish to list or create buckets. All buckets you create via the API will therefore be created in the preferred Project you choose when creating the API key. Similarly, when listing buckets, buckets from your preferred Project will be listed.
       Note that:
-        - This only applies to the creation and/or listing of Object Storage buckets, and no other products or resources.
+        - This applies to all actions on Object Storage buckets, but it does not apply to other products or resources.
         - You can still create and/or list buckets in your Project of choice via the Scaleway console.
       See our [dedicated documentation](/iam/api-cli/using-api-key-object-storage/) for more information.
     </Message>


### PR DESCRIPTION
Preferred project impacts all actions on Object Storage, not only Creates and Lists. This MR fixes that on the "Create API Key" page