### PR TITLE
Disambiguate naming

### DIFF
--- a/pages/load-balancer/how-to/set-up-s3-failover.mdx
+++ b/pages/load-balancer/how-to/set-up-s3-failover.mdx
@@ -36,7 +36,7 @@ You can set up a customized error page during creation of your Load Balancer, or
 1. Follow the instructions for [creating a Load Balancer](/load-balancer/how-to/create-load-balancer/).
 2. Click the  **+Advanced Settings** button while configuring your backend.
     <Lightbox src="scaleway-customized-error-page.webp" alt="" />
-3. Slide the <Icon name="toggle" /> toggle to activate the customized error page feature, and enter a Scaleway Object Storage [Bucket Website](/object-storage/concepts/#bucket-website) URL in the box. Note that the URL of the bucket endpoint is not sufficient, the bucket website URL is specifically required (e.g.`https://my-bucket.s3-website.nl-ams.scw.cloud`).
+3. Slide the <Icon name="toggle" /> toggle to activate the customized error page feature, and enter a Scaleway Object Storage [Bucket Website](/object-storage/concepts/#bucket-website) page URL in the box. Note that the URL of the bucket endpoint is not sufficient, the bucket website URL is specifically required (e.g.`https://my-bucket.s3-website.nl-ams.scw.cloud/error.html`).
     <Message type="note">
       This feature is only available for Load Balancers using the HTTP protocol on their backend.
     </Message>
@@ -54,7 +54,7 @@ You can set up a customized error page during creation of your Load Balancer, or
     <Message type="note">
       This feature is only available for Load Balancers using the HTTP protocol on their backend.
     </Message>
-7. Enter a Scaleway Object Storage [Bucket Website](/object-storage/concepts/#bucket-website) URL in the box, if activating the feature. Note that the URL of the bucket endpoint is not sufficient, the bucket website URL is specifically required (e.g.`https://my-bucket.s3-website.nl-ams.scw.cloud`).
+7. Enter a Scaleway Object Storage [Bucket Website](/object-storage/concepts/#bucket-website) page URL in the box, if activating the feature. Note that the URL of the bucket endpoint is not sufficient, the bucket webpage URL is specifically required (e.g.`https://my-bucket.s3-website.nl-ams.scw.cloud/error.html`).
 8. Click **Edit backend** to finish.
 
 ## How to create a static website for your customized error page


### PR DESCRIPTION
Remove confusion on whether it is a bucket URL or a page URL.