### PR TITLE
docs(instances): specify that the account must be verified in order for the tutorial snapshot-import-export-feature.mdx to work

### DIFF
--- a/pages/instances/how-to/snapshot-import-export-feature.mdx
+++ b/pages/instances/how-to/snapshot-import-export-feature.mdx
@@ -21,7 +21,7 @@ More information on the QCOW2 file format and how to use it can be found in the 
 
 <Macro id="requirements" />
 
-- A Scaleway account logged into the [console](https://console.scaleway.com)
+- A Scaleway verified account (payment, phone and ID set) logged into the [console](https://console.scaleway.com)
 - [Owner](/iam/concepts/#owner) status or [IAM permissions](/iam/concepts/#permission) allowing you to perform actions in the intended Organization
 - A valid [API key](/iam/how-to/create-api-keys/)
 - An [Instance](/instances/how-to/create-an-instance/) using [Block Storage volumes](/block-storage/how-to/create-a-volume/)


### PR DESCRIPTION
### Description

Specify that the account must be verified in order for the tutorial snapshot-import-export-feature.mdx to work.

Otherwise, the actions detailed are not available (Create snapshot button disabled, export to object storage not available...)
