### PR TITLE
docs(gen): update devtools wording

### DIFF
--- a/faq/public-gateways.mdx
+++ b/faq/public-gateways.mdx
@@ -29,7 +29,7 @@ Moreover, the Public Gateway supports [static NAT](/public-gateways/how-to/confi
 
 On 12 July 2023, DHCP functionality moved from Public Gateways to Private Networks. See our [dedicated migration documentation](/vpc/reference-content/vpc-migration/) for full details.
 
-Pre-existing static leases created via the Public Gateway were fully migrated and still work for your attached resources on a Private Network. Manual static lease configuration is still available via the API and other devtools, but is no longer available via the Scaleway console. We recommend that you use [Scaleway IPAM](/ipam/) to reserve private IP addresses on specific Private Networks, which you can then use when attaching resources.
+Pre-existing static leases created via the Public Gateway were fully migrated and still work for your attached resources on a Private Network. Manual static lease configuration is still available via the API and other developer tools, but is no longer available via the Scaleway console. We recommend that you use [Scaleway IPAM](/ipam/) to reserve private IP addresses on specific Private Networks, which you can then use when attaching resources.
 
 ## Why is my Public Gateway labelled as Legacy?
 

--- a/pages/kubernetes/reference-content/kubernetes-load-balancer.mdx
+++ b/pages/kubernetes/reference-content/kubernetes-load-balancer.mdx
@@ -45,7 +45,7 @@ Here is a quick overview of how to create a Load Balancer for your cluster:
 - Modify your Load Balancer's configuration as necessary via the yaml manifest and [Load Balancer annotations](https://github.com/scaleway/scaleway-cloud-controller-manager/blob/master/docs/loadbalancer-annotations.md) , putting any new annotations into effect via kubectl, so the CCM can carry out the modifications as necessary.
 
 <Message type="important">
-Load Balancers for Kubernetes clusters should **always** be provisioned via the cluster's Cloud Controller Manager. It is **not** correct procedure to provision the Load Balancer by creating a Scaleway Load Balancer in the console or via the API, and then attempting to use it as your cluster's external Load Balancer. Similarly, you cannot use the Scaleway console or devtools to edit your cluster's Load Balancer after creation, this must be done via the CCM, as detailed in this documentation.
+Load Balancers for Kubernetes clusters should **always** be provisioned via the cluster's Cloud Controller Manager. It is **not** correct procedure to provision the Load Balancer by creating a Scaleway Load Balancer in the console or via the API, and then attempting to use it as your cluster's external Load Balancer. Similarly, you cannot use the Scaleway console or developer tools to edit your cluster's Load Balancer after creation, this must be done via the CCM, as detailed in this documentation.
 </Message>
 
 ## Creating a Load Balancer for your cluster: Step by step
@@ -128,7 +128,7 @@ Your Load Balancer will be created with a default configuration unless you defin
 With annotations, you can configure parameters such as the balancing method, health check settings, and more.
 
 <Message type="important">
-You should **never** try to modify the configuration of your cluster's Load Balancer via the Scaleway console, the API, or any other devtools. Any modifications made this way will be overwritten by the cluster's CCM. You should **always** use annotations as described below to configure your cluster's Load Balancer.
+You should **never** try to modify the configuration of your cluster's Load Balancer via the Scaleway console, the API, or any other developer tools. Any modifications made this way will be overwritten by the cluster's CCM. You should **always** use annotations as described below to configure your cluster's Load Balancer.
 </Message>
 
 Add annotations to the `metadata` section of your LoadBalancer Service's yaml manifest as shown below. In this example we include two annotations, but you can include as many as you need.

--- a/pages/kubernetes/reference-content/using-load-balancer-annotations.mdx
+++ b/pages/kubernetes/reference-content/using-load-balancer-annotations.mdx
@@ -26,7 +26,7 @@ See the full list of available Load Balancer annotations [here](https://github.c
 - [Configuring health checks](/load-balancer/reference-content/configuring-health-checks/)
 
 <Message type="important">
-You should **always** use annotations as described below to configure your cluster's Load Balancer. Any modifications made to the configuration of your Kubernetes cluster's Load Balancer via the Scaleway console, the API, or any other devtools, will be **overwritten by the cluster's CCM**.
+You should **always** use annotations as described below to configure your cluster's Load Balancer. Any modifications made to the configuration of your Kubernetes cluster's Load Balancer via the Scaleway console, the API, or any other developer tools, will be **overwritten by the cluster's CCM**.
 </Message>
 
 The following documentation shows you how to use annotations to fine tune your Load Balancer's configuration.

--- a/pages/load-balancer/reference-content/public-private-accessibility.mdx
+++ b/pages/load-balancer/reference-content/public-private-accessibility.mdx
@@ -30,7 +30,7 @@ A Load Balancer is defined as public when you choose the "public" accessibility 
 - It must have a public IPv4 address, which can either be a new address created along with the Load Balancer, or an existing available flexible IP address held in your account.
 - It can optionally have an additional public IPv6 address.
 - The Load Balancer is accessible over the public internet via its public IP address(es), but can optionally also be attached to up to eight different Private Networks.
-- It can be configured or deleted using the Scaleway API, console, CLI, Terraform/OpenTofu or other devtools.
+- It can be configured or deleted using the Scaleway API, console, CLI, Terraform/OpenTofu or other developer tools.
 - It provides its metrics to [Scaleway Cockpit](/cockpit/concepts/#cockpit), allows the use of Let's Encrypt certificates, and (if the appropriate Load Balancer type is selected), supports multi-cloud IP addresses for its backend servers.
 
 <Lightbox src="scaleway-public-lb.webp" alt="" />
@@ -42,7 +42,7 @@ A Load Balancer is defined as private when you choose the "private" accessibilit
 - It has no public IP address for sending requests or initiating TCP connections.
 - It only listens to requests or connections sent to its interface(s) on the [Private Network(s)](/vpc/concepts/#private-networks) it is attached to. It is not accessible over the public internet.
 - Like a public Load Balancer, it can be attached to up to eight different Private Networks.
-- It can be configured or deleted using the Scaleway API, console, CLI, Terraform/OpenTofu, or other devtools.
+- It can be configured or deleted using the Scaleway API, console, CLI, Terraform/OpenTofu, or other developer tools.
 - It provides its metrics to [Scaleway Cockpit](/cockpit/concepts/#cockpit), even though there is no traffic.
 - It does not allow the use of a Let's Encrypt [certificate](/load-balancer/concepts/#certificate) - only imported certificates are supported.
 - It does not support multi-cloud IP addresses for its backend servers, since it is not directly connected to the internet. Routes to them are thus, not guaranteed.

--- a/pages/messaging/api-cli/nats-cli.mdx
+++ b/pages/messaging/api-cli/nats-cli.mdx
@@ -70,7 +70,7 @@ To create a [stream](/messaging/concepts/#stream), use the command `nats stream 
     - The volume of billed messages
 </Message>
 
-You can connect to your stream using code, devtools or the NATS CLI (for testing purposes only).
+You can connect to your stream using code, developer tools or the NATS CLI (for testing purposes only).
 
 ## NATS cheat sheet
 

--- a/pages/public-gateways/concepts.mdx
+++ b/pages/public-gateways/concepts.mdx
@@ -55,7 +55,7 @@ Scaleway Public Gateways are either in **Legacy mode** or **IPAM mode**. The mod
 
 **Legacy** Public Gateways use a [workaround](/vpc/reference-content/vpc-migration/#public-gateways-and-vpc) to ensure IPAM compatibility. Your gateway is a legacy gateway if:
 - You created it via the Scaleway console prior to 17 October 2023
-- You created it via the Scaleway API or devtools prior to 17 October 2023, and you did not use the `ipam_config` object when creating the [GatewayNetwork](https://www.scaleway.com/en/developers/api/public-gateway/#path-gateway-networks-attach-a-public-gateway-to-a-private-network) (attachment to a Private Network).
+- You created it via the Scaleway API or developer tools prior to 17 October 2023, and you did not use the `ipam_config` object when creating the [GatewayNetwork](https://www.scaleway.com/en/developers/api/public-gateway/#path-gateway-networks-attach-a-public-gateway-to-a-private-network) (attachment to a Private Network).
 
 The auto-calculated `is_legacy` [Gateway parameter](https://www.scaleway.com/en/developers/api/public-gateway/#path-gateways-create-a-public-gateway) will have a value of `true`. 
 
@@ -65,7 +65,7 @@ Private Networks attached to legacy Public Gateways must stay in the gateway's a
 
 **IPAM** Public Gateways are fully and natively integrated with the Scaleway IPAM without any workaround. Your gateway is in IPAM mode if:
 - You created it via the Scaleway console on or after 17 October 2023 
-- You created it via the Scaleway API or devtools using the `ipam_config` object, and the auto-calculated `is_legacy` [Gateway parameter](https://www.scaleway.com/en/developers/api/public-gateway/#path-gateways-create-a-public-gateway) has a value of `false`. 
+- You created it via the Scaleway API or developer tools using the `ipam_config` object, and the auto-calculated `is_legacy` [Gateway parameter](https://www.scaleway.com/en/developers/api/public-gateway/#path-gateways-create-a-public-gateway) has a value of `false`. 
 
 You cannot "migrate" a legacy Public Gateway to become an IPAM-mode gateway. While legacy Public Gateways continue to function thanks to our [workaround](/vpc/reference-content/vpc-migration/#public-gateways-and-vpc), you cannot modify them to become natively integrated IPAM networks. If you wish to have an IPAM-mode Public Gateway, for example to benefit from IP management via Scaleway's [IPAM](https://www.scaleway.com/en/developers/api/vpc/) API as more features become available, or to use Kapsule with full isolation, you must create a new gateway.
 

--- a/pages/vpc/reference-content/vpc-migration.mdx
+++ b/pages/vpc/reference-content/vpc-migration.mdx
@@ -89,7 +89,7 @@ If you fall into one of the cases where DHCP is not automatically activated for 
 
 See the dedicated documentation on [activating DHCP](/vpc/how-to/activate-dhcp/)
 
-Any static DHCP reservations (static leases) configured via a Public Gateway have been transparently migrated. Going forward, [DHCP reservations via the Public Gateway API](https://www.scaleway.com/en/developers/api/public-gateway/) and other devtools are deprecated but still available via the API, to avoid breaking changes. They are no longer available via the console. We strongly recommend that you use our IPAM product to [reserve](/ipam/how-to/reserve-ip/) and manage your IP addresses.
+Any static DHCP reservations (static leases) configured via a Public Gateway have been transparently migrated. Going forward, [DHCP reservations via the Public Gateway API](https://www.scaleway.com/en/developers/api/public-gateway/) and other developer tools are deprecated but still available via the API, to avoid breaking changes. They are no longer available via the console. We strongly recommend that you use our IPAM product to [reserve](/ipam/how-to/reserve-ip/) and manage your IP addresses.
 
 ## Aspect 3: DNS on Private Networks
 
@@ -127,7 +127,7 @@ When creating a Kubernetes Kapsule cluster with [full isolation](/kubernetes/ref
 
 ## Impacts on the rest of the Scaleway ecosystem
 
-The general availability of VPC brings the following changes to our devtools and console:
+The general availability of VPC brings the following changes to our developer tools and console:
 
 **Scaleway console**
 - The existing **Private Networks** section, available from the main menu (sidebar) of the [console](https://console.scaleway.com/), will soon cease to be accessible. Instead, you should select **VPC** in the sidebar, and then click on the relevant VPC, to access and manage your Private Networks.


### PR DESCRIPTION
### Description

Updated `devtools` wording to more formal `developer tools` in some documentations.