### PR TITLE
Set the S3 endpoint URL the example AWS config

### DIFF
--- a/pages/object-storage/api-cli/object-storage-aws-cli.mdx
+++ b/pages/object-storage/api-cli/object-storage-aws-cli.mdx
@@ -52,6 +52,7 @@ The AWS-CLI is an open-source tool built on top of the [AWS SDK for Python (Boto
     
     [services scw-nl-ams]
     s3 =
+      endpoint_url = https://s3.nl-ams.scw.cloud
       max_concurrent_requests = 100
       max_queue_size = 1000
       multipart_threshold = 50 MB


### PR DESCRIPTION
### Your checklist for this pull request

- [ ] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

_I'm gonna be honest, I'm doing this from the GitHub web UI, which is making this a pain to comply with._

### Description

When going through this example, I noted that `aws s3 ls` was still trying to connect to AWS, and then noticed that in a step lower down the S3 endpoint URL was set, but not in the initial example configuration.