### PR TITLE
fix(changelog): fix icon name format for efp

### DIFF
--- a/menu/changelogs.json
+++ b/menu/changelogs.json
@@ -276,6 +276,6 @@
   {
     "category": "environmental-footprint",
     "label": "Environmental Footprint",
-    "icon": "EnvFootprint"
+    "icon": "envFootprint"
   }
 ]


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

Please describe what you added or changed.

- icon names in changelog menu should be in _camelCase_ format.
