### PR TITLE
fix(ipam): add doc for reverse IPv6

### DIFF
--- a/menu/navigation.json
+++ b/menu/navigation.json
@@ -3382,6 +3382,10 @@
                   {
                     "label": "IPAM API Reference",
                     "slug": "https://www.scaleway.com/en/developers/api/ipam/"
+                  },
+                  {
+                    "label": "Set a reverse IPv6 DNS record",
+                    "slug": "set-ip-reverse"
                   }
                 ],
                 "label": "API/CLI",

--- a/pages/instances/how-to/configure-reverse-dns.mdx
+++ b/pages/instances/how-to/configure-reverse-dns.mdx
@@ -36,3 +36,7 @@ Reverse DNS is the opposite of classic "forward" DNS and maps an IP address to a
     <Message type="note">
       Once the reverse DNS has been updated, it may take up to 24 hours before it is fully propagated.
     </Message>
+
+<Message type="tip">
+You cannot set reverse DNS for individual addresses within a flexible IPv6 /64 block via the Scaleway console. See our dedicated documentation on [how to use the IPAM API](/ipam/api-cli/set-ip-reverse/) for this purpose.
+</Message>

--- a/pages/ipam/api-cli/index.mdx
+++ b/pages/ipam/api-cli/index.mdx
@@ -1,0 +1,9 @@
+---
+meta:
+  title: IPAM - API/CLI Documentation
+  description: IPAM API/CLI Documentation
+content:
+  h1: IPAM - API/CLI Documentation
+  paragraph: IPAM API/CLI Documentation
+---
+

--- a/pages/ipam/api-cli/set-ip-reverse.mdx
+++ b/pages/ipam/api-cli/set-ip-reverse.mdx
@@ -1,0 +1,55 @@
+---
+meta:
+  title: Setting a reverse IPv6 DNS record via the IPAM API
+  description: This page explains how to set a reverse DNS record for an IPv6 address via the IPAM API
+content:
+  h1: Setting a reverse IPv6 DNS record via the IPAM API
+  paragraph: This page explains how to set a reverse DNS record for an IPv6 address via the IPAM API
+tags: ipv6 reverse dns instance eui-64
+categories:
+  - network
+dates:
+  validation: 2025-03-19
+  posted: 2025-03-19
+---
+
+The Scaleway console allows you to [configure reverse DNS](/instances/how-to/configure-reverse-dns/) for flexible IP addresses.
+
+For IPv4 addresses, the console functionality is convenient. However, for IPv6 addresses the console only allows you to configure a single reverse DNS record for the entire /64 block, and not individual addresses within the block.
+
+You can solve this problem by using the IPAM API to set reverse DNS for individual addresses within your IPv6 block. IPAM is Scaleway's IP Address Manager tool, which acts as a single source of truth for all Scaleway IP addresses.
+
+<Macro id="requirements" />
+
+- A Scaleway account logged into the [console](https://console.scaleway.com)
+- [Owner](/iam/concepts/#owner) status or [IAM permissions](/iam/concepts/#permission) allowing you to perform actions in the intended Organization
+- A public IPv6 address for an IPAM-compatible Scaleway resource (e.g an Instance)
+
+Use the [update an IP](https://www.scaleway.com/en/developers/api/ipam/#path-ips-update-an-ip) call to set the reverse of the desired IPv6 addresses. An example call is shown below. Replace `<ip-id>` with your flexible IPv6 address's IP ID, and modify the payload according to the domains and addresses you want to configure.
+
+<Message type="tip">
+To find the IP ID for your address, use the [IPAM: List IPs](https://www.scaleway.com/en/developers/api/ipam/#path-ips-list-existing-ips) call.
+</Message>
+
+```
+curl -X PATCH \
+  -H "X-Auth-Token: $SCW_SECRET_KEY" \
+  -H "Content-Type: application/json" \
+  "https://api.scaleway.com/ipam/v1/regions/fr-par/ips/{ip_id}" \
+  -d '{
+    "reverses":[
+        {
+          "hostname":"reverse1.example.com",
+          "address":"2001:bc8:710:5c6f::1"
+        },
+        {
+          "hostname":"reverse2.example.com",
+          "address":"2001:bc8:710:5c6f::2"
+        },
+        {
+          "hostname":"reverse3.example.com",
+          "address":"2001:bc8:710:5c6f::3"
+        }
+    ]
+  }'
+```

--- a/pages/ipam/api-cli/set-ip-reverse.mdx
+++ b/pages/ipam/api-cli/set-ip-reverse.mdx
@@ -40,15 +40,15 @@ curl -X PATCH \
     "reverses":[
         {
           "hostname":"reverse1.example.com",
-          "address":"2001:bc8:710:5c6f::1"
+          "address":"2001:db8::1"
         },
         {
           "hostname":"reverse2.example.com",
-          "address":"2001:bc8:710:5c6f::2"
+          "address":"2001:db8::2"
         },
         {
           "hostname":"reverse3.example.com",
-          "address":"2001:bc8:710:5c6f::3"
+          "address":"2001:db8::3"
         }
     ]
   }'


### PR DESCRIPTION
Add doc for how to configure reverse IPv6 DNS via IPAM, after request from Instances team based on support tickets and IEs