### PR TITLE
docs(fix): replace managed dashboard with preconfigured

### DIFF
--- a/menu/navigation.json
+++ b/menu/navigation.json
@@ -3855,7 +3855,7 @@
                     "slug": "configure-alerts-for-scw-resources"
                   },
                   {
-                    "label": "Access Grafana and managed dashboards",
+                    "label": "Access Grafana and preconfigured dashboards",
                     "slug": "access-grafana-and-managed-dashboards"
                   },
                   {

--- a/pages/cockpit/concepts.mdx
+++ b/pages/cockpit/concepts.mdx
@@ -94,7 +94,7 @@ A Grafana user is any individual who can log in to [Grafana](https://grafana.com
 - an editor: can build and view dashboards
 
 <Message type="note">
- - Managed dashboards in the "Scaleway" folder are always read-only, regardless of your role.
+ - Preconfigured dashboards in the "Scaleway" folder are always read-only, regardless of your role.
  - The `admin` user is not yet available for creation.
 </Message>
 
@@ -124,11 +124,6 @@ Preconfigured alerts are regionalized alerting rules that Scaleway defines for y
  You must enable the alert manager to enable preconfigured alerts. Preconfigured alerts will only be active in the regions where you have enabled the alert manager.
 </Message>
 
-
-## Managed dashboards
-
-A managed dashboard is a set of one or more panels that Scaleway sets up and updates for you to visualize the metrics and logs associated with your Scaleway products.
-
 ## Metric
 
 A metric is a lifecycle-related numerical representation of data (e.g. disk usage and CPU usage) measured over intervals of time. Metrics give you a bird's eye view of your infrastructure.
@@ -138,6 +133,10 @@ You can push metrics with any Prometheus-compatible agent such as [Prometheus](h
 ## Mimir
 
 [Grafana Mimir](https://github.com/grafana/mimir) is an open source software project that allows you to store your metrics by providing long-term storage for [Prometheus](https://prometheus.io/docs/introduction/overview/#what-is-prometheus).
+
+## Preconfigured dashboards
+
+A preconfigured dashboard is a set of one or more panels that Scaleway sets up and updates for you to visualize the metrics and logs associated with your Scaleway products.
 
 ## Prometheus Remote Write
 

--- a/pages/cockpit/how-to/access-grafana-and-managed-dashboards.mdx
+++ b/pages/cockpit/how-to/access-grafana-and-managed-dashboards.mdx
@@ -1,11 +1,11 @@
 ---
 meta:
-  title: How to access Grafana and your managed dashboards
-  description: Learn to access your Grafana managed dashboards, including steps to log in, navigate, and view your resources.
+  title: How to access Grafana and your preconfigured dashboards
+  description: Learn to access your Grafana preconfigured dashboards, including steps to log in, navigate, and view your resources.
 content:
-  h1: How to access Grafana and your managed dashboards
-  paragraph: Learn to access your Grafana managed dashboards, including steps to log in, navigate, and view your resources.
-tags: observability cockpit grafana managed-dashboard
+  h1: How to access Grafana and your preconfigured dashboards
+  paragraph: Learn to access your Grafana preconfigured dashboards, including steps to log in, navigate, and view your resources.
+tags: observability cockpit grafana preconfigured-dashboard
 categories:
   - observability
 dates:
@@ -13,9 +13,9 @@ dates:
   posted: 2022-10-31
 ---
 
-Scaleway provides you with managed dashboards you can access in Grafana, for [Scaleway resources integrated with Cockpit](/cockpit/reference-content/cockpit-limitations/#product-integration-into-cockpit).
+Scaleway provides you with preconfigured dashboards you can access in Grafana, for [Scaleway resources integrated with Cockpit](/cockpit/reference-content/cockpit-limitations/#product-integration-into-cockpit).
 
-This page shows you how to access [managed dashboards](/cockpit/concepts/#managed-dashboards).
+This page shows you how to access [preconfigured dashboards](/cockpit/concepts/#preconfigured-dashboards).
 
 <Macro id="requirements" />
 
@@ -25,13 +25,13 @@ This page shows you how to access [managed dashboards](/cockpit/concepts/#manage
 
 
 1. Click **Cockpit** in the Observability section of the [console](https://console.scaleway.com/) side menu. The **Cockpit** overview page displays.
-2. Click **Open dashboards** to open your managed dashboards in Grafana. You are redirected to the Grafana website.
+2. Click **Open dashboards** to open your preconfigured dashboards in Grafana. You are redirected to the Grafana website.
 3. Enter your [Grafana credentials](/cockpit/how-to/retrieve-grafana-credentials/).
 4. Click **Log in**. The Grafana overview page displays.
 5. Click the **Home** icon at the top left of your screen.
-6. Click **Dashboard**. The Scaleway folder appears, with a list of all available managed dashboards for Scaleway resources.
+6. Click **Dashboard**. The Scaleway folder appears, with a list of all available preconfigured dashboards for Scaleway resources.
 7. Click the dashboard you want to view.
 
 <Message type="important">
- Managed dashboards in the “Scaleway” folder are always read-only.
+ Preconfigured dashboards in the “Scaleway” folder are always read-only.
 </Message>

--- a/pages/cockpit/how-to/retrieve-grafana-credentials.mdx
+++ b/pages/cockpit/how-to/retrieve-grafana-credentials.mdx
@@ -13,7 +13,7 @@ dates:
   posted: 2022-10-31
 ---
 
-This page shows you how to retrieve your Grafana credentials to access your Grafana [dashboards](/cockpit/concepts/#managed-dashboards) using the [Scaleway console](https://console.scaleway.com/).
+This page shows you how to retrieve your Grafana credentials to access your preconfigured [dashboards](/cockpit/concepts/#preconfigured-dashboards) using the [Scaleway console](https://console.scaleway.com/).
 
 <Macro id="requirements" />
 

--- a/pages/cockpit/how-to/send-logs-from-k8s-to-cockpit.mdx
+++ b/pages/cockpit/how-to/send-logs-from-k8s-to-cockpit.mdx
@@ -137,7 +137,7 @@ You can also use Terraform/OpenTofu to manage and deploy Helm charts, providing 
 ## Explore your logs in Cockpit
 
 1. Click **Cockpit** in the Observability section of the Scaleway [console](https://console.scaleway.com/) side menu. The **Cockpit Overview** page displays.
-2. Click **Open dashboards** to open your managed dashboards in Grafana. You are redirected to the Grafana website.
+2. Click **Open dashboards** to open your preconfigured dashboards in Grafana. You are redirected to the Grafana website.
 3. Log in to Grafana using your [Grafana credentials](/cockpit/how-to/retrieve-grafana-credentials/).
 4. Click the **Home** icon, then click **Explore**.
 5. Select your custom data source in the search drop-down on the upper left corner of your screen.

--- a/pages/cockpit/how-to/send-metrics-from-k8s-to-cockpit.mdx
+++ b/pages/cockpit/how-to/send-metrics-from-k8s-to-cockpit.mdx
@@ -166,7 +166,7 @@ Once you have configured your `values.yml` file, you can use Helm to deploy the 
 Now that your metrics are exported to your Cockpit, you can access and query them.
 
 1. Click **Cockpit** in the Observability section of the Scaleway [console](https://console.scaleway.com/) side menu. The **Cockpit Overview** page displays.
-2. Click **Open dashboards** to open your managed dashboards in Grafana. You are redirected to the Grafana website.
+2. Click **Open dashboards** to open your preconfigured dashboards in Grafana. You are redirected to the Grafana website.
 3. Log in to Grafana using your [Grafana credentials](/cockpit/how-to/retrieve-grafana-credentials/).
 4. Click the **Home** icon, then click **Explore**.
 5. Select your custom data source in the search drop-down on the upper left corner of your screen.

--- a/pages/cockpit/how-to/send-metrics-with-grafana-alloy.mdx
+++ b/pages/cockpit/how-to/send-metrics-with-grafana-alloy.mdx
@@ -92,7 +92,7 @@ For the sake of this documentation, we are using Grafana Alloy on macOS. Refer t
 ## Visualizing your metrics
 
 1. Click **Cockpit** in the Observability section of the [console](https://console.scaleway.com/) side menu. The **Cockpit** overview page displays.
-2. Click **Open dashboards** to open your managed dashboards in Grafana. You are redirected to the Grafana website.
+2. Click **Open dashboards** to open your preconfigured dashboards in Grafana. You are redirected to the Grafana website.
 3. Enter your [Grafana credentials](/cockpit/how-to/retrieve-grafana-credentials/).
 4. Click **Log in**. The Grafana overview page displays.
 5. Click the **Toggle menu** icon in the top left corner of your screen.

--- a/pages/managed-inference/how-to/monitor-deployment.mdx
+++ b/pages/managed-inference/how-to/monitor-deployment.mdx
@@ -28,4 +28,4 @@ This documentation page shows you how to monitor your Managed Inference deployme
 3. Click the **Monitoring** tab of your deployment. The Cockpit overview displays.
 4. Click **Open Grafana metrics dashboard** to open your Cockpit's Grafana interface.
 5. Authenticate with your [Grafana credentials](/cockpit/how-to/retrieve-grafana-credentials/). The Grafana dashboard displays.
-6. Select your Managed Inference dashboard from the [list of your managed dashboards](/cockpit/how-to/access-grafana-and-managed-dashboards/) to visualize your metrics.
+6. Select your Managed Inference dashboard from the [list of your preconfigured dashboards](/cockpit/how-to/access-grafana-and-managed-dashboards/) to visualize your metrics.


### PR DESCRIPTION
Replaced wording "managed dashboards" with "preconfigued dashboards"