### PR TITLE
Specify a recent version of cert-manager

### DIFF
--- a/tutorials/traefik-v2-cert-manager/index.mdx
+++ b/tutorials/traefik-v2-cert-manager/index.mdx
@@ -75,9 +75,9 @@ In this step, we will create a wildcard DNS record to point to the external IP a
 
 ### Installing cert-manager
 
-1. Install cert-manager:
+1. Install a recent version of cert-manager, in this example v1.16:
     ```sh
-    kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.0.0/cert-manager.yaml
+    kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.16.0/cert-manager.yaml
     ```
 2. Verify the installation:
     ```sh


### PR DESCRIPTION
First, I just copied the URL from the wizard and got v1.0.0 that was incompatible with the following steps.

### Your checklist for this pull request

- [ ] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

Please describe what you added or changed.
