### PR TITLE
docs(serverless): fix missing parameters to Handle function signature in Go example int-fix-serverless

### DIFF
--- a/pages/serverless-functions/how-to/package-function-dependencies-in-zip.mdx
+++ b/pages/serverless-functions/how-to/package-function-dependencies-in-zip.mdx
@@ -183,7 +183,7 @@ The example above will create a `.zip` archive that contains the myFunction fold
     .
     ├── go.mod
     ├── go.sum
-    └── handler.go → package handler with func Handle()
+    └── handler.go → package handler with func Handle(w http.ResponseWriter, r *http.Request)
 
     ```
 


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

It was confusing as examples in other languages show the parameters
