### PR TITLE
fix(vpc): add troubleshooting info for dns

### DIFF
--- a/pages/vpc/how-to/attach-resources-to-pn.mdx
+++ b/pages/vpc/how-to/attach-resources-to-pn.mdx
@@ -150,7 +150,7 @@ If you do not see an IP address in the screens above for your resource, and you 
 
 In addition to using its IP address, you can also access a resource on a Private Network via its hostname, thanks to VPC's inbuilt [private DNS](/vpc/concepts/#dns).
 
-A resource's hostname is equivalent to the name you gave the resource when creating it. For example, if you have an Instance with the name `instance123` attached to a Private Network named `prodpn`, its address on that network is `instance123.prodpn.internal`.
+A resource's hostname is equivalent to the name you gave the resource when creating it. For example, if you have an Instance with the name `instance123` attached to a Private Network named `prodpn`, its address on that network is `instance123.prodpn.internal`. The `.internal` is important to allow Scaleway DNS to distinguish public and private hostnames.
 
 For full information on Scaleway internal DNS and hostname formats, including troubleshooting advice, see our [dedicated documentation](/vpc/reference-content/dns/).
 

--- a/pages/vpc/troubleshooting/private-dns-dhcp-not-working.mdx
+++ b/pages/vpc/troubleshooting/private-dns-dhcp-not-working.mdx
@@ -19,7 +19,7 @@ There are some cases when a Private Network's private DNS or DHCP may not work '
 
 - Make sure that [DHCP is activated](/vpc/how-to/activate-dhcp/) on your Private Network.
 - Ensure that you have tried [detaching/reattaching](/vpc/troubleshooting/resource-attached-no-ip/#no-ip-address-is-displayed-but-i-have-activated-dhcp) the affected resources from/to the Private Network, particularly if they are older resources or you have [changed their name](/vpc/how-to/attach-resources-to-pn/#how-to-access-a-resource-on-a-private-network-via-its-hostname-dns).
-- Ensure that you are addressing resources attached to a Private Network with the correct format of hostname: `resource-name.private-network-name.internal`. The `.internal` is important to allow Scaleway DNS to distinguish public and private hostnames and correctly resolve requests. [Find out more about DNS](/vpc/reference-content/dns.mdx).
+- Ensure that you are correctly addressing resources attached to a Private Network, using the format `resource-name.private-network-name.internal`. The `.internal` is important to allow Scaleway DNS to distinguish public and private hostnames and correctly resolve requests. [Find out more about DNS](/vpc/reference-content/dns.mdx).
 
 ## Resources with a dot in their hostname
 

--- a/pages/vpc/troubleshooting/private-dns-dhcp-not-working.mdx
+++ b/pages/vpc/troubleshooting/private-dns-dhcp-not-working.mdx
@@ -19,6 +19,7 @@ There are some cases when a Private Network's private DNS or DHCP may not work '
 
 - Make sure that [DHCP is activated](/vpc/how-to/activate-dhcp/) on your Private Network.
 - Ensure that you have tried [detaching/reattaching](/vpc/troubleshooting/resource-attached-no-ip/#no-ip-address-is-displayed-but-i-have-activated-dhcp) the affected resources from/to the Private Network, particularly if they are older resources or you have [changed their name](/vpc/how-to/attach-resources-to-pn/#how-to-access-a-resource-on-a-private-network-via-its-hostname-dns).
+- Ensure that you are addressing resources attached to a Private Network with the correct format of hostname: `resource-name.private-network-name.internal`. The `.internal` is important to allow Scaleway DNS to distinguish public and private hostnames and correctly resolve requests. [Find out more about DNS](/vpc/reference-content/dns.mdx).
 
 ## Resources with a dot in their hostname
 

--- a/pages/vpc/troubleshooting/private-dns-dhcp-not-working.mdx
+++ b/pages/vpc/troubleshooting/private-dns-dhcp-not-working.mdx
@@ -19,7 +19,7 @@ There are some cases when a Private Network's private DNS or DHCP may not work '
 
 - Make sure that [DHCP is activated](/vpc/how-to/activate-dhcp/) on your Private Network.
 - Ensure that you have tried [detaching/reattaching](/vpc/troubleshooting/resource-attached-no-ip/#no-ip-address-is-displayed-but-i-have-activated-dhcp) the affected resources from/to the Private Network, particularly if they are older resources or you have [changed their name](/vpc/how-to/attach-resources-to-pn/#how-to-access-a-resource-on-a-private-network-via-its-hostname-dns).
-- Ensure that you are correctly addressing resources attached to a Private Network, using the format `resource-name.private-network-name.internal`. The `.internal` is important to allow Scaleway DNS to distinguish public and private hostnames and correctly resolve requests. [Find out more about DNS](/vpc/reference-content/dns.mdx).
+- Ensure that you are correctly addressing resources attached to a Private Network, using the format `resource-name.private-network-name.internal`. The `.internal` is important to allow Scaleway DNS to distinguish public and private hostnames and correctly resolve requests. [Find out more about DNS](/vpc/reference-content/dns/).
 
 ## Resources with a dot in their hostname
 


### PR DESCRIPTION
Based on user feedback from the Scaleway Community Slack, add a mention of the .internal part of private network resource hostnames to troubleshooting.