### PR TITLE
fix(docs): cta in tutorials

### DIFF
--- a/tutorials/back-up-postgresql-barman/index.mdx
+++ b/tutorials/back-up-postgresql-barman/index.mdx
@@ -13,7 +13,12 @@ dates:
   validation: 2024-09-16
   posted: 2018-08-29
 ---
-
+<ClickableBanner
+  productLogo="generic"
+  title="Ensure database reliability with PostgreSQL backups using Barman on Scaleway."
+  url="https://account.scaleway.com/register"
+  label="Create your account"
+/>
 Barman is an open-source administration tool designed for PostgreSQL server disaster recovery. Developed in Python, Barman offers the capability to efficiently conduct remote backups across multiple servers in diverse business environments.
 
 Setting itself apart with its unique methodology, Barman uses PostgreSQL logs for backup creation, offering a sophisticated alternative to traditional SQL dump processes.

--- a/tutorials/backup-postgresql-pgbackrest-s3/index.mdx
+++ b/tutorials/backup-postgresql-pgbackrest-s3/index.mdx
@@ -202,3 +202,9 @@ If you want to back up at certain time intervals, you can add this to the cron:
     ```
     sudo -u postgres pgbackrest --stanza=db-primary --repo1-retention-diff=1 expire
     ```
+<ClickableBanner
+  productLogo="generic"
+  title="Protect your databases with automated backups to Scaleway Object Storage."
+  url="https://account.scaleway.com/register"
+  label="Create your account"
+/>

--- a/tutorials/bash-christmas-tree/index.mdx
+++ b/tutorials/bash-christmas-tree/index.mdx
@@ -127,7 +127,7 @@ ssh root@<Instance Public IP>
 
 <ClickableBanner
   productLogo="generic"
-  title="Bring some holiday fun to your terminal with this Bash script!"
+  title="Start your Cloud journey with Scaleway."
   url="https://account.scaleway.com/register"
   label="Create your account"
 />

--- a/tutorials/bash-christmas-tree/index.mdx
+++ b/tutorials/bash-christmas-tree/index.mdx
@@ -124,3 +124,10 @@ ssh root@<Instance Public IP>
 
     <Lightbox src="scaleway-animated-tree.gif" alt="" />
 2. Exit the script by pressing `CTRL` + `c`.
+
+<ClickableBanner
+  productLogo="generic"
+  title="Bring some holiday fun to your terminal with this Bash script!"
+  url="https://account.scaleway.com/register"
+  label="Create your account"
+/>

--- a/tutorials/configure-failover-proxmox/index.mdx
+++ b/tutorials/configure-failover-proxmox/index.mdx
@@ -113,3 +113,9 @@ ISO files are archive files that contain identical copies of the data found on o
 <Message type="tip">
   Follow the official documentation to learn more about [VM templates and Clones](https://pve.proxmox.com/wiki/VM_Templates_and_Clones) or watch tutorials on the official [Youtube canal](https://www.youtube.com/user/ProxmoxVE).
 </Message>
+<ClickableBanner
+  productLogo="generic"
+  title="Ensure high availability with failover setup for Proxmox on Scaleway."
+  url="https://account.scaleway.com/register"
+  label="Create your account"
+/>

--- a/tutorials/get-started-kubernetes-loadbalancer/index.mdx
+++ b/tutorials/get-started-kubernetes-loadbalancer/index.mdx
@@ -12,7 +12,12 @@ dates:
   validation: 2024-10-03
   posted: 2023-09-19
 ---
-
+<ClickableBanner
+  productLogo="generic"
+  title="Deploy and scale your applications with Kubernetes Load Balancers on Scaleway."
+  url="https://account.scaleway.com/register"
+  label="Create your account"
+/>
 This tutorial accompanies the third [video demonstration](https://www.youtube.com/watch?v=W3gPUQ_ELEo) in our series to help users get started with Kubernetes. We walk you through Kubernetes fundamentals for beginners. In this installment, we show you how to create a Load Balancer for your [Scaleway Kubernetes Kapsule](https://www.scaleway.com/en/kubernetes-kapsule/).
 
 First, we address the question of why we need a Load Balancer for our cluster, comparing it with the NodePort service we used in the previous tutorial. We then explain how to create a Load Balancer, check it out in the Scaleway console, and finally test that we can access our cluster's deployed application at the Load Balancer's IP address.

--- a/tutorials/get-started-kubernetes-loadbalancer/index.mdx
+++ b/tutorials/get-started-kubernetes-loadbalancer/index.mdx
@@ -14,7 +14,7 @@ dates:
 ---
 <ClickableBanner
   productLogo="generic"
-  title="Deploy and scale your applications with Kubernetes Load Balancers on Scaleway."
+  title="Deploy and scale your applications with Kubernetes and Load Balancers on Scaleway."
   url="https://account.scaleway.com/register"
   label="Create your account"
 />

--- a/tutorials/how-to-implement-rag-generativeapis/index.mdx
+++ b/tutorials/how-to-implement-rag-generativeapis/index.mdx
@@ -379,3 +379,9 @@ You can fix this with `Applications/Python 3.X` (where `X` is your version numbe
 If this is a private repository, make sure to pass a token having permission to this repo either by logging in with `huggingface-cli login` or by passing ```token=<your_token>```
 
 **Solution**: This is caused by the LangChain OpenAI adapter trying to tokenize content. Ensure you set `check_embedding_ctx_length=False` in OpenAIEmbedding configuration to avoid tokenizing content, as tokenization will be performed server-side in Generative APIs.
+<ClickableBanner
+  productLogo="generic"
+  title="Enhance your AI applications with Retrieval-Augmented Generation on Scaleway."
+  url="https://account.scaleway.com/register"
+  label="Create your account"
+/>

--- a/tutorials/install-apache-ansible/index.mdx
+++ b/tutorials/install-apache-ansible/index.mdx
@@ -190,3 +190,9 @@ Customize Apache configuration as per your requirements:
 Once Ansible is fully set up, you can visit your web browser on port 8081 (rather than port 80). In most web browsers, this can be easily achieved by adding :port onto the end of the URL: http://public_ip_address:8081/.
 
 <Lightbox src="scaleway-apache_defaultpage.webp" alt="" />
+<ClickableBanner
+  productLogo="generic"
+  title="Automate your web server deployment using Ansible on Scaleway."
+  url="https://account.scaleway.com/register"
+  label="Create your account"
+/>

--- a/tutorials/install-github-actions-runner-mac/index.mdx
+++ b/tutorials/install-github-actions-runner-mac/index.mdx
@@ -12,7 +12,12 @@ dates:
   validation: 2024-10-24
   posted: 2024-01-31
 ---
-
+<ClickableBanner
+  productLogo="generic"
+  title="Automate your CI/CD workflows on macOS with GitHub Actions Runner"
+  url="https://account.scaleway.com/register"
+  label="Create your account"
+/>
 GitHub Actions is a powerful CI/CD platform that allows users to automate their software development workflows, connected to a GitHub organization or repository. While GitHub offers online runners with a pay-as-you-go model, self-hosted runners provide increased control and customization for your CI/CD setup. This tutorial guides you through setting up, configuring, and connecting a self-hosted runner on a Mac mini to execute macOS pipelines.
 
 <Macro id="requirements" />

--- a/tutorials/install-github-actions-runner-mac/index.mdx
+++ b/tutorials/install-github-actions-runner-mac/index.mdx
@@ -14,7 +14,7 @@ dates:
 ---
 <ClickableBanner
   productLogo="generic"
-  title="Automate your CI/CD workflows on macOS with GitHub Actions Runner"
+  title="Automate your CI/CD workflows on macOS with GitHub Actions Runners"
   url="https://account.scaleway.com/register"
   label="Create your account"
 />

--- a/tutorials/install-pgbouncer/index.mdx
+++ b/tutorials/install-pgbouncer/index.mdx
@@ -215,3 +215,9 @@ You can do an online restart without terminating the connections. PgBouncer laun
     ```
 
 This setup allows the basic installation of PgBouncer. For more information on commands and configuration, refer to the [official documentation](https://www.pgbouncer.org).
+<ClickableBanner
+  productLogo="generic"
+  title="Deploy PgBouncer on Scaleway and optimize your database connections"
+  url="https://account.scaleway.com/register"
+  label="Create your account"
+/>

--- a/tutorials/install-wireguard/index.mdx
+++ b/tutorials/install-wireguard/index.mdx
@@ -12,7 +12,12 @@ dates:
   validation: 2025-01-02
   posted: 2019-03-28
 ---
-
+<ClickableBanner
+  productLogo="generic"
+  title="Enhance security with WireGuard VPN on your Scaleway infrastructure."
+  url="https://account.scaleway.com/register"
+  label="Create your account"
+/>
 WireGuard® is a VPN (Virtual Private Network) software designed for simplicity and efficiency. It is distinguished by its small codebase, which aims to reduce complexity and potential security vulnerabilities, and offers faster performance compared to some other VPN solutions, due to its streamlined design.
 
 In terms of security, WireGuard uses modern cryptographic protocols, including Curve25519, ChaCha20, and Poly1305, focusing on established cryptographic methods.

--- a/tutorials/jump-desktop/index.mdx
+++ b/tutorials/jump-desktop/index.mdx
@@ -83,3 +83,9 @@ From the [Mac mini list in your Scaleway console](https://console.scaleway.com/a
     Your Mac mini will be displayed.
 
 <Lightbox src="scaleway-mac-mini-m1.webp" alt="Mac mini page" />
+<ClickableBanner
+  productLogo="generic"
+  title="Remotely access your machines with Jump Desktop on Scaleway."
+  url="https://account.scaleway.com/register"
+  label="Create your account"
+/>

--- a/tutorials/load-testing-vegeta/index.mdx
+++ b/tutorials/load-testing-vegeta/index.mdx
@@ -220,3 +220,9 @@ The data collected during each load test is stored in an output file.
     ```
 
 For more information about Vegeta, refer to the [official documentation](https://github.com/tsenart/vegeta/blob/master/README.md).
+<ClickableBanner
+  productLogo="generic"
+  title="Simulate real-world traffic and optimize your application's performance."
+  url="https://account.scaleway.com/register"
+  label="Create your account"
+/>

--- a/tutorials/nginx-reverse-proxy/index.mdx
+++ b/tutorials/nginx-reverse-proxy/index.mdx
@@ -12,7 +12,12 @@ dates:
   validation: 2024-12-24
   posted: 2018-10-11
 ---
-
+<ClickableBanner
+  productLogo="generic"
+  title="Deploy your reverse proxy in minutes"
+  url="https://account.scaleway.com/register"
+  label="Create your account"
+/>
 An Nginx HTTPS reverse proxy is an intermediary proxy service that takes a client request, passes it on to one or more servers, and subsequently delivers the server's response back to the client. While most common applications can run as web servers on their own, the Nginx web server can provide many advanced features such as load balancing, TLS/SSL capabilities, and acceleration that most specialized applications lack.
 
 There are significant benefits to setting up an Nginx HTTPS reverse proxy:

--- a/tutorials/overleaf/index.mdx
+++ b/tutorials/overleaf/index.mdx
@@ -12,8 +12,12 @@ dates:
   validation: 2025-01-09
   posted: 2023-10-02
 ---
-
-
+<ClickableBanner
+  productLogo="generic"
+  title="Host your own Overleaf instance on Scaleway for seamless teamwork."
+  url="https://account.scaleway.com/register"
+  label="Create your account"
+/>
 Overleaf is a collaborative writing and publishing system that uses LaTeX, a typesetting software that allows for creating structured, professional documents online.
 
 It is particularly favored by academics and professionals for producing scientific documents, research papers, theses, and presentations due to its precise formatting and styling capabilities. Overleaf also supports real-time collaboration between multiple authors.

--- a/tutorials/proxy-protocol-v2-load-balancer/index.mdx
+++ b/tutorials/proxy-protocol-v2-load-balancer/index.mdx
@@ -13,7 +13,12 @@ dates:
   validation: 2024-09-16
   posted: 2019-06-28
 ---
-
+<ClickableBanner
+  productLogo="generic"
+  title="Preserve client IPs with Proxy Protocol v2 on Scaleway Load Balancers."
+  url="https://account.scaleway.com/register"
+  label="Create your account"
+/>
 [Proxy Protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt) allows a backend application, like an Apache or Nginx web server, to retrieve client connection information that has passed through a load-balanced infrastructure. The protocol transports connection information including the originating IP address, the proxy server IP address, and both ports.
 
 This tutorial shows you how and why to enable Proxy Protocol on your Scaleway Load Balancer, and how to configure your backend server application to correctly handle the protocol.

--- a/tutorials/python-for-loops/index.mdx
+++ b/tutorials/python-for-loops/index.mdx
@@ -925,3 +925,9 @@ for group in numbers:
     Items that cost less than 1 euro: ['butter', 'sugar']
     Items that cost more than (or exactly) 1 euro: ['bread', 'jam']
     ```
+<ClickableBanner
+  productLogo="generic"
+  title="Master Python loops and enhance your coding skills."
+  url="https://account.scaleway.com/register"
+  label="Create your account"
+/>

--- a/tutorials/python-for-loops/index.mdx
+++ b/tutorials/python-for-loops/index.mdx
@@ -927,7 +927,7 @@ for group in numbers:
     ```
 <ClickableBanner
   productLogo="generic"
-  title="Master Python loops and enhance your coding skills."
+  title="Start your Cloud journey with Scaleway."
   url="https://account.scaleway.com/register"
   label="Create your account"
 />

--- a/tutorials/setup-nginx-reverse-proxy-s3/index.mdx
+++ b/tutorials/setup-nginx-reverse-proxy-s3/index.mdx
@@ -13,7 +13,12 @@ dates:
   validation: 2025-01-22
   posted: 2020-06-04
 ---
-
+<ClickableBanner
+  productLogo="generic"
+  title="Securely route traffic to your S3 storage with Nginx on Scaleway."
+  url="https://account.scaleway.com/register"
+  label="Create your account"
+/>
 Scaleway Object Storage provides the capability to securely store unlimited data within designated buckets. Accessing your stored data is convenient and direct, facilitated through your storage bucket.
 
 For optimized access, you can use an Instance as a proxy, leveraging the power of Nginx as a reverse proxy. This configuration enables read-only access to the contents of your bucket.

--- a/tutorials/veeam-backup-replication-s3/index.mdx
+++ b/tutorials/veeam-backup-replication-s3/index.mdx
@@ -11,7 +11,12 @@ tags: vSphere Object-Storage Veeam-Backup Veeam
 dates:
   validation: 2024-12-05
 ---
-
+<ClickableBanner
+  productLogo="generic"
+  title="Secure your backups by storing them in Scaleway’s Object Storage."
+  url="https://account.scaleway.com/register"
+  label="Create your account"
+/>
 ## Veeam Overview
 
 [Veeam Backup & Replication](https://www.veeam.com/vm-backup-recovery-replication-software.html) is a proprietary backup application, developed by Veeam for virtual environments built on VMware vSphere and Microsoft Hyper-V hypervisors.

--- a/tutorials/wireguard-mesh-vpn/index.mdx
+++ b/tutorials/wireguard-mesh-vpn/index.mdx
@@ -238,3 +238,9 @@ You have now configured a mesh network using WireGuard which allows your Instanc
 For more information about WireGuard, refer to the [official documentation](https://www.wireguard.com/quickstart/).
 
 “WireGuard” is a registered trademark of [Jason A. Donenfeld](https://www.zx2c4.com/).
+<ClickableBanner
+  productLogo="generic"
+  title="Easily set up a secure and scalable VPN network with WireGuard on Scaleway."
+  url="https://account.scaleway.com/register"
+  label="Create your account"
+/>


### PR DESCRIPTION
Following our last Inday, we are testing account creations from the docs. 
CTAs have been added to the most viewed tutorials: 50% at the top and 50% at the bottom. 

See the recap and examples here: [Gsheet](https://docs.google.com/spreadsheets/d/1JGLyCDux5cRioDF9so3iRay27shAmuvBkZ7aVQ--nSs/edit?gid=0#gid=0)

To be reviewed: title for each CTA

