### PR TITLE
feat(secret-manager): scheduled deletion doc

### DIFF
--- a/faq/secret-manager.mdx
+++ b/faq/secret-manager.mdx
@@ -5,7 +5,7 @@ meta:
 content:
   h1: Secret Manager
 dates:
-  validation: 2024-09-23
+  validation: 2025-03-27
 category: identity-and-access-management
 productIcon: SecretManagerProductIcon
 ---
@@ -40,3 +40,5 @@ To understand the secrets encryption process, refer to our [related documentatio
 At the end of the month, you are billed for the number of secret versions stored and API requests made on the service.
 A secret version is billed if it is in an enabled or disabled state.
 If, for example, you have used a secret version for five days, you will only be billed for the five days and not for the whole month. Find out more about pricing on our [dedicated page](https://www.scaleway.com/en/pricing/?tags=available).
+
+Recovering secrets [scheduled for deletion](/secret-manager/concepts/#scheduled-deletion) is billed €0.01 per version associated with the secret.

--- a/menu/navigation.json
+++ b/menu/navigation.json
@@ -556,6 +556,10 @@
                     "slug": "delete-secret"
                   },
                   {
+                    "label": "Recover secrets scheduled for deletion",
+                    "slug": "recover-secrets"
+                  },
+                  {
                     "label": "Delete a version",
                     "slug": "delete-version"
                   }

--- a/pages/secret-manager/concepts.mdx
+++ b/pages/secret-manager/concepts.mdx
@@ -7,7 +7,7 @@ content:
   paragraph: Discover essential concepts of Scaleway Secret Manager, including secret versioning, ephemeral policies, and path management.
 tags: secret-manager secret version
 dates:
-  validation: 2025-01-13
+  validation: 2025-03-19
 ---
 
 ## Disabling a version
@@ -108,6 +108,15 @@ Secret types refer to the different kinds of sensitive data you can store with S
 
 
 Upon secret creation, you must choose a secret type that will also be applied to the secret version. All the secret's subsequent versions must be of the same type.
+
+## Scheduled deletion
+
+Scheduled deletion lets you mark a secret and its versions for deletion ahead of time. Instead of immediate deletion, the secret enters a 7 day pending deletion period, during which you can still recover it. During this time, you can read secret versions but cannot edit, access, or delete them. After the retention period, the secret and all its versions are permanently deleted.
+
+Recovering your secrets is billed €0.01 per version associated with the secret.
+
+Ephemeral secrets are deleted immediately when scheduled for deletion.
+
 
 ## Tag
 

--- a/pages/secret-manager/concepts.mdx
+++ b/pages/secret-manager/concepts.mdx
@@ -7,7 +7,7 @@ content:
   paragraph: Discover essential concepts of Scaleway Secret Manager, including secret versioning, ephemeral policies, and path management.
 tags: secret-manager secret version
 dates:
-  validation: 2025-03-19
+  validation: 2025-03-27
 ---
 
 ## Disabling a version
@@ -111,12 +111,11 @@ Upon secret creation, you must choose a secret type that will also be applied to
 
 ## Scheduled deletion
 
-Scheduled deletion lets you mark a secret and its versions for deletion ahead of time. Instead of immediate deletion, the secret enters a 7 day pending deletion period, during which you can still recover it. During this time, you can read secret versions but cannot edit, access, or delete them. After the retention period, the secret and all its versions are permanently deleted.
+Scheduled deletion lets you mark a secret and its versions for deletion ahead of time. Instead of immediate deletion, the secret enters a 7-day pending deletion period, during which you can still [recover it](/secret-manager/how-to/recover-secrets/).
 
-Recovering your secrets is billed €0.01 per version associated with the secret.
+During this time, you can read secret versions but cannot edit, access, or delete them. After the retention period, the secret and all its versions are permanently deleted. You can also schedule a secret version for deletion without impacting the secret associated with the version.
 
-Ephemeral secrets are deleted immediately when scheduled for deletion.
-
+Recovering deleted secrets is billed €0.01 per version associated with the secret.
 
 ## Tag
 

--- a/pages/secret-manager/how-to/delete-secret.mdx
+++ b/pages/secret-manager/how-to/delete-secret.mdx
@@ -7,13 +7,13 @@ content:
   paragraph: Discover how to securely delete secrets using Scaleway's intuitive console. Follow these steps to manage your sensitive data effectively.
 tags: secret sensitive-data storage-system
 dates:
-  validation: 2025-03-14
+  validation: 2025-03-19
   posted: 2023-02-21
 categories:
   - identity-and-access-management
 ---
 
-This page explains how to delete a [secret](/secret-manager/concepts/#secret) using the [Scaleway console](https://console.scaleway.com). You **cannot delete protected secrets**, i.e. secrets to which you have applied [secret protection](/secret-manager/concepts/#secret-protection).
+This page explains how to [schedule secret deletion](/secret-manager/concepts/#scheduled-deletion) using the [Scaleway console](https://console.scaleway.com). You **cannot delete protected secrets**, i.e. secrets to which you have applied [secret protection](/secret-manager/concepts/#secret-protection).
 
 <Macro id="requirements" />
 
@@ -25,13 +25,14 @@ This page explains how to delete a [secret](/secret-manager/concepts/#secret) us
 
 1. Click **Secret Manager** in the **Security and Identity** section of the [Scaleway console](https://console.scaleway.com/) side menu.
 2. Select the [region](/secret-manager/concepts/#region) in which to delete the secret, in the **Region** drop-down.
-3. Access the secret you wish to delete. The secret's **Overview** tab displays.
-4. Scroll down and click **Delete secret**. A pop-up displays.
-5. Type **DELETE** and click **Delete secret**.
+3. Click <Icon name="more" /> next to the secret you want to delete and click **Delete**. A pop-up displays informing you that the action schedules the deletion of your secret and its version.
+4. Type **DELETE** and click **Delete secret** to confirm. Your secret displays in the **Scheduled for deletion** tab for a period of 7 days before being permanently deleted.
 
 <Message type="important">
   - Although you cannot delete a [protected secret](/secret-manager/concepts/#secret-protection), you can delete its versions
   - Deleting a secret is a permanent action. It erases every version you have created for your secret
+  - Scheduled deletion does not delete your secret immediately unless it is an ephemeral secret. Find out how to recover secrets scheduled for deletion.
 </Message>
+
 
 

--- a/pages/secret-manager/how-to/delete-secret.mdx
+++ b/pages/secret-manager/how-to/delete-secret.mdx
@@ -5,15 +5,17 @@ meta:
 content:
   h1: How to delete a secret
   paragraph: Discover how to securely delete secrets using Scaleway's intuitive console. Follow these steps to manage your sensitive data effectively.
-tags: secret sensitive-data storage-system
+tags: secret sensitive-data storage-system schedule-deletion
 dates:
-  validation: 2025-03-19
+  validation: 2025-03-27
   posted: 2023-02-21
 categories:
   - identity-and-access-management
 ---
 
 This page explains how to [schedule secret deletion](/secret-manager/concepts/#scheduled-deletion) using the [Scaleway console](https://console.scaleway.com). You **cannot delete protected secrets**, i.e. secrets to which you have applied [secret protection](/secret-manager/concepts/#secret-protection).
+
+Once you schedule a secret for deletion, it enters a 7 day pending deletion period, during which you can still [recover it](/secret-manager/how-to/recover-secrets/). After this retention period, the secret and all its versions are permanently deleted.
 
 <Macro id="requirements" />
 
@@ -29,8 +31,8 @@ This page explains how to [schedule secret deletion](/secret-manager/concepts/#s
 4. Type **DELETE** and click **Delete secret** to confirm. Your secret displays in the **Scheduled for deletion** tab for a period of 7 days before being permanently deleted.
 
 <Message type="important">
-  - Although you cannot delete a [protected secret](/secret-manager/concepts/#secret-protection), you can delete its versions
-  - Deleting a secret is a permanent action. It erases every version you have created for your secret
+  - Although you cannot delete a [protected secret](/secret-manager/concepts/#secret-protection), you can delete its versions.
+  - Deleting a secret is a permanent action. It erases every version you have created for your secret if you do not [recover it](/secret-manager/how-to/recover-secrets/) before the end of the retention period.
   - Scheduled deletion does not delete your secret immediately unless it is an ephemeral secret. [Find out how to recover secrets scheduled for deletion](/secret-manager/how-to/recover-secrets/).
 </Message>
 

--- a/pages/secret-manager/how-to/delete-secret.mdx
+++ b/pages/secret-manager/how-to/delete-secret.mdx
@@ -31,7 +31,7 @@ This page explains how to [schedule secret deletion](/secret-manager/concepts/#s
 <Message type="important">
   - Although you cannot delete a [protected secret](/secret-manager/concepts/#secret-protection), you can delete its versions
   - Deleting a secret is a permanent action. It erases every version you have created for your secret
-  - Scheduled deletion does not delete your secret immediately unless it is an ephemeral secret. Find out how to recover secrets scheduled for deletion.
+  - Scheduled deletion does not delete your secret immediately unless it is an ephemeral secret. [Find out how to recover secrets scheduled for deletion](/secret-manager/how-to/recover-secrets/).
 </Message>
 
 

--- a/pages/secret-manager/how-to/delete-version.mdx
+++ b/pages/secret-manager/how-to/delete-version.mdx
@@ -5,15 +5,15 @@ meta:
 content:
   h1: How to delete a version
   paragraph: Learn how to securely delete versions of secrets using the Scaleway console. Follow these steps to effectively manage your sensitive data.
-tags: sensitive-data storage-system api-key
+tags: sensitive-data storage-system api-key schedule-deletion
 dates:
-  validation: 2025-03-14
+  validation: 2025-03-27
   posted: 2023-02-21
 categories:
   - identity-and-access-management
 ---
 
-This page explains how to delete a secret [version](/secret-manager/concepts/#version) using the [Scaleway console](https://console.scaleway.com).
+This page explains how to [schedule a secret for deletion](/secret-manager/concepts/#scheduled-deletion) using the [Scaleway console](https://console.scaleway.com).
 
 <Macro id="requirements" />
 
@@ -26,12 +26,11 @@ This page explains how to delete a secret [version](/secret-manager/concepts/#ve
 2. Select the [region](/secret-manager/concepts/#region) in which to delete the version, in the **Region** drop-down.
 3. Access the secret for which you want to delete the version. Your secret's **Overview** tab displays.
 4. Click the **Versions** tab.
-5. Click <Icon name="more" /> next to the version you want to delete.
-6. Click **Delete**. A pop-up displays.
-7. Type **DELETE** and click **Delete version**.
+5. Click <Icon name="more" /> next to the version you want to delete, and click **Delete**. A pop-up displays informing you that the action schedules the deletion of your version.
+6. Type **DELETE** and click **Delete version** to confirm. Your version displays in the **Scheduled for deletion** tab for a period of 7 days before being permanently deleted.
 
 <Message type="important">
- Deleting a version is permanent. You will not be able to use the version again.
+ Deleting a version is permanent. You will not be able to use the version again if you do not [recover it](/secret-manager/how-to/recover-secrets/) before the end of the 7-day retention period.
 </Message>
 
 

--- a/pages/secret-manager/how-to/recover-secrets.mdx
+++ b/pages/secret-manager/how-to/recover-secrets.mdx
@@ -7,13 +7,13 @@ content:
   paragraph: Discover how to securely delete secrets using Scaleway's intuitive console. Follow these steps to manage your sensitive data effectively.
 tags: secret sensitive-data scheduled-deletion recover-secret
 dates:
-  validation: 2025-03-19
-  posted: 2025-03-19
+  validation: 2025-03-27
+  posted: 2025-03-27
 categories:
   - identity-and-access-management
 ---
 
-This page shows you how to recover secrets scheduled for deletion using the Scaleway console. Once you schedule a secret for deletion, it enters a 7 day pending deletion period, during which you can still recover it.
+This page shows you how to recover secrets scheduled for deletion using the Scaleway [console](https://console.scaleway.com). Once you schedule a secret for deletion, it enters a 7 day pending deletion period, during which you can still recover it.
 After this retention period, the secret and all its versions are permanently deleted.
 
 <Message type="important">

--- a/pages/secret-manager/how-to/recover-secrets.mdx
+++ b/pages/secret-manager/how-to/recover-secrets.mdx
@@ -1,0 +1,38 @@
+---
+meta:
+  title: How to recover secrets scheduled for deletion
+  description: Discover how to securely delete secrets using the Scaleway console. Follow these steps to manage your sensitive data effectively.
+content:
+  h1: How to recover secrets scheduled for deletion
+  paragraph: Discover how to securely delete secrets using Scaleway's intuitive console. Follow these steps to manage your sensitive data effectively.
+tags: secret sensitive-data scheduled-deletion recover-secret
+dates:
+  validation: 2025-03-19
+  posted: 2025-03-19
+categories:
+  - identity-and-access-management
+---
+
+This page shows you how to recover secrets scheduled for deletion using the Scaleway console. Once you schedule a secret for deletion, it enters a 7 day pending deletion period, during which you can still recover it.
+After this retention period, the secret and all its versions are permanently deleted.
+
+<Message type="important">
+  Scheduled deletion deletes ephemeral secrets and their versions immediately
+</Message>
+
+<Macro id="requirements" />
+
+- A Scaleway account logged into the [console](https://console.scaleway.com)
+- [Owner](/iam/concepts/#owner) status or [IAM permissions](/iam/concepts/#permission) allowing you to perform actions in the intended Organization
+- [Generated an API key](/iam/how-to/create-api-keys/) and enabled the `SecretManagerFullAccess` [permission set](/iam/reference-content/permission-sets/)
+- Created a [secret](/secret-manager/how-to/create-secret/)
+- Scheduled secrets for deletion
+
+1. Click **Secret Manager** in the **Security and Identity** section of the [Scaleway console](https://console.scaleway.com/) side menu.
+2. Select the [region](/secret-manager/concepts/#region) in which to recover the secret, in the **Region** drop-down.
+3. Click the **Scheduled for deletion** tab. Your secrets dispaly.
+4. Click <Icon name="more" /> next to the secret you want to recover and click **Recover**. A pop-up displays with the estimated cost for recovering the secret.
+    <Message type="note">
+     Recovering a secret is billed €0.01 per version associated with the secret
+    </Message>
+5. Click **Recover secret** to confirm. Your secret displays in the **Secrets** tab.


### PR DESCRIPTION
### Your checklist for this pull request

- Added scheduled deletion concept
- Edited how to delete a secret to add scheduled deletion
- Added how to recover secrets scheduled for deletion page

To consider:

- Scheduled deletion is going to become the new deletion system - no more deletion as we have it now - When we delete a version, it is scheduled for deletion and will be deleted 7 days later. No impact on the version's secret.
- Add bulk delete and bulk recover steps
- Do we add billing information in the FAQ about recovering versions?
