### PR TITLE
docs(audit-trail): add tutorial to export audit trail to datadog

### DIFF
--- a/tutorials/export-audit-trail-to-datadog/index.mdx
+++ b/tutorials/export-audit-trail-to-datadog/index.mdx
@@ -1,10 +1,10 @@
 ---
 meta:
   title: Exporting Audit Trail events to DataDog
-  description: Learn how to export audit trail events to DataDog
+  description: Learn how to export Scaleway Audit Trail events to DataDog
 content:
   h1: Exporting Audit Trail events to DataDog
-  paragraph: Learn how to export audit trail events to DataDog
+  paragraph: Learn how to export Scaleway Audit Trail events to DataDog
 tags: audit-trail log events
 categories:
   - audit-trail

--- a/tutorials/export-audit-trail-to-datadog/index.mdx
+++ b/tutorials/export-audit-trail-to-datadog/index.mdx
@@ -1,0 +1,167 @@
+---
+meta:
+  title: Export Audit Trail to DataDog
+  description: Learn how to export audit trail events to DataDog
+content:
+  h1: Export Audit Trail to DataDog
+  paragraph: Learn how to export audit trail events to DataDog
+tags: audit-trail log events
+categories:
+  - audit-trail
+  - instances
+dates:
+  validation: 2025-02-06
+  posted: 2025-02-06
+---
+
+This guide will help you exporting audit trail events to DataDog. For that, it will depends on building a [custom OpenTelemetry Collector](https://opentelemetry.io/docs/collector/custom-collector/) that will collect Audit Trail events through the [Audit Trail receiver](https://github.com/scaleway/opentelemetry-collector-scaleway/tree/main/receiver/scwaudittrail) and export them with the [DataDog exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/datadogexporter).
+
+<Macro id="requirements" />
+
+- A Scaleway account logged into the [console](https://console.scaleway.com)
+- [Owner](/iam/concepts/#owner) status or [IAM permissions](/iam/concepts/#permission) allowing you to perform actions in the intended Organization
+- An [SSH key](/organizations-and-projects/how-to/create-ssh-key/)
+- An [Instance](/instances/how-to/create-an-instance/)
+
+## Building the collector
+
+The first step is to install the OpenTelemetry Collector Builder by following [this link](https://opentelemetry.io/docs/collector/custom-collector/#step-1---install-the-builder).
+
+Once you have the `ocb` binary, you will create the manifest in YAML to configure the builder. Create a file `builder-config.yaml` with the following content:
+
+```yaml
+dist:
+  name: otelcol-audit-trail
+  description: OpenTelemetry Collector for Audit Trail
+  output_path: ./otelcol-audit-trail
+
+exporters:
+  - gomod:
+      github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter v0.118.0
+
+processors:
+  - gomod:
+      go.opentelemetry.io/collector/processor/batchprocessor v0.118.0
+
+receivers:
+  - gomod:
+      github.com/scaleway/opentelemetry-collector-scaleway/receiver/scwaudittrail v0.1.0
+
+providers:
+  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.24.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.24.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v1.24.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.24.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.24.0
+```
+
+Then you can build the collector by running the following command:
+
+```
+./ocb --config builder-config.yaml
+```
+
+You will have a new folder named `otelcol-audit-trail/` with the binary compiled inside named `otelcol-audit-trail`.
+
+## Deploying the collector
+
+The next thing to do is to upload the collector binary to your instance:
+
+```
+scp otelcol-audit-trail/otelcol-audit-trail root@<IP ADDRESS>:/usr/local/bin/
+```
+
+The remaining of the tutoial will happen inside the instance, you need to ssh to it.
+
+```
+ssh root@<IP ADDRESS>
+```
+
+## Configure the collector
+
+The custom collector we just build needs a configuration to run. Create the file `/etc/opentelemetry-collector/config.yaml` with the following content:
+
+```yaml
+receivers:
+  scwaudittrail:
+    access_key: <SCW_ACCESS_KEY>
+    secret_key: <SCW_SECRET_KEY>
+    organization_id: <SCW_DEFAULT_ORGANIZATION_ID>
+    region: <SCW_DEFAULT_REGION>
+
+processors:
+  batch:
+    send_batch_max_size: 1000
+    send_batch_size: 100
+    timeout: 10s
+
+exporters:
+  datadog:
+    idle_conn_timeout: 10s
+    api:
+      key: <DD_API_KEY>
+      site: <DD_SITE>
+
+service:
+  pipelines:
+    logs:
+      receivers: [scwaudittrail]
+      processors: [batch]
+      exporters: [datadog]
+```
+
+Be sure to replace the following variables:
+- SCW_ACCESS_KEY: Scaleway API access key
+- SCW_SECRET_KEY: Scaleway API secret key
+- SCW_DEFAULT_ORGANIZATION_ID: Scaleway organization ID
+- SCW_DEFAULT_REGION: Scaleway region
+- DD_API_KEY: DataDog API key
+- DD_SITE: DataDog site (see documentation in [DataDog site](https://docs.datadoghq.com/getting_started/site/#access-the-datadog-site))
+
+## Running the collector
+
+Create the systemd service that will run the collector by creating the file `/etc/systemd/system/opentelemetry-collector.service` with the following content:
+
+```
+[Unit]
+Description=OpenTelemetry Collector
+After=multi-user.target
+
+[Service]
+ExecStart=/usr/local/bin/otelcol-audit-trail --config /etc/opentelemetry-collector/config.yaml
+Type=simple
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Run the following command to update systemd services:
+
+```
+systemctl daemon-reload
+```
+
+Then you can enable and start the service by running:
+
+```
+systemctl enable opentelemetry-collector.service
+systemctl start opentelemetry-collector.service
+```
+
+You can ensure the service is running with the command:
+
+```
+systemctl status opentelemetry-collector.service
+```
+
+And you can follow the logs with the command
+
+```
+journalctl -fu opentelemetry-collector.service
+```
+
+To confirm that the collector is polling Audit Trail events you should see something like this in the logs:
+
+```
+Feb 07 15:34:30 scw-beautiful-zhukovsky otelcol-audit-trail[1723]: 2025-02-07T15:34:30.687Z        info        scwaudittrail@v0.1.0/receiver.go:80        Polling Audit Trail logs        {"kind": "receiver", "name": "scwaudittrail", "data_type": "logs"}
+```

--- a/tutorials/export-audit-trail-to-datadog/index.mdx
+++ b/tutorials/export-audit-trail-to-datadog/index.mdx
@@ -105,7 +105,7 @@ Create a file named `/etc/opentelemetry-collector/config.yaml` and paste the fol
       datadog:
         idle_conn_timeout: 10s
         api:
-          key: <DD_API_SECRET_KEY>
+          key: <DD_API_KEY>
           site: <DD_SITE>
     
     service:

--- a/tutorials/export-audit-trail-to-datadog/index.mdx
+++ b/tutorials/export-audit-trail-to-datadog/index.mdx
@@ -21,7 +21,7 @@ This tutorial shows you how to export your Audit Trail events to [DataDog](https
 - A Scaleway account logged into the [console](https://console.scaleway.com)
 - [Owner](/iam/concepts/#owner) status or [IAM permissions](/iam/concepts/#permission) allowing you to perform actions in the intended Organization
 - Created an [SSH key](/organizations-and-projects/how-to/create-ssh-key/)
-- Created an [Instance](/instances/how-to/create-an-instance/)
+- Created a Scaleway [Instance](/instances/how-to/create-an-instance/)
 - Installed the [OpenTelemetry collector builder](https://opentelemetry.io/docs/collector/custom-collector/#step-1---install-the-builder)
 - Created a [Datadog account](https://app.datadoghq.com/account/login) and a [Datadog API key](https://docs.datadoghq.com/account_management/api-app-keys/#api-keys)
 
@@ -105,7 +105,7 @@ Create a file named `/etc/opentelemetry-collector/config.yaml` and paste the fol
       datadog:
         idle_conn_timeout: 10s
         api:
-          key: <DD_API_KEY>
+          key: <DD_API_SECRET_KEY>
           site: <DD_SITE>
     
     service:
@@ -118,12 +118,12 @@ Create a file named `/etc/opentelemetry-collector/config.yaml` and paste the fol
 
 Make sure that you replace:
 
-- `SCW_ACCESS_KEY` with your Scaleway API access key
-- `SCW_SECRET_KEY` with your Scaleway API secret key
-- `SCW_DEFAULT_ORGANIZATION_ID` with your Scaleway Organization ID
-- `SCW_DEFAULT_REGION` with the Scaleway region to target
-- `DD_API_KEY` with your DataDog API key
-- `DD_SITE` with the [DataDog site](https://docs.datadoghq.com/getting_started/site/#access-the-datadog-site) you are on
+- `<SCW_ACCESS_KEY>` with your Scaleway API access key
+- `<SCW_SECRET_KEY>` with your Scaleway API secret key
+- `<SCW_DEFAULT_ORGANIZATION_ID>` with your Scaleway Organization ID
+- `<SCW_DEFAULT_REGION>` with the Scaleway region to target
+- `<DD_API_KEY>` with your DataDog API secret key
+- `<DD_SITE>` with the [DataDog site](https://docs.datadoghq.com/getting_started/site/#access-the-datadog-site) you are on
 
 ## Running the Collector
 
@@ -148,7 +148,7 @@ Make sure that you replace:
     systemctl daemon-reload
     ```
 
-3. Run the following command to enable and start the service:
+3. Run the following commands to enable and start the service:
 
     ```
     systemctl enable opentelemetry-collector.service
@@ -167,7 +167,7 @@ Make sure that you replace:
     journalctl -fu opentelemetry-collector.service
     ```
 
-AN output similar to the following should display to confirm that the Collector is pulling Audit Trail events:
+An output similar to the following should display to confirm that the Collector is pulling Audit Trail events:
 
     ```
     Feb 07 15:34:30 scw-beautiful-zhukovsky otelcol-audit-trail[1723]: 2025-02-07T15:34:30.687Z        info        scwaudittrail@v0.1.0/receiver.go:80        Polling Audit Trail logs        {"kind": "receiver", "name": "scwaudittrail", "data_type": "logs"}

--- a/tutorials/export-audit-trail-to-datadog/index.mdx
+++ b/tutorials/export-audit-trail-to-datadog/index.mdx
@@ -167,7 +167,7 @@ Make sure that you replace:
     journalctl -fu opentelemetry-collector.service
     ```
 
-An output similar to the following should display to confirm that the Collector is pulling Audit Trail events:
+An output similar to the following should display to confirm that the Collector is polling Audit Trail events:
 
     ```
     Feb 07 15:34:30 scw-beautiful-zhukovsky otelcol-audit-trail[1723]: 2025-02-07T15:34:30.687Z        info        scwaudittrail@v0.1.0/receiver.go:80        Polling Audit Trail logs        {"kind": "receiver", "name": "scwaudittrail", "data_type": "logs"}

--- a/tutorials/export-audit-trail-to-datadog/index.mdx
+++ b/tutorials/export-audit-trail-to-datadog/index.mdx
@@ -55,10 +55,10 @@ providers:
   - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.24.0
 ```
 
-Then you can build the collector by running the following command:
+Then you can build the collector by running the following command. We specify `GOOS` and `GOARCH` because the target deployment is linux with an AMD64 CPU.
 
 ```
-./ocb --config builder-config.yaml
+GOOS=linux GOARCH=amd64 ./ocb --config builder-config.yaml
 ```
 
 You will have a new folder named `otelcol-audit-trail/` with the binary compiled inside named `otelcol-audit-trail`.

--- a/tutorials/export-audit-trail-to-datadog/index.mdx
+++ b/tutorials/export-audit-trail-to-datadog/index.mdx
@@ -1,167 +1,174 @@
 ---
 meta:
-  title: Export Audit Trail to DataDog
+  title: Exporting Audit Trail events to DataDog
   description: Learn how to export audit trail events to DataDog
 content:
-  h1: Export Audit Trail to DataDog
+  h1: Exporting Audit Trail events to DataDog
   paragraph: Learn how to export audit trail events to DataDog
 tags: audit-trail log events
 categories:
   - audit-trail
   - instances
 dates:
-  validation: 2025-02-06
-  posted: 2025-02-06
+  validation: 2025-02-10
+  posted: 2025-02-10
 ---
 
-This guide will help you exporting audit trail events to DataDog. For that, it will depends on building a [custom OpenTelemetry Collector](https://opentelemetry.io/docs/collector/custom-collector/) that will collect Audit Trail events through the [Audit Trail receiver](https://github.com/scaleway/opentelemetry-collector-scaleway/tree/main/receiver/scwaudittrail) and export them with the [DataDog exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/datadogexporter).
+This tutorial shows you how to export your Audit Trail events to [DataDog](https://www.datadoghq.com/). For the purpose of this tutorail, we are building a [custom OpenTelemetry Collector](https://opentelemetry.io/docs/collector/custom-collector/) to collect Audit Trail events through the [Audit Trail receiver](https://github.com/scaleway/opentelemetry-collector-scaleway/tree/main/receiver/scwaudittrail) and export them with the [DataDog exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/datadogexporter).
 
 <Macro id="requirements" />
 
 - A Scaleway account logged into the [console](https://console.scaleway.com)
 - [Owner](/iam/concepts/#owner) status or [IAM permissions](/iam/concepts/#permission) allowing you to perform actions in the intended Organization
-- An [SSH key](/organizations-and-projects/how-to/create-ssh-key/)
-- An [Instance](/instances/how-to/create-an-instance/)
+- Created an [SSH key](/organizations-and-projects/how-to/create-ssh-key/)
+- Created an [Instance](/instances/how-to/create-an-instance/)
+- Installed the [OpenTelemetry collector builder](https://opentelemetry.io/docs/collector/custom-collector/#step-1---install-the-builder)
+- Created a [Datadog account](https://app.datadoghq.com/account/login) and a [Datadog API key](https://docs.datadoghq.com/account_management/api-app-keys/#api-keys)
 
-## Building the collector
+## Building the OpenTelemetry collector
 
-The first step is to install the OpenTelemetry Collector Builder by following [this link](https://opentelemetry.io/docs/collector/custom-collector/#step-1---install-the-builder).
+1. Open a terminal and check that the `ocb` binary is ready to be used. The output of the `help` command should display, meaning the `ocb` binary is ready to be used.
 
-Once you have the `ocb` binary, you will create the manifest in YAML to configure the builder. Create a file `builder-config.yaml` with the following content:
+    ```
+    ./ocb help
+    ```
 
-```yaml
-dist:
-  name: otelcol-audit-trail
-  description: OpenTelemetry Collector for Audit Trail
-  output_path: ./otelcol-audit-trail
+2. Create a manifest file named `builder-config.yaml` and paste the following content into it. This file is used to defines code generation, the compile process, and the components to include in your Collector’s distribution.
 
-exporters:
-  - gomod:
-      github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter v0.118.0
+    ```yaml
+    dist:
+      name: otelcol-audit-trail
+      description: OpenTelemetry Collector for Audit Trail
+      output_path: ./otelcol-audit-trail
+    
+    exporters:
+      - gomod:
+          github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter v0.118.0
+    
+    processors:
+      - gomod:
+          go.opentelemetry.io/collector/processor/batchprocessor v0.118.0
+    
+    receivers:
+      - gomod:
+          github.com/scaleway/opentelemetry-collector-scaleway/receiver/scwaudittrail v0.1.0
+    
+    providers:
+      - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.24.0
+      - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.24.0
+      - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v1.24.0
+      - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.24.0
+      - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.24.0
+    ```
 
-processors:
-  - gomod:
-      go.opentelemetry.io/collector/processor/batchprocessor v0.118.0
+3. Run the following command to build the Collector. `GOOS` and `GOARCH` are needed in the command as the target deployment is Linux with an AMD64 CPU.
 
-receivers:
-  - gomod:
-      github.com/scaleway/opentelemetry-collector-scaleway/receiver/scwaudittrail v0.1.0
+    ```
+    GOOS=linux GOARCH=amd64 ./ocb --config builder-config.yaml
+    ```
 
-providers:
-  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.24.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.24.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v1.24.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.24.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.24.0
-```
+You now have a new folder named `otelcol-audit-trail/` with the binary `otelcol-audit-trail` compiled inside.
 
-Then you can build the collector by running the following command. We specify `GOOS` and `GOARCH` because the target deployment is linux with an AMD64 CPU.
+## Deploying the Collector
 
-```
-GOOS=linux GOARCH=amd64 ./ocb --config builder-config.yaml
-```
+1. Run the following command to upload the Collector binary to your Instance. Make sure that you replace `<INSTANCE_IP_ADDRESS>` with the IP address of your Instance.
 
-You will have a new folder named `otelcol-audit-trail/` with the binary compiled inside named `otelcol-audit-trail`.
+    ```
+    scp otelcol-audit-trail/otelcol-audit-trail root@<INSTANCE_IP_ADDRESS>:/usr/local/bin/
+    ```
 
-## Deploying the collector
+2. Connect to your Instance via SSH:
 
-The next thing to do is to upload the collector binary to your instance:
+    ```
+    ssh root@<INSTANCE_IP_ADDRESS>
+    ```
 
-```
-scp otelcol-audit-trail/otelcol-audit-trail root@<IP ADDRESS>:/usr/local/bin/
-```
+## Configure the Collector
 
-The remaining of the tutoial will happen inside the instance, you need to ssh to it.
+Create a file named `/etc/opentelemetry-collector/config.yaml` and paste the following content into it. This file is the configuration our custom Collector will run. 
 
-```
-ssh root@<IP ADDRESS>
-```
+    ```yaml
+    receivers:
+      scwaudittrail:
+        access_key: <SCW_ACCESS_KEY>
+        secret_key: <SCW_SECRET_KEY>
+        organization_id: <SCW_DEFAULT_ORGANIZATION_ID>
+        region: <SCW_DEFAULT_REGION>
+    
+    processors:
+      batch:
+        send_batch_max_size: 1000
+        send_batch_size: 100
+        timeout: 10s
+    
+    exporters:
+      datadog:
+        idle_conn_timeout: 10s
+        api:
+          key: <DD_API_KEY>
+          site: <DD_SITE>
+    
+    service:
+      pipelines:
+        logs:
+          receivers: [scwaudittrail]
+          processors: [batch]
+          exporters: [datadog]
+    ```
 
-## Configure the collector
+Make sure that you replace:
 
-The custom collector we just build needs a configuration to run. Create the file `/etc/opentelemetry-collector/config.yaml` with the following content:
+- `SCW_ACCESS_KEY` with your Scaleway API access key
+- `SCW_SECRET_KEY` with your Scaleway API secret key
+- `SCW_DEFAULT_ORGANIZATION_ID` with your Scaleway Organization ID
+- `SCW_DEFAULT_REGION` with the Scaleway region to target
+- `DD_API_KEY` with your DataDog API key
+- `DD_SITE` with the [DataDog site](https://docs.datadoghq.com/getting_started/site/#access-the-datadog-site) you are on
 
-```yaml
-receivers:
-  scwaudittrail:
-    access_key: <SCW_ACCESS_KEY>
-    secret_key: <SCW_SECRET_KEY>
-    organization_id: <SCW_DEFAULT_ORGANIZATION_ID>
-    region: <SCW_DEFAULT_REGION>
+## Running the Collector
 
-processors:
-  batch:
-    send_batch_max_size: 1000
-    send_batch_size: 100
-    timeout: 10s
+1. Create a file named `/etc/systemd/system/opentelemetry-collector.service` and paste the following content into it. This file will create the `systemd` service that runs the Collector.
 
-exporters:
-  datadog:
-    idle_conn_timeout: 10s
-    api:
-      key: <DD_API_KEY>
-      site: <DD_SITE>
+    ```
+    [Unit]
+    Description=OpenTelemetry Collector
+    After=multi-user.target
+    
+    [Service]
+    ExecStart=/usr/local/bin/otelcol-audit-trail --config /etc/opentelemetry-collector/config.yaml
+    Type=simple
+    
+    [Install]
+    WantedBy=multi-user.target
+    ```
 
-service:
-  pipelines:
-    logs:
-      receivers: [scwaudittrail]
-      processors: [batch]
-      exporters: [datadog]
-```
+2. Run the following command to update `systemd` services:
 
-Be sure to replace the following variables:
-- SCW_ACCESS_KEY: Scaleway API access key
-- SCW_SECRET_KEY: Scaleway API secret key
-- SCW_DEFAULT_ORGANIZATION_ID: Scaleway organization ID
-- SCW_DEFAULT_REGION: Scaleway region
-- DD_API_KEY: DataDog API key
-- DD_SITE: DataDog site (see documentation in [DataDog site](https://docs.datadoghq.com/getting_started/site/#access-the-datadog-site))
+    ```
+    systemctl daemon-reload
+    ```
 
-## Running the collector
+3. Run the following command to enable and start the service:
 
-Create the systemd service that will run the collector by creating the file `/etc/systemd/system/opentelemetry-collector.service` with the following content:
+    ```
+    systemctl enable opentelemetry-collector.service
+    systemctl start opentelemetry-collector.service
+    ```
 
-```
-[Unit]
-Description=OpenTelemetry Collector
-After=multi-user.target
+4. Make sure that the service is running:
 
-[Service]
-ExecStart=/usr/local/bin/otelcol-audit-trail --config /etc/opentelemetry-collector/config.yaml
-Type=simple
+    ```
+    systemctl status opentelemetry-collector.service
+    ```
 
-[Install]
-WantedBy=multi-user.target
-```
+5. Run the command below to visualize your logs:
 
-Run the following command to update systemd services:
+    ```
+    journalctl -fu opentelemetry-collector.service
+    ```
 
-```
-systemctl daemon-reload
-```
+AN output similar to the following should display to confirm that the Collector is pulling Audit Trail events:
 
-Then you can enable and start the service by running:
-
-```
-systemctl enable opentelemetry-collector.service
-systemctl start opentelemetry-collector.service
-```
-
-You can ensure the service is running with the command:
-
-```
-systemctl status opentelemetry-collector.service
-```
-
-And you can follow the logs with the command
-
-```
-journalctl -fu opentelemetry-collector.service
-```
-
-To confirm that the collector is polling Audit Trail events you should see something like this in the logs:
-
-```
-Feb 07 15:34:30 scw-beautiful-zhukovsky otelcol-audit-trail[1723]: 2025-02-07T15:34:30.687Z        info        scwaudittrail@v0.1.0/receiver.go:80        Polling Audit Trail logs        {"kind": "receiver", "name": "scwaudittrail", "data_type": "logs"}
-```
+    ```
+    Feb 07 15:34:30 scw-beautiful-zhukovsky otelcol-audit-trail[1723]: 2025-02-07T15:34:30.687Z        info        scwaudittrail@v0.1.0/receiver.go:80        Polling Audit Trail logs        {"kind": "receiver", "name": "scwaudittrail", "data_type": "logs"}
+    ```


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

Add tutorial to build, deploy and run an OpenTelemetry Collector to export Audit Trail events to DataDog.
