### PR TITLE
docs(cockpit): fix k8s-monitoring Chart version ext-fix-cockpit

### DIFF
--- a/pages/cockpit/how-to/send-logs-from-k8s-to-cockpit.mdx
+++ b/pages/cockpit/how-to/send-logs-from-k8s-to-cockpit.mdx
@@ -88,7 +88,9 @@ Once you have configured your `values.yml` file, you can use Helm to deploy the 
 1. [Connect](/kubernetes/how-to/connect-cluster-kubectl/) `kubectl` to your Kubernetes cluster
 2. Run the command below to install the `k8s-monitoring` Helm chart:
     ```
-    helm install -f /your-path/to/values.yml name-of-your-choice-for-your-log-ingester k8s-monitoring --version 1.6.16
+    helm repo add grafana https://grafana.github.io/helm-charts
+    helm repo update
+    helm install -f /your-path/to/values.yml name-of-your-choice-for-your-log-ingester grafana/k8s-monitoring --version 2.0.21
     ```
       The `-f` flag specifies the path to your `values.yml` file, which contains the configuration for the Helm chart. Make sure that you replace `/your-path/to/values.yml` with the correct path where your `values.yml` file is stored. Make sure that you also replace `name-of-your-choice-for-your-log-ingester` with a clear name (ex. `alloy-logs-ingester`). In our configuration, we are using `alloy-lm-ingester`.
       Helm installs the `k8s-monitoring` chart, which includes the Alloy DaemonSet configured to collect logs from your Kubernetes cluster.

--- a/pages/cockpit/how-to/send-metrics-from-k8s-to-cockpit.mdx
+++ b/pages/cockpit/how-to/send-metrics-from-k8s-to-cockpit.mdx
@@ -148,7 +148,9 @@ Once you have configured your `values.yml` file, you can use Helm to deploy the 
 1. [Connect](/kubernetes/how-to/connect-cluster-kubectl/) `kubectl` to your Kubernetes cluster
 2. Run the command below to install the `k8s-monitoring` Helm chart:
     ```
-    helm install -f /your-path/to/values.yml name-of-your-choice-for-your-metric-ingester k8s-monitoring --version 1.6.16
+    helm repo add grafana https://grafana.github.io/helm-charts
+    helm repo update
+    helm install -f /your-path/to/values.yml name-of-your-choice-for-your-metric-ingester grafana/k8s-monitoring --version 2.0.21
     ```
       The `-f` flag specifies the path to your `values.yml` file, which contains the configuration for the Helm chart. Make sure that you replace `/your-path/to/values.yml` with the correct path where your `values.yml` file is stored. Make sure that you also replace `name-of-your-choice-for-your-metric-ingester` with a clear name (ex. `alloy-metrics-ingester`). In our configuration, we are using `alloy-lm-ingester`.
       Helm installs the `k8s-monitoring` chart, which includes the Alloy DaemonSet configured to collect metrics from your Kubernetes cluster.


### PR DESCRIPTION
ext-fix-cockpit

### Your checklist for this pull request

- [X] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

The k8s-monitoring config proposed only works with v2.x, so we should suggest to install the 2.x Helm Chart, otherwise the installation will fail.
