### PR TITLE
feat(cockpit): retention updates

### DIFF
--- a/changelog/may2024/2024-05-24-cockpit-added-cockpit-available-in-all-region.mdx
+++ b/changelog/may2024/2024-05-24-cockpit-added-cockpit-available-in-all-region.mdx
@@ -9,5 +9,5 @@ category: observability
 product: cockpit
 ---
 
-Cockpit is now available in all three Scaleway regions: Paris, Amsterdam, and Warsaw. From the Scaleway console, you can now decide in which region to enable the [alert manager](/cockpit/concepts/#alert-manager) and your [preconfigured alerts](/cockpit/concepts/#preconfigured-alerts). You can also choose the regions in which to create your [data types](/cockpit/concepts/#data-types), [data sources](/cockpit/concepts/#data-sources), and [tokens](/cockpit/concepts/#tokens).
+Cockpit is now available in all three Scaleway regions: Paris, Amsterdam, and Warsaw. From the Scaleway console, you can now decide in which region to enable the [alert manager](/cockpit/concepts/#alert-manager) and your [preconfigured alerts](/cockpit/concepts/#preconfigured-alerts). You can also choose the regions in which to create your [data types](/cockpit/concepts/#data-types), [data sources](/cockpit/concepts/#data-sources), and [tokens](/cockpit/concepts/#cockpit-tokens).
 

--- a/macros/cockpit/plan-deprecation.mdx
+++ b/macros/cockpit/plan-deprecation.mdx
@@ -4,9 +4,13 @@ macro: cockpit-plan-deprecation
 
 <Message type="important">
 
- **Cockpit pricing plans were deprecated on January 1st 2025** <br /><br />
+ **Pricing update for Cockpit data custom retention** <br /><br />
 
- The [retention](/cockpit/concepts/#retention) period previously set for your Scaleway and custom logs, metrics and traces remains the same. <br /><br />
- You can change the retention period for your metrics, logs, and traces for free during the retention period edition beta (starting January 1st 2025). <br /><br />
- Find out [how to change data retention period](/cockpit/how-to/change-data-retention/) in the dedicated documentation.
+ On January 1st, 2025, Cockpit pricing plans were deprecated and replaced by the custom [retention](/cockpit/concepts/#retention) feature, available for free during beta.
+ On May 1st, 2025, this feature reaches general availability and becomes billable.
+
+ **Logs and traces**: free retention for 7 days, then charged €0.002/GB/day
+ **Metrics**: free retention for 31 days, then charged €0.0002/10 million samples/day
+
+ Refer to the [dedicated documentation](/cockpit/how-to/change-data-retention/) to adjust retention settings and learn more about new pricing.
 </Message>

--- a/macros/cockpit/plan-deprecation.mdx
+++ b/macros/cockpit/plan-deprecation.mdx
@@ -2,15 +2,18 @@
 macro: cockpit-plan-deprecation
 ---
 
-<Message type="important">
+<Message type="note">
 
  **Pricing update for Cockpit data custom retention** <br /><br />
 
  On January 1st, 2025, Cockpit pricing plans were deprecated and replaced by the custom [retention](/cockpit/concepts/#retention) feature, available for free during beta.
- On May 1st, 2025, this feature reaches general availability and becomes billable.
+ On May 1st, 2025, this feature reaches general availability and **becomes billable**. <br /><br />
 
- **Logs and traces**: free retention for 7 days, then charged €0.002/GB/day
+ **Logs and traces**: free retention for 7 days, then charged €0.002/GB/days
+
  **Metrics**: free retention for 31 days, then charged €0.0002/10 million samples/day
 
- Refer to the [dedicated documentation](/cockpit/how-to/change-data-retention/) to adjust retention settings and learn more about new pricing.
+ Custom data ingestion remains billable at [the current pricing](/cockpit/faq/#how-am-i-billed-for-using-cockpit-with-custom-data).
+
+ Refer to the [dedicated documentation](/cockpit/how-to/change-data-retention/) to adjust retention settings.
 </Message>

--- a/macros/cockpit/plan-deprecation.mdx
+++ b/macros/cockpit/plan-deprecation.mdx
@@ -4,16 +4,16 @@ macro: cockpit-plan-deprecation
 
 <Message type="note">
 
- **Pricing update for Cockpit data custom retention** <br /><br />
+ **Pricing update for Cockpit custom retention** <br /><br />
 
  On January 1st, 2025, Cockpit pricing plans were deprecated and replaced by the custom [retention](/cockpit/concepts/#retention) feature, available for free during beta.
  On May 1st, 2025, this feature reaches general availability and **becomes billable**. <br /><br />
 
- **Logs and traces**: free retention for 7 days, then charged €0.002/GB/days
+ **Logs and traces**: free retention for 7 days, then charged €0.002/GB/day
 
  **Metrics**: free retention for 31 days, then charged €0.0002/10 million samples/day
 
- Custom data ingestion remains billable at [the current pricing](/cockpit/faq/#how-am-i-billed-for-using-cockpit-with-custom-data).
+ Ingestion of custom data remains billable at [the current pricing](/cockpit/faq/#how-am-i-billed-for-using-cockpit-with-custom-data).
 
  Refer to the [dedicated documentation](/cockpit/how-to/change-data-retention/) to adjust retention settings.
 </Message>

--- a/pages/cockpit/concepts.mdx
+++ b/pages/cockpit/concepts.mdx
@@ -7,7 +7,7 @@ content:
   paragraph: Explore Scaleway Observability concepts including metrics, logs, and alerts management through Cockpit. Learn about agents, alerting rules, Grafana integration, and data types for comprehensive monitoring.
 tags: observability alert-manager contact-points endpoint grafana loki logql prometheus promql tokens
 dates:
-  validation: 2024-12-26
+  validation: 2025-04-03
 categories:
   - observability
 ---
@@ -138,7 +138,7 @@ You can decide in which region to enable the [alert manager](#alert-manager) and
 
 ## Retention
 
-Retention or data retention refers to the duration for which data, such as metrics, logs, or traces, is stored before being automatically deleted. Retention allows you to manage the lifecycle of your Scaleway and custom data by selecting storage periods that align with your needs.
+Retention or data retention refers to the duration for which the data (metrics, logs, and traces) you push to Cockpit is stored before being automatically deleted. Retention allows you to manage the lifecycle of your Scaleway and custom data by selecting storage periods that align with your needs.
 
 The minimum and maximum retention periods for each data source type are as follows:
 

--- a/pages/cockpit/concepts.mdx
+++ b/pages/cockpit/concepts.mdx
@@ -44,6 +44,15 @@ Alerting rules allow you to define criteria that determine whether an alert is t
 
 A Cockpit is an instance of the Observability product that stores metrics, logs, and traces and provides a dedicated dashboarding system on Grafana to visualize them. A Scaleway Project can have only one Cockpit, which is automatically activated when you are using [Scaleway resources that are integrated into Cockpit](/cockpit/reference-content/cockpit-limitations/#product-integration-into-cockpit).
 
+## Cockpit tokens
+
+Tokens are regionalized secret keys that allow you to authenticate against the endpoints of your Cockpit's datasources (metrics, logs, alerts). You can generate new tokens and select token permissions such as:
+
+- **Push**: allows you to send your metrics, logs, and traces to your Cockpit.
+- **Query**: allows you to fetch your metrics, logs, and traces from your Cockpit.
+- **Rules**: allow you to configure alerting and recording rules.
+- **Alerts**: allow you to set up the alert manager.
+
 ## Contact points
 
 Contact points define who is notified when an alert fires, according to the region in which you have added them. Contact points include emails, Slack, on-call systems, and texts. When an alert fires, all contact points are notified.
@@ -168,15 +177,6 @@ Scaleway only supports the OpenTelemetry HTTP push path.
 ## Time series
 
 A time series is a sequence of numerical data points in successive order, that tracks the value of a parameter over time. Example of parameter: the disk usage of a machine hosting a database, expressed in percentage.
-
-## Cockpit tokens
-
-Tokens are regionalized secret keys that allow you to authenticate against the endpoints of your Cockpit's datasources (metrics, logs, alerts). You can generate new tokens and select token permissions such as:
-
-- **Push**: allows you to send your metrics, logs, and traces to your Cockpit.
-- **Query**: allows you to fetch your metrics, logs, and traces from your Cockpit.
-- **Rules**: allow you to configure alerting and recording rules.
-- **Alerts**: allow you to set up the alert manager.
 
 ## Traces
 

--- a/pages/cockpit/concepts.mdx
+++ b/pages/cockpit/concepts.mdx
@@ -145,8 +145,10 @@ The minimum and maximum retention periods for each data source type are as follo
 | Custom metrics                                 | Custom logs/traces                           | Scaleway metrics                               | Scaleway logs/traces                          |
 |------------------------------------------------|----------------------------------------------|------------------------------------------------|-----------------------------------------------|
 | Minimum retention period: 1 day                | Minimum retention period: 1 day              | Minimum retention period: 31 days              | Minimum retention period: 1 day               |
-| Maximum retention period: 1825 days (5 years)  | Maximum retention period: 1825 days (5 years)| Maximum retention period: 1825 days (5 years)  | Maximum retention period: 1825 days (5 years) |
+| Maximum retention period: 365 days (1 year)  | Maximum retention period: 365 days (1 year)| Maximum retention period: 365 days (1 year)  | Maximum retention period: 365 days (1 year) |
 | Default retention period: 31 days              | Default retention period: 7 days             | Default retention period: 31 days              | Default retention period: 7 days              |
+
+**Starting May 1, 2025, the maximum retention period for custom and Scaleway metrics, logs and traces will be of 1825 days (5 years)**. The information on the table above will be updated accordingly.
 
 ## Samples
 

--- a/pages/cockpit/concepts.mdx
+++ b/pages/cockpit/concepts.mdx
@@ -154,7 +154,7 @@ The minimum and maximum retention periods for each data source type are as follo
 | Retention period  | Custom metrics    | Custom logs/traces | Scaleway metrics  | Scaleway logs/traces |
 |-------------------|-------------------|--------------------|-------------------|----------------------|
 | Minimum retention | 1 day             | 1 days             | 31 days           | 1 day                |
-| Maximum retention | 365 days (1 year) | 365 days (1 year)  | 365 days (1 year) | 365 days (1 year)    |
+| Maximum retention | 365 days (1 year) | 31 days            | 365 days (1 year) | 31 days              |
 | Default retention | 31 days           | 7 days             | 31 days           | 7 days               |
 
 **Starting May 1, 2025, the maximum retention period for custom and Scaleway metrics, logs and traces will be of 1825 days (5 years)**. The information on the table above will be updated accordingly.

--- a/pages/cockpit/concepts.mdx
+++ b/pages/cockpit/concepts.mdx
@@ -138,15 +138,15 @@ You can decide in which region to enable the [alert manager](#alert-manager) and
 
 ## Retention
 
-Retention or data retention refers to the duration for which the data (metrics, logs, and traces) you push to Cockpit is stored before being automatically deleted. Retention allows you to manage the lifecycle of your Scaleway and custom data by selecting storage periods that align with your needs.
+Retention or data retention refers to the duration for which the data (metrics, logs, and traces) pushed to Cockpit (by Scaleway products or yourself) is stored before being automatically deleted. Retention allows you to manage the lifecycle of your Scaleway and custom data by selecting storage periods that align with your needs.
 
 The minimum and maximum retention periods for each data source type are as follows:
 
-| Custom metrics                                 | Custom logs/traces                           | Scaleway metrics                               | Scaleway logs/traces                          |
-|------------------------------------------------|----------------------------------------------|------------------------------------------------|-----------------------------------------------|
-| Minimum retention period: 1 day                | Minimum retention period: 1 day              | Minimum retention period: 31 days              | Minimum retention period: 1 day               |
-| Maximum retention period: 365 days (1 year)  | Maximum retention period: 365 days (1 year)| Maximum retention period: 365 days (1 year)  | Maximum retention period: 365 days (1 year) |
-| Default retention period: 31 days              | Default retention period: 7 days             | Default retention period: 31 days              | Default retention period: 7 days              |
+| Retention period  | Custom metrics    | Custom logs/traces | Scaleway metrics  | Scaleway logs/traces |
+|-------------------|-------------------|--------------------|-------------------|----------------------|
+| Minimum retention | 1 day             | 1 days             | 31 days           | 1 day                |
+| Maximum retention | 365 days (1 year) | 365 days (1 year)  | 365 days (1 year) | 365 days (1 year)    |
+| Default retention | 31 days           | 7 days             | 31 days           | 7 days               |
 
 **Starting May 1, 2025, the maximum retention period for custom and Scaleway metrics, logs and traces will be of 1825 days (5 years)**. The information on the table above will be updated accordingly.
 
@@ -157,7 +157,7 @@ A sample is a unique measuring point on a time series.
 ## Scaleway data
 
 Scaleway data is the observability data (metrics and/or logs) that is natively collected by all Scaleway products, integrated with Cockpit.
-Refer to the dedicated documentation page to find out which resources are integrated with Cockpit.
+Refer to the [dedicated documentation page](/cockpit/reference-content/cockpit-limitations/#product-integration-into-cockpit) to find out which resources are integrated with Cockpit.
 
 ## Tempo
 
@@ -171,7 +171,7 @@ A time series is a sequence of numerical data points in successive order, that t
 
 ## Cockpit tokens
 
-Tokens are regionalized secret keys that allow you to authenticate against your Cockpit's endpoints (metrics, logs, alerts). You can generate new tokens and select token permissions such as:
+Tokens are regionalized secret keys that allow you to authenticate against the endpoints of your Cockpit's datasources (metrics, logs, alerts). You can generate new tokens and select token permissions such as:
 
 - **Push**: allows you to send your metrics, logs, and traces to your Cockpit.
 - **Query**: allows you to fetch your metrics, logs, and traces from your Cockpit.

--- a/pages/cockpit/concepts.mdx
+++ b/pages/cockpit/concepts.mdx
@@ -56,6 +56,10 @@ A Cockpit is an instance of the Observability product that stores metrics, logs,
 
 Contact points define who is notified when an alert fires, according to the region in which you have added them. Contact points include emails, Slack, on-call systems, and texts. When an alert fires, all contact points are notified.
 
+## Custom data
+
+Custom data is any data (metrics, logs or traces) that you may push to Cockpit. It can be data collected from your applications hosted at Scaleway or elsewhere.
+
 ## Data sources
 
 Data sources are regionalized backends that allow you to store and fetch your metrics, logs, and traces. By default, **Scaleway data sources** are enabled if you are using [Scaleway resources integrated with Cockpit](/cockpit/reference-content/cockpit-limitations/#product-integration-into-cockpit) on your Project.
@@ -102,14 +106,6 @@ A Grafana user is any individual who can log in to [Grafana](https://grafana.com
 
 Loki is the log aggregation system used by [Grafana](https://grafana.com/docs/grafana/latest/introduction/) to store and query your logs.
 
-## Loki Remote Write
-
-`Loki Remote Write` is the protocol used to push your logs to your Cockpit's logs' endpoint.
-
-## LogQL
-
-LogQL is [Grafana Loki’s language](https://grafana.com/docs/loki/latest/logql/) for querying logs. LogQL uses labels and operators for filtering.
-
 ## Logs
 
 Logs are a data type that provides a record of all events and errors taking place during the lifecycle of your resources. They represent an excellent source of visibility if you want to know when a problem occurred, or which events correlate with it.
@@ -142,10 +138,6 @@ A preconfigured dashboard is a set of one or more panels that Scaleway sets up a
 
 `Prometheus Remote Write` is the protocol used to push your metrics to your Cockpit's metrics' endpoint.
 
-## PromQL
-
-PromQL, short for Prometheus Querying Language, is the main way to query metrics within Prometheus. It is designed for building queries for graphs and alerts.
-
 ## Receivers
 
 Receivers are hubs consisting of contact points. You can associate one or several alerts with one or more receivers. This allows you to diversify your alerts.
@@ -166,22 +158,27 @@ Retention or data retention refers to the duration for which data, such as metri
 
 The minimum and maximum retention periods for each data source type are as follows:
 
-| Custom metrics                                 | Custom logs/traces                          | Scaleway metrics                               | Scaleway logs/traces                        |
-|------------------------------------------------|---------------------------------------------|------------------------------------------------|---------------------------------------------|
-| Minimum retention period: 1 day                | Minimum retention period: 1 day             | Minimum retention period: 31 days              | Minimum retention period: 1 day             |
-| Maximum retention period: 365 days (12 months) | Maximum retention period: 31 days (1 month) | Maximum retention period: 365 days (12 months) | Maximum retention period: 31 days (1 month) |
-| Default retention period: 31 days              | Default retention period: 7 days            | Default retention period: 31 days              | Default retention period: 7 days            |
+| Custom metrics                                 | Custom logs/traces                           | Scaleway metrics                               | Scaleway logs/traces                          |
+|------------------------------------------------|----------------------------------------------|------------------------------------------------|-----------------------------------------------|
+| Minimum retention period: 1 day                | Minimum retention period: 1 day              | Minimum retention period: 31 days              | Minimum retention period: 1 day               |
+| Maximum retention period: 1825 days (5 years)  | Maximum retention period: 1825 days (5 years)| Maximum retention period: 1825 days (5 years)  | Maximum retention period: 1825 days (5 years) |
+| Default retention period: 31 days              | Default retention period: 7 days             | Default retention period: 31 days              | Default retention period: 7 days              |
 
 ## Samples
 
 A sample is a unique measuring point on a time series.
+
+## Scaleway data
+
+Scaleway data is the observability data (metrics and/or logs) that is natively collected by all Scaleway products, integrated with Cockpit.
+Refer to the dedicated documentation page to find out which resources are integrated with Cockpit.
 
 ## Tempo
 
 Tempo is [Grafana's open source](https://grafana.com/docs/tempo/latest/) tracing tool that allows you to search for traces, generate metrics from them, and link your tracing data with logs and metrics. Tempo can be used with open-source tracing protocols such as [Jaeger](https://www.jaegertracing.io/docs/1.50/), [Zipkin](https://zipkin.io/), and [OpenTelemetry](https://opentelemetry.io/docs/what-is-opentelemetry/).
 
 <Message type="important">
- During the beta of the traces feature, only the [OpenTelemetry](https://opentelemetry.io/docs/what-is-opentelemetry/) HTTP push path is supported. Scaleway is working on implementing the [Open Telemetry gRPC](https://opentelemetry.io/docs/specs/semconv/rpc/grpc/), [Zipkin](https://zipkin.io/) and [Jaeger](https://www.jaegertracing.io/docs/1.50/) protocols.
+ Only the [OpenTelemetry](https://opentelemetry.io/docs/what-is-opentelemetry/) HTTP push path is supported. Scaleway is working on implementing the [Open Telemetry gRPC](https://opentelemetry.io/docs/specs/semconv/rpc/grpc/), [Zipkin](https://zipkin.io/) and [Jaeger](https://www.jaegertracing.io/docs/1.50/) protocols.
 </Message>
 
 ## Time series
@@ -196,10 +193,6 @@ Tokens are regionalized secret keys that allow you to authenticate against your 
 - **Query**: allows you to fetch your metrics, logs, and traces from your Cockpit.
 - **Rules**: allow you to configure alerting and recording rules.
 - **Alerts**: allow you to set up the alert manager.
-
-## TraceQL
-
-[TraceQL](https://grafana.com/docs/tempo/latest/traceql/) is Grafana Tempo's query language designed for searching and extracting traces.
 
 ## Traces
 

--- a/pages/cockpit/concepts.mdx
+++ b/pages/cockpit/concepts.mdx
@@ -12,10 +12,6 @@ categories:
   - observability
 ---
 
-## Active series
-
-Active series refer to [time series](#time-series) for which the latest [samples](#samples) received by your Cockpit are less than 10 minutes old.
-
 ## Agent
 
 An agent is a software component that runs on your systems to gather [data types](#data-types) from the host system or applications running on it. The agent then forwards this data to Cockpit for analysis and visualization.
@@ -28,16 +24,12 @@ An agent is a software component that runs on your systems to gather [data types
 
 Alerting detects complex conditions defined by a rule and keeps you aware of issues in your environments. When a condition defined by a rule is met, the rule tracks it as an alert and responds by triggering one or more actions.
 
-<Message type="important">
- The **Grafana alert manager** on the Grafana interface is inactive. We strongly recommend that you select the **Scaleway Alerting** alert manager if you want to manage your alerts using Grafana.
-</Message>
-
 ## Alert manager
 
 Scaleway's regionalized alert manager allows you to manage and respond to alerts according to the regions you have enabled it in. It handles alerts sent when the alerting rules we run are firing. The alert manager triggers alerts (e.g. emails or texts) if a criteria you have configured on your applications' metrics and logs is activated.
 
 <Message type="important">
- The **Grafana alert manager** on the Grafana interface is inactive. We strongly recommend that you select the **Scaleway Alerting** alert manager if you want to manage your alerts using Grafana.
+ Scaleway does not support the **Grafana alert manager** on the Grafana interface. You must select the **Scaleway Alerting** alert manager if you want to manage your alerts using Grafana.
 </Message>
 
 ## Alerting rules
@@ -134,17 +126,9 @@ You can push metrics with any Prometheus-compatible agent such as [Prometheus](h
 
 A preconfigured dashboard is a set of one or more panels that Scaleway sets up and updates for you to visualize the metrics and logs associated with your Scaleway products.
 
-## Prometheus Remote Write
-
-`Prometheus Remote Write` is the protocol used to push your metrics to your Cockpit's metrics' endpoint.
-
 ## Receivers
 
 Receivers are hubs consisting of contact points. You can associate one or several alerts with one or more receivers. This allows you to diversify your alerts.
-
-## Recording rules
-
-Recording rules allow you to precompute frequently needed or computationally expensive expressions and save their results as a new set of time series.
 
 ## Region
 
@@ -177,15 +161,13 @@ Refer to the dedicated documentation page to find out which resources are integr
 
 Tempo is [Grafana's open source](https://grafana.com/docs/tempo/latest/) tracing tool that allows you to search for traces, generate metrics from them, and link your tracing data with logs and metrics. Tempo can be used with open-source tracing protocols such as [Jaeger](https://www.jaegertracing.io/docs/1.50/), [Zipkin](https://zipkin.io/), and [OpenTelemetry](https://opentelemetry.io/docs/what-is-opentelemetry/).
 
-<Message type="important">
- Only the [OpenTelemetry](https://opentelemetry.io/docs/what-is-opentelemetry/) HTTP push path is supported. Scaleway is working on implementing the [Open Telemetry gRPC](https://opentelemetry.io/docs/specs/semconv/rpc/grpc/), [Zipkin](https://zipkin.io/) and [Jaeger](https://www.jaegertracing.io/docs/1.50/) protocols.
-</Message>
+Scaleway only supports the OpenTelemetry HTTP push path.
 
 ## Time series
 
 A time series is a sequence of numerical data points in successive order, that tracks the value of a parameter over time. Example of parameter: the disk usage of a machine hosting a database, expressed in percentage.
 
-## Tokens
+## Cockpit tokens
 
 Tokens are regionalized secret keys that allow you to authenticate against your Cockpit's endpoints (metrics, logs, alerts). You can generate new tokens and select token permissions such as:
 

--- a/pages/cockpit/concepts.mdx
+++ b/pages/cockpit/concepts.mdx
@@ -151,7 +151,7 @@ Retention or data retention refers to the duration for which the data (metrics, 
 
 The minimum and maximum retention periods for each data source type are as follows:
 
-| Retention period  | Custom metrics    | Custom logs/traces | Scaleway metrics  | Scaleway logs/traces |
+| Retention period  | Custom metrics    | Custom logs/traces | Scaleway metrics  | Scaleway logs        |
 |-------------------|-------------------|--------------------|-------------------|----------------------|
 | Minimum retention | 1 day             | 1 days             | 31 days           | 1 day                |
 | Maximum retention | 365 days (1 year) | 31 days            | 365 days (1 year) | 31 days              |

--- a/pages/cockpit/concepts.mdx
+++ b/pages/cockpit/concepts.mdx
@@ -46,7 +46,7 @@ A Cockpit is an instance of the Observability product that stores metrics, logs,
 
 ## Cockpit tokens
 
-Tokens are regionalized secret keys that allow you to authenticate against the endpoints of your Cockpit's datasources (metrics, logs, alerts). You can generate new tokens and select token permissions such as:
+Tokens are regionalized secret keys that allow you to authenticate against the endpoints of your Cockpit's [data sources](#data-sources) (metrics, logs, alerts). You can generate new tokens and select token permissions such as:
 
 - **Push**: allows you to send your metrics, logs, and traces to your Cockpit.
 - **Query**: allows you to fetch your metrics, logs, and traces from your Cockpit.

--- a/pages/cockpit/faq.mdx
+++ b/pages/cockpit/faq.mdx
@@ -23,25 +23,27 @@ Cockpit integrates seamlessly with Scaleway’s ecosystem. It provides pre-built
 
 Refer to the [dedicated documentation page](/cockpit/reference-content/cockpit-limitations/#product-integration-into-cockpit) for the whole list of Scaleway resources integrated with Cockpit.
 
-## What is Scaleway data?
+## What is the difference between Scaleway and custom data?
+
+### Scaleway data
 
 Scaleway data is the observability data (metrics and/or logs) that is natively collected by all [Scaleway products integrated with Cockpit](/cockpit/reference-content/cockpit-limitations/#product-integration-into-cockpit).
+
+### Custom data
+
+Custom data refers to any metrics, logs, or traces that you manually push to Cockpit. This can include data from applications hosted at Scaleway or any other platform.
 
 ## How am I billed for using Cockpit with my Scaleway data?
 
 Scaleway data is collected and available in Cockpit for free. Retention is also free as long as it stays within the default period: 31 days for metrics and 7 days for logs and traces.
 
-You can [adjust the retention period](/cockpit/how-to/change-data-retention) from 1 day to 5 years. However, starting May 1, 2025, data stored beyond the default period will incur charges based on daily storage volume.
-
-Sending custom data to Cockpit (such as data from non-integrated Scaleway resources or external sources) also incurs additional costs.
-
-## What is custom data?
-
-Custom data refers to any metrics, logs, or traces that you manually push to Cockpit. This can include data from applications hosted at Scaleway or any other platform.
+You can [adjust the retention period](/cockpit/how-to/change-data-retention) from 1 day (for logs and traces) or 31 days (for metrics) to 1 year. Refer to the [dedicated documentation](/cockpit/concepts/#retention) for more information on available retention periods. However, starting May 1, 2025, data stored beyond the default period will incur charges based on daily storage volume.
 
 ## How am I billed for using Cockpit with custom data?
 
-Retention of custom data is free within the default period: 31 days for custom metrics and 7 days for custom logs and traces. You can [adjust the retention period](/cockpit/how-to/change-data-retention) from 1 day to 5 years. However, starting May 1, 2025, data stored beyond the default period will be charged based on daily storage volume.
+Sending custom data to Cockpit such as data from non-integrated Scaleway resources or external sources incurs additional costs.
+
+Retention of custom data is free within the default period: 31 days for custom metrics and 7 days for custom logs and traces. You can [adjust the retention period](/cockpit/how-to/change-data-retention) from 1 day (for logs and traces) and 31 days (for metrics) to 1 year. However, starting May 1, 2025, data stored beyond the default period will be charged based on daily storage volume.
 
 Querying custom data is always free.
 
@@ -84,8 +86,6 @@ All ingested data, whether from Scaleway or custom sources, is retained for free
 - **Logs and traces:** €0.002 per GB/day
 
 If you delete your data source or reduce its retention period below the default value, data will be deleted and you will no longer be charged for extended retention.
-
-**Custom data ingestion remains billable at the current pricing**.
 
 <Concept>
   ## See custom retention pricing examples

--- a/pages/cockpit/faq.mdx
+++ b/pages/cockpit/faq.mdx
@@ -23,27 +23,35 @@ Cockpit integrates seamlessly with Scaleway’s ecosystem. It provides pre-built
 
 Refer to the [dedicated documentation page](/cockpit/reference-content/cockpit-limitations/#product-integration-into-cockpit) for the whole list of Scaleway resources integrated with Cockpit.
 
+## What is Scaleway data?
+
+Scaleway data is the observability data (metrics and/or logs) that is natively collected by all [Scaleway products integrated with Cockpit](/cockpit/reference-content/cockpit-limitations/#product-integration-into-cockpit).
+
 ## How am I billed for using Cockpit with my Scaleway data?
 
-Using Cockpit with your Scaleway data is free of charge.
+Scaleway data is collected and is available in Cockpit free of charge. Retention for Scaleway data is also free of charge as long as the retention period does not exceed the default one. The default retention period is 31 days for Scaleway metrics, and 7 days for Scaleway logs and traces.
 
-The retention period you set for your data - whether from [Scaleway resources integrated with Cockpit](/cockpit/reference-content/cockpit-limitations/#product-integration-into-cockpit) or custom data - will be free of charge.
+Your Scaleway data can be retained between 1 day and 5 years. You can change the retention period at any time. From May 1st 2025, any data retained beyond the default retention period will be charged based on the volume of data stored daily.
 
 Additional costs apply for sending custom data to Cockpit. This means that you will be billed for sending **data from Scaleway resources that are not integrated with Cockpit**, or data from any other external resources.
 
+## What is custom data?
+
+Custom data is any data (metrics, logs, and traces) that you push to Cockpit. It can be data collected from your applications hosted at Scaleway or elsewhere.
+
 ## How am I billed for using Cockpit with custom data?
 
-Custom data is any data that is external to Scaleway, or **data from Scaleway resources not integrated with Cockpit**. Refer to the [dedicated documentation page](/cockpit/reference-content/cockpit-limitations/#product-integration-into-cockpit) to find out which resources are integrated with Cockpit.
+Retention for custom data is free of charge as long as the retention period does not exceed the default one. The default retention period is 31 days for custom metrics, and 7 days for custom logs and traces.
 
-During the beta of the retention period edition feature, the retention period you set for your custom data is free of charge.
+Your custom data can be retained between 1 day and 5 years. You can change the retention period at any time. From May 1st 2025, any data retained beyond the default retention period will be charged based on the volume of data stored daily.
 
 You will not be charged for **querying** custom data.
 
-Data ingestion is billed as follows:
+Ingestion for custom data is billed as follows:
 
-- Custom metrics are billed €0.15 per million samples of metrics ingested, per month.
-- Custom logs are billed €0.35 per GB ingested, per month.
-- Custom traces are billed €0.35 per GB ingested, per month.
+- Custom metrics are billed €0.15 per million samples of metrics ingested
+- Custom logs are billed €0.35 per GB ingested
+- Custom traces are billed €0.35 per GB ingested
 
 Scaleway applies volume discounts to bill custom metrics. This means that the monthly pricing for custom metrics will be calculated in levels. **Scaleway applies six levels of volume discounts.**
 
@@ -66,6 +74,24 @@ Here is an example of how you would be billed for sending 52 billion custom metr
 - 2 billion samples at €0.11 per million samples: €220
 
 **Total:** €6.650 per month with volume discounts instead of €7.800 without volume discounts.
+
+## How am I billed for increasing data retention period?
+
+Data ingested, whether it is Scaleway or custom data, is retained for free during:
+
+- 31 days for metrics
+- 7 days for logs and traces
+
+From May 1st 2025, any data retained beyond these default values will be charged as follows based on the volume of data stored daily:
+
+- Metrics: 0.0002€/10 million samples/day
+- Logs and traces: 0.002€/GB/day
+
+If you delete your data source or reduce its retention period below the default value, data will be deleted and you will no longer be charged for extended retention.
+
+For example, if you ingest an average of 2GB of logs daily and you increase your retention period to 10 days, retention will not be charged during the first 7 days after ingestion. You will only be charged for the remaining 3 days, then your data will be deleted.
+Your estimated cost is `retention_cost` = 2 GB x (10 days - 7 days) x 0.002€ x 30 days = 0.36€/month
+If you want to store your logs for 3 months, your estimated cost is: `retention_cost` = 2 GB x (90 days - 7 days) x 0.002€ x 30 days = 9.96€/month
 
 ## Why are Cockpit pricing plans being deprecated?
 

--- a/pages/cockpit/faq.mdx
+++ b/pages/cockpit/faq.mdx
@@ -5,7 +5,7 @@ meta:
 content:
   h1: Cockpit FAQ
 dates:
-  validation: 2024-11-25
+  validation: 2025-03-27
 category: observability
 productIcon: CockpitProductIcon
 ---
@@ -27,7 +27,7 @@ Refer to the [dedicated documentation page](/cockpit/reference-content/cockpit-l
 
 Using Cockpit with your Scaleway data is free of charge.
 
-During the beta phase of the retention period edition feature, the retention period you set for your data - whether from [Scaleway resources integrated with Cockpit](/cockpit/reference-content/cockpit-limitations/#product-integration-into-cockpit) or custom data - will be free of charge.
+The retention period you set for your data - whether from [Scaleway resources integrated with Cockpit](/cockpit/reference-content/cockpit-limitations/#product-integration-into-cockpit) or custom data - will be free of charge.
 
 Additional costs apply for sending custom data to Cockpit. This means that you will be billed for sending **data from Scaleway resources that are not integrated with Cockpit**, or data from any other external resources.
 

--- a/pages/cockpit/faq.mdx
+++ b/pages/cockpit/faq.mdx
@@ -78,7 +78,7 @@ All ingested data, whether from Scaleway or custom sources, is retained for free
 - **Metrics:** 31 days
 - **Logs and traces:** 7 days
 
-Starting May 1, 2025, data retained beyond these periods will be charged based on daily storage volume:
+**Starting May 1, 2025, data retained beyond these periods will be charged** based on daily storage volume:
 
 - **Metrics:** €0.0002 per 10 million samples/day
 - **Logs and traces:** €0.002 per GB/day

--- a/pages/cockpit/faq.mdx
+++ b/pages/cockpit/faq.mdx
@@ -29,23 +29,21 @@ Scaleway data is the observability data (metrics and/or logs) that is natively c
 
 ## How am I billed for using Cockpit with my Scaleway data?
 
-Scaleway data is collected and is available in Cockpit free of charge. Retention for Scaleway data is also free of charge as long as the retention period does not exceed the default one. The default retention period is 31 days for Scaleway metrics, and 7 days for Scaleway logs and traces.
+Scaleway data is collected and available in Cockpit for free. Retention is also free as long as it stays within the default period: 31 days for metrics and 7 days for logs and traces.
 
-Your Scaleway data can be retained between 1 day and 5 years. You can change the retention period at any time. From May 1st 2025, any data retained beyond the default retention period will be charged based on the volume of data stored daily.
+You can [adjust the retention period](/cockpit/how-to/change-data-retention) from 1 day to 5 years. However, starting May 1, 2025, data stored beyond the default period will incur charges based on daily storage volume.
 
-Additional costs apply for sending custom data to Cockpit. This means that you will be billed for sending **data from Scaleway resources that are not integrated with Cockpit**, or data from any other external resources.
+Sending custom data to Cockpit (such as data from non-integrated Scaleway resources or external sources) also incurs additional costs.
 
 ## What is custom data?
 
-Custom data is any data (metrics, logs, and traces) that you push to Cockpit. It can be data collected from your applications hosted at Scaleway or elsewhere.
+Custom data refers to any metrics, logs, or traces that you manually push to Cockpit. This can include data from applications hosted at Scaleway or any other platform.
 
 ## How am I billed for using Cockpit with custom data?
 
-Retention for custom data is free of charge as long as the retention period does not exceed the default one. The default retention period is 31 days for custom metrics, and 7 days for custom logs and traces.
+Retention of custom data is free within the default period: 31 days for custom metrics and 7 days for custom logs and traces. You can [adjust the retention period](/cockpit/how-to/change-data-retention) from 1 day to 5 years. However, starting May 1, 2025, data stored beyond the default period will be charged based on daily storage volume.
 
-Your custom data can be retained between 1 day and 5 years. You can change the retention period at any time. From May 1st 2025, any data retained beyond the default retention period will be charged based on the volume of data stored daily.
-
-You will not be charged for **querying** custom data.
+Querying custom data is always free.
 
 Ingestion for custom data is billed as follows:
 
@@ -67,7 +65,6 @@ Scaleway applies volume discounts to bill custom metrics. This means that the mo
 
 Here is an example of how you would be billed for **sending 52 billion custom metrics samples per month**:
 
-Here is an example of how you would be billed for sending 52 billion custom metrics samples per month:
 - 10 billion samples at €0.15 per million samples: €1.500
 - 15 billion samples at €0.13 per million samples: €1.950
 - 25 billion samples at €0.12 per million samples: €3.000
@@ -77,21 +74,32 @@ Here is an example of how you would be billed for sending 52 billion custom metr
 
 ## How am I billed for increasing data retention period?
 
-Data ingested, whether it is Scaleway or custom data, is retained for free during:
+All ingested data, whether from Scaleway or custom sources, is retained for free within the default periods:
+- **Metrics:** 31 days
+- **Logs and traces:** 7 days
 
-- 31 days for metrics
-- 7 days for logs and traces
+Starting May 1, 2025, data retained beyond these periods will be charged based on daily storage volume:
 
-From May 1st 2025, any data retained beyond these default values will be charged as follows based on the volume of data stored daily:
-
-- Metrics: 0.0002€/10 million samples/day
-- Logs and traces: 0.002€/GB/day
+- **Metrics:** €0.0002 per 10 million samples/day
+- **Logs and traces:** €0.002 per GB/day
 
 If you delete your data source or reduce its retention period below the default value, data will be deleted and you will no longer be charged for extended retention.
 
-For example, if you ingest an average of 2GB of logs daily and you increase your retention period to 10 days, retention will not be charged during the first 7 days after ingestion. You will only be charged for the remaining 3 days, then your data will be deleted.
-Your estimated cost is `retention_cost` = 2 GB x (10 days - 7 days) x 0.002€ x 30 days = 0.36€/month
-If you want to store your logs for 3 months, your estimated cost is: `retention_cost` = 2 GB x (90 days - 7 days) x 0.002€ x 30 days = 9.96€/month
+**Custom data ingestion remains billable at the current pricing**.
+
+<Concept>
+  ## See custom retention pricing examples
+  ### For 10 days of retention
+  If you ingest an average of **2GB of logs daily** and increase retention to **10 days**. Retention is free for the first **7 days**, so you are only charged for the extra **3 days**:
+
+  **Monthly estimated cost:**
+    `retention_cost` = 2 GB x (10 - 7) x 0.002€ x 30 days = 0.36€/month
+
+  ### For 90 days of retention
+  If you extend retention to **90 days**, you are charged for the extra **83 days** beyond the free period:
+  **Monthly estimated cost:**
+   `retention_cost` = 2 GB x (90 - 7) x 0.002€ x 30 days = 9.96€/month
+</Concept>
 
 ## Why are Cockpit pricing plans being deprecated?
 

--- a/pages/cockpit/faq.mdx
+++ b/pages/cockpit/faq.mdx
@@ -25,6 +25,8 @@ Refer to the [dedicated documentation page](/cockpit/reference-content/cockpit-l
 
 ## What is the difference between Scaleway and custom data?
 
+[Scaleway data](#scaleway-data) is collected automatically from Scaleway products, while [custom data](#custom-data) is manually pushed from your own sources.
+
 ### Scaleway data
 
 Scaleway data is the observability data (metrics and/or logs) that is natively collected by all [Scaleway products integrated with Cockpit](/cockpit/reference-content/cockpit-limitations/#product-integration-into-cockpit).

--- a/pages/cockpit/faq.mdx
+++ b/pages/cockpit/faq.mdx
@@ -37,9 +37,9 @@ Custom data refers to any metrics, logs, or traces that you manually push to Coc
 
 ## How am I billed for using Cockpit with my Scaleway data?
 
-Scaleway data is collected and available in Cockpit for free. Retention is also free as long as it stays within the default period: 31 days for metrics and 7 days for logs and traces.
+Scaleway data is collected and available in Cockpit for free. Retention is also free as long as it stays within the default period: 31 days for metrics and 7 days for logs.
 
-You can [adjust the retention period](/cockpit/how-to/change-data-retention) from 1 day (for logs and traces) or 31 days (for metrics) to 1 year. Refer to the [dedicated documentation](/cockpit/concepts/#retention) for more information on available retention periods. However, starting May 1, 2025, data stored beyond the default period will incur charges based on daily storage volume.
+You can [adjust the retention period](/cockpit/how-to/change-data-retention) from 1 day (for logs) or 31 days (for metrics) to 1 year. Refer to the [dedicated documentation](/cockpit/concepts/#retention) for more information on available retention periods. However, starting May 1, 2025, data stored beyond the default period will incur charges based on daily storage volume.
 
 ## How am I billed for using Cockpit with custom data?
 

--- a/pages/cockpit/how-to/change-data-retention.mdx
+++ b/pages/cockpit/how-to/change-data-retention.mdx
@@ -13,7 +13,7 @@ dates:
   posted: 2024-11-25
 ---
 
-This page shows you how to change the [retention](/cockpit/concepts/#retention) period for your data sources. Refer to the Cockpit FAQ for detailed information on custom retention pricing.
+This page shows you how to change the [retention](/cockpit/concepts/#retention) period for your data sources. Refer to the [Cockpit FAQ](/cockpit/faq/) for detailed information on pricing.
 
 <Message type="note">
  **Pricing update for Cockpit custom retention** <br /><br />

--- a/pages/cockpit/how-to/change-data-retention.mdx
+++ b/pages/cockpit/how-to/change-data-retention.mdx
@@ -13,7 +13,7 @@ dates:
   posted: 2024-11-25
 ---
 
-This page shows you how to change the [retention](/cockpit/concepts/#retention) period for your data sources.
+This page shows you how to change the [retention](/cockpit/concepts/#retention) period for your data sources. Refer to the Cockpit FAQ for detailed information on custom retention pricing.
 
 <Message type="important">
   On January 1st, 2025, Cockpit pricing plans were deprecated and replaced by the custom [retention](/cockpit/concepts/#retention) feature, available for free during beta.
@@ -24,6 +24,7 @@ This page shows you how to change the [retention](/cockpit/concepts/#retention) 
 
   - A Scaleway account logged into the [console](https://console.scaleway.com)
   - [Owner](/iam/concepts/#owner) status or [IAM permissions](/iam/concepts/#permission) allowing you to perform actions in the intended Organization
+  - [Created](/cockpit/how-to/create-external-data-sources) Scaleway or custom data sources
 
 1. Click **Cockpit** in the Observability section of the [console](https://console.scaleway.com/) side menu. The **Cockpit** overview page displays.
 2. Click the **Data sources** tab.
@@ -32,13 +33,12 @@ This page shows you how to change the [retention](/cockpit/concepts/#retention) 
          You can change the retention period for both Scaleway and custom data sources. Each data source can have a different retention period.
         </Message>
 4. Click **More info**. The **Data source information** page displays.
-5. Click the **Edit retention** button and drag the slider to adjust the retention period:
-    - Drag the slider to the **right to increase** your retention period, or
-    - Drag the slider to the **left to decrease** the retention period.
-
+5. Click the **Edit retention** button and:
+6. Enter the number of days, months or years you want your retention period to last
+7. Select either `days`, `months`, or `years` in the drop-down.
         <Message type="important">
          - Reducing the retention period of a data source will permanently delete all observability data in that data source beyond the selected timeframe. This deletion is irreversible and takes effect a few minutes after the retention period is reduced, even if the retention period is later increased.
          - Find out about the [retention periods available for each data source type](/cockpit/concepts/#retention).
          - Adjusting data retention beyond the default period is billed based on the volume of data stored. Check the [Cockpit FAQ](/cockpit/faq/) for information on data retention billing.
         </Message>
-6. Click **Edit retention period** to confirm.
+8. Click **Edit retention period** to confirm.

--- a/pages/cockpit/how-to/change-data-retention.mdx
+++ b/pages/cockpit/how-to/change-data-retention.mdx
@@ -32,7 +32,7 @@ This page shows you how to change the [retention](/cockpit/concepts/#retention) 
 
   - A Scaleway account logged into the [console](https://console.scaleway.com)
   - [Owner](/iam/concepts/#owner) status or [IAM permissions](/iam/concepts/#permission) allowing you to perform actions in the intended Organization
-  - [Created](/cockpit/how-to/create-external-data-sources) Scaleway or custom data sources
+  - Created [Scaleway resources integrated with Cockpit](/cockpit/reference-content/cockpit-limitations/#product-integration-into-cockpit) or [created](/cockpit/how-to/create-external-data-sources) custom data sources
 
 1. Click **Cockpit** in the Observability section of the [console](https://console.scaleway.com/) side menu. The **Cockpit** overview page displays.
 2. Click the **Data sources** tab.

--- a/pages/cockpit/how-to/change-data-retention.mdx
+++ b/pages/cockpit/how-to/change-data-retention.mdx
@@ -9,18 +9,15 @@ tags: cockpit data-retention retention-period edit-retention
 categories:
   - observability
 dates:
-  validation: 2024-11-25
+  validation: 2025-04-02
   posted: 2024-11-25
 ---
 
 This page shows you how to change the [retention](/cockpit/concepts/#retention) period for your data sources.
 
 <Message type="important">
-
- **Cockpit pricing plans were deprecated on January 1st 2025** <br /><br />
-
- The [retention](/cockpit/concepts/#retention) period previously set for your Scaleway and custom logs, metrics and traces remains the same. <br /><br />
- You can change the retention period for your metrics, logs, and traces for free during the retention period edition beta (starting January 1st 2025). <br /><br />
+  On January 1st, 2025, Cockpit pricing plans were deprecated and replaced by the custom [retention](/cockpit/concepts/#retention) feature, available for free during beta.
+  On May 1st, 2025, this feature reaches general availability and becomes billable. Refer to the [Cockpit FAQ](/cockpit/faq/) to find out about new pricing.
 </Message>
 
 <Macro id="requirements" />
@@ -42,9 +39,6 @@ This page shows you how to change the [retention](/cockpit/concepts/#retention) 
         <Message type="important">
          - Reducing the retention period of a data source will permanently delete all observability data in that data source beyond the selected timeframe. This deletion is irreversible and takes effect a few minutes after the retention period is reduced, even if the retention period is later increased.
          - Find out about the [retention periods available for each data source type](/cockpit/concepts/#retention).
+         - Adjusting data retention beyond the default period is billed based on the volume of data stored. Check the [Cockpit FAQ](/cockpit/faq/) for information on data retention billing.
         </Message>
 6. Click **Edit retention period** to confirm.
-
-        <Message type="note">
-         Adjusting data retention is free of charge during Beta.
-        </Message>

--- a/pages/cockpit/how-to/change-data-retention.mdx
+++ b/pages/cockpit/how-to/change-data-retention.mdx
@@ -15,9 +15,17 @@ dates:
 
 This page shows you how to change the [retention](/cockpit/concepts/#retention) period for your data sources. Refer to the Cockpit FAQ for detailed information on custom retention pricing.
 
-<Message type="important">
-  On January 1st, 2025, Cockpit pricing plans were deprecated and replaced by the custom [retention](/cockpit/concepts/#retention) feature, available for free during beta.
-  On May 1st, 2025, this feature reaches general availability and becomes billable. Refer to the [Cockpit FAQ](/cockpit/faq/) to find out about new pricing.
+<Message type="note">
+ **Pricing update for Cockpit custom retention** <br /><br />
+
+ On January 1st, 2025, Cockpit pricing plans were deprecated and replaced by the custom [retention](/cockpit/concepts/#retention) feature, available for free during beta.
+ On May 1st, 2025, this feature reaches general availability and **becomes billable**. <br /><br />
+
+ **Logs and traces**: free retention for 7 days, then charged €0.002/GB/day
+
+ **Metrics**: free retention for 31 days, then charged €0.0002/10 million samples/day
+
+ Ingestion of custom data remains billable at [the current pricing](/cockpit/faq/#how-am-i-billed-for-using-cockpit-with-custom-data).
 </Message>
 
 <Macro id="requirements" />
@@ -33,12 +41,12 @@ This page shows you how to change the [retention](/cockpit/concepts/#retention) 
          You can change the retention period for both Scaleway and custom data sources. Each data source can have a different retention period.
         </Message>
 4. Click **More info**. The **Data source information** page displays.
-5. Click the **Edit retention** button and:
-6. Enter the number of days, months or years you want your retention period to last
-7. Select either `days`, `months`, or `years` in the drop-down.
+5. Click the **Edit retention** button.
+6. Drag the slider to adjust the [retention period](/cockpit/concepts/#retention) for your data source:
+    - Drag the slider to the **right to increase** your retention period, or
+    - Drag the slider to the **left to decrease** the retention period.
         <Message type="important">
          - Reducing the retention period of a data source will permanently delete all observability data in that data source beyond the selected timeframe. This deletion is irreversible and takes effect a few minutes after the retention period is reduced, even if the retention period is later increased.
          - Find out about the [retention periods available for each data source type](/cockpit/concepts/#retention).
-         - Adjusting data retention beyond the default period is billed based on the volume of data stored. Check the [Cockpit FAQ](/cockpit/faq/) for information on data retention billing.
         </Message>
-8. Click **Edit retention period** to confirm.
+7. Click **Edit retention period** to confirm.

--- a/pages/cockpit/how-to/create-external-data-sources.mdx
+++ b/pages/cockpit/how-to/create-external-data-sources.mdx
@@ -8,7 +8,7 @@ content:
 categories:
   - observability
 dates:
-  validation: 2025-03-26
+  validation: 2025-04-04
   posted: 2024-04-05
 ---
 

--- a/pages/cockpit/how-to/create-token.mdx
+++ b/pages/cockpit/how-to/create-token.mdx
@@ -13,7 +13,7 @@ dates:
   posted: 2022-10-31
 ---
 
-This page shows you how to create [tokens](/cockpit/concepts/#tokens), to grant other cloud providers’ services and platforms access to your [Cockpit](/cockpit/concepts/#cockpit).
+This page shows you how to create [tokens](/cockpit/concepts/#cockpit-tokens), to grant other cloud providers’ services and platforms access to your [Cockpit](/cockpit/concepts/#cockpit).
 
 <Macro id="requirements" />
 

--- a/tutorials/pushing-metrics-logs-from-scw-instance/index.mdx
+++ b/tutorials/pushing-metrics-logs-from-scw-instance/index.mdx
@@ -51,7 +51,7 @@ The `tuto-cockpit-instance` directory contains a `workshop` folder with several 
 - `nginx.conf` specifies server settings
 - `run.sh` executes the Grafana agent with the specified configuration file (agent.yaml).
 
-The only file we will be editing in this tutorial is the `agent.yaml` file to add your Cockpit [token](/cockpit/concepts/#tokens).
+The only file we will be editing in this tutorial is the `agent.yaml` file to add your Cockpit [token](/cockpit/concepts/#cockpit-tokens).
 
 1. Open another terminal and type the following command to clone our `tuto-cockpit-instance` directory on your local machine:
 

--- a/tutorials/use-cockpit-with-terraform/index.mdx
+++ b/tutorials/use-cockpit-with-terraform/index.mdx
@@ -17,7 +17,7 @@ In this tutorial, you will learn how to get started with Cockpit using a Terrafo
 
 - A [Grafana user](/cockpit/concepts/#grafana-users)
 - A folder in the Grafana user interface
-- A Cockpit [token](/cockpit/concepts/#tokens) with permission to query and push metrics
+- A Cockpit [token](/cockpit/concepts/#cockpit-tokens) with permission to query and push metrics
 - A metric [data source](/cockpit/concepts/#data-sources)
 
 <Macro id="requirements" />


### PR DESCRIPTION
- Added new retention periods (from 1 day to 5 years) in the "concepts" page under the "Retention" concept
- Added new FAQ questions => "What is Scaleway data?" and "What is custom data?" with explanation for both
- Added info banner about new pricing updates in FAQ, and "How to change data retention period"
- Added question in FAQ "How am I billed for increasing data retention period" with custom retention pricing examples for 10 days and 3 months in a collapsable bar.
- Added info that Scaleway does not support the Grafana agent
- Added new concepts: "custom data" and "Scaleway data"
- Changed wording from "Tokens" to "Cockpit tokens"
- Deleted concepts previously agreed upon with @sfinet-scw 


I am adding a screenshot of how the banner looks below:

<img width="850" alt="Capture d’écran 2025-04-04 à 17 07 34" src="https://github.com/user-attachments/assets/383cf816-ee01-4a72-9e71-e496398adaa1" />

This is a screen recording of how the FAQ question with the collapsible example looks:

https://github.com/user-attachments/assets/c402ece4-551d-49de-818e-b5caa85cf00f