### PR TITLE
feat(changelog): kubernetes-removed-end-of-support-kubernetes-versions-1 2025-03-05

### DIFF
--- a/changelog/march2025/2025-03-05-kubernetes-removed-end-of-support-kubernetes-versions-1.mdx
+++ b/changelog/march2025/2025-03-05-kubernetes-removed-end-of-support-kubernetes-versions-1.mdx
@@ -1,0 +1,12 @@
+---
+title: End of support Kubernetes versions 1.25 and 1.26
+status: removed
+date: 2025-03-05
+category: containers
+product: kubernetes
+---
+
+Clusters using the Kubernetes 1.25 and 1.26 versions will be automatically upgraded to the Kubernetes 1.27 version after March 6th, 2026.
+
+[Find more details in our version support policy.](https://www.scaleway.com/en/docs/kubernetes/reference-content/version-support-policy/)
+

--- a/changelog/march2025/2025-03-05-kubernetes-removed-end-of-support-kubernetes-versions-1.mdx
+++ b/changelog/march2025/2025-03-05-kubernetes-removed-end-of-support-kubernetes-versions-1.mdx
@@ -8,5 +8,5 @@ product: kubernetes
 
 Clusters using the Kubernetes 1.25 and 1.26 versions will be automatically upgraded to the Kubernetes 1.27 version after March 6th, 2026.
 
-[Find more details in our version support policy.](https://www.scaleway.com/en/docs/kubernetes/reference-content/version-support-policy/)
+[Find more details in our version support policy.](/kubernetes/reference-content/version-support-policy/)
 


### PR DESCRIPTION
Reporter: Galem Kayo

This PR is a new changelog contribution. It has been created automatically.

Make sure to review it carefully before merging it.