### PR TITLE
fix(gen): fix missing concepts icon for overview pages

### DIFF
--- a/pages/apple-silicon/index.mdx
+++ b/pages/apple-silicon/index.mdx
@@ -31,7 +31,7 @@ meta:
     />
     <SummaryCard
         title="Concepts"
-        icon="information-circle-outline"
+        icon="info"
         description="Core concepts that give you a better understanding of Scaleway Apple silicon."
         label="View Concepts"
         url="/apple-silicon/concepts/"

--- a/pages/billing/index.mdx
+++ b/pages/billing/index.mdx
@@ -24,7 +24,7 @@ meta:
     />
     <SummaryCard
         title="Concepts"
-        icon="information-circle-outline"
+        icon="info"
         description="Core concepts that give you a better understanding of Scaleway billing."
         label="View Concepts"
         url="/billing/concepts"

--- a/pages/classic-hosting/index.mdx
+++ b/pages/classic-hosting/index.mdx
@@ -24,7 +24,7 @@ meta:
     />
     <SummaryCard
         title="Concepts"
-        icon="information-circle-outline"
+        icon="info"
         description="Core concepts that give you a better understanding of Webhosting Classic."
         label="View Concepts"
         url="/classic-hosting/concepts/"

--- a/pages/data-lab/index.mdx
+++ b/pages/data-lab/index.mdx
@@ -24,7 +24,7 @@ meta:
     />
     <SummaryCard
         title="Concepts"
-        icon="information-circle-outline"
+        icon="info"
         description="Core concepts that give you a better understanding of Scaleway Distributed Data Lab."
         label="View Concepts"
         url="/data-lab/concepts/"

--- a/pages/dedibox-account/index.mdx
+++ b/pages/dedibox-account/index.mdx
@@ -24,7 +24,7 @@ meta:
     />
     <SummaryCard
         title="Concepts"
-        icon="information-circle-outline"
+        icon="info"
         description="Core concepts that give you a better understanding of your Dedibox account."
         label="View Concepts"
         url="/dedibox-account/concepts/"

--- a/pages/dedibox-dns/index.mdx
+++ b/pages/dedibox-dns/index.mdx
@@ -17,7 +17,7 @@ meta:
 <Grid>
     <SummaryCard
         title="Concepts"
-        icon="information-circle-outline"
+        icon="info"
         description="Core concepts that give you a better understanding of DNS."
         label="View Concepts"
         url="/dedibox-dns/concepts/"

--- a/pages/dedibox-domains/index.mdx
+++ b/pages/dedibox-domains/index.mdx
@@ -28,7 +28,7 @@ meta:
     />
     <SummaryCard
         title="Concepts"
-        icon="information-circle-outline"
+        icon="info"
         description="Core concepts that give you a better understanding of domains and their related services."
         label="View Concepts"
         url="/dedibox-domains/concepts/"

--- a/pages/dedibox-hardware/index.mdx
+++ b/pages/dedibox-hardware/index.mdx
@@ -17,7 +17,7 @@ meta:
 <Grid>
     <SummaryCard
         title="Concepts"
-        icon="information-circle-outline"
+        icon="info"
         description="Core concepts about the hardware of our dedicated servers."
         label="View Concepts"
         url="/dedibox-hardware/concepts/"

--- a/pages/dedibox-ip-failover/index.mdx
+++ b/pages/dedibox-ip-failover/index.mdx
@@ -24,7 +24,7 @@ meta:
     />
     <SummaryCard
         title="Concepts"
-        icon="information-circle-outline"
+        icon="info"
         description="Core concepts that give you a better understanding of failover IPs."
         label="View Concepts"
         url="/dedibox-ip-failover/concepts/"

--- a/pages/dedibox-ipv6/index.mdx
+++ b/pages/dedibox-ipv6/index.mdx
@@ -24,7 +24,7 @@ meta:
     />
     <SummaryCard
         title="Concepts"
-        icon="information-circle-outline"
+        icon="info"
         description="Core concepts that give you a better understanding of IPv6."
         label="View Concepts"
         url="/dedibox-ipv6/concepts/"

--- a/pages/dedibox-kvm-over-ip/index.mdx
+++ b/pages/dedibox-kvm-over-ip/index.mdx
@@ -24,7 +24,7 @@ meta:
     />
     <SummaryCard
         title="Concepts"
-        icon="information-circle-outline"
+        icon="info"
         description="Core concepts that give you a better understanding of KVM-over-IP."
         label="View Concepts"
         url="/dedibox-kvm-over-ip/concepts/"

--- a/pages/dedibox-rpn/index.mdx
+++ b/pages/dedibox-rpn/index.mdx
@@ -24,7 +24,7 @@ meta:
     />
     <SummaryCard
         title="Concepts"
-        icon="information-circle-outline"
+        icon="info"
         description="Core concepts that give you a better understanding of RPN."
         label="View Concepts"
         url="/dedibox-rpn/concepts/"

--- a/pages/dedibox-scaleway/index.mdx
+++ b/pages/dedibox-scaleway/index.mdx
@@ -24,7 +24,7 @@ meta:
     />
     <SummaryCard
         title="Concepts"
-        icon="information-circle-outline"
+        icon="info"
         description="Core concepts that give you a better understanding of Dedibox servers."
         label="View Concepts"
         url="/dedibox-scaleway/concepts/"

--- a/pages/dedibox-vps/index.mdx
+++ b/pages/dedibox-vps/index.mdx
@@ -27,7 +27,7 @@ meta:
     />
     <SummaryCard
         title="Concepts"
-        icon="information-circle-outline"
+        icon="info"
         description="Core concepts that give you a better understanding of Dedibox VPS."
         label="View Concepts"
         url="/dedibox-vps/concepts/"

--- a/pages/dedibox/index.mdx
+++ b/pages/dedibox/index.mdx
@@ -26,7 +26,7 @@ meta:
     />
     <SummaryCard
         title="Concepts"
-        icon="information-circle-outline"
+        icon="info"
         description="Core concepts that give you a better understanding of dedicated servers."
         label="View Concepts"
         url="/dedibox/concepts/"

--- a/pages/elastic-metal/index.mdx
+++ b/pages/elastic-metal/index.mdx
@@ -24,7 +24,7 @@ meta:
     />
     <SummaryCard
         title="Concepts"
-        icon="information-circle-outline"
+        icon="info"
         description="Core concepts that give you a better understanding of Scaleway Elastic Metal."
         label="View Concepts"
         url="/elastic-metal/concepts/"

--- a/pages/environmental-footprint/environmental-footprint/index.mdx
+++ b/pages/environmental-footprint/environmental-footprint/index.mdx
@@ -21,7 +21,7 @@ This feature is currently only available for Elastic Metal servers. Refer to the
 <Grid>
     <SummaryCard
         title="Concepts"
-        icon="information-circle-outline"
+        icon="info"
         description="Core concepts that give you a better understanding of the Environmental Footprint calculator."
         label="View Concepts"
         url="/environmental-footprint/concepts"

--- a/pages/environmental-footprint/index.mdx
+++ b/pages/environmental-footprint/index.mdx
@@ -21,7 +21,7 @@ This feature is currently only available for Elastic Metal servers. Refer to the
 <Grid>
     <SummaryCard
         title="Concepts"
-        icon="information-circle-outline"
+        icon="info"
         description="Core concepts that give you a better understanding of the Environmental Footprint calculator."
         label="View Concepts"
         url="/environmental-footprint/concepts"

--- a/pages/generative-apis/index.mdx
+++ b/pages/generative-apis/index.mdx
@@ -24,7 +24,7 @@ meta:
     />
     <SummaryCard
         title="Concepts"
-        icon="information-circle-outline"
+        icon="info"
         description="Core concepts that give you a better understanding of Scaleway Generative APIs."
         label="View Concepts"
         url="/generative-apis/concepts/"

--- a/pages/gpu/index.mdx
+++ b/pages/gpu/index.mdx
@@ -24,7 +24,7 @@ meta:
     />
     <SummaryCard
         title="Concepts"
-        icon="information-circle-outline"
+        icon="info"
         description="Core concepts that give you a better understanding of Scaleway GPU Instances."
         label="View concepts"
         url="/gpu/concepts/"

--- a/pages/instances/index.mdx
+++ b/pages/instances/index.mdx
@@ -24,7 +24,7 @@ meta:
     />
     <SummaryCard
         title="Concepts"
-        icon="information-circle-outline"
+        icon="info"
         description="Core concepts that give you a better understanding of Scaleway Instances."
         label="View Concepts"
         url="/instances/concepts/"

--- a/pages/iot-hub/index.mdx
+++ b/pages/iot-hub/index.mdx
@@ -24,7 +24,7 @@ meta:
     />
     <SummaryCard
         title="Concepts"
-        icon="information-circle-outline"
+        icon="info"
         description="Core concepts that give you a better understanding of IoT Hub."
         label="View Concepts"
         url="/iot-hub/concepts/"

--- a/pages/kubernetes/index.mdx
+++ b/pages/kubernetes/index.mdx
@@ -24,7 +24,7 @@ meta:
     />
     <SummaryCard
         title="Concepts"
-        icon="information-circle-outline"
+        icon="info"
         description="Core concepts that give you a better understanding of Kubernetes Kapsule and Kosmos."
         label="View Concepts"
         url="/kubernetes/concepts/"

--- a/pages/managed-inference/index.mdx
+++ b/pages/managed-inference/index.mdx
@@ -24,7 +24,7 @@ meta:
     />
     <SummaryCard
         title="Concepts"
-        icon="information-circle-outline"
+        icon="info"
         description="Core concepts that give you a better understanding of Scaleway Managed Inference."
         label="View Concepts"
         url="/managed-inference/concepts/"

--- a/pages/webhosting/index.mdx
+++ b/pages/webhosting/index.mdx
@@ -24,7 +24,7 @@ meta:
     />
     <SummaryCard
         title="Concepts"
-        icon="information-circle-outline"
+        icon="info"
         description="Core concepts that give you a better understanding of Scaleway Web Hosting."
         label="View Concepts"
         url="/webhosting/concepts/"


### PR DESCRIPTION
### Your checklist for this pull request

- [ ] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

Fixed concepts info icon for several pages