### PR TITLE
feat(km): replacing product description

### DIFF
--- a/pages/key-manager/index.mdx
+++ b/pages/key-manager/index.mdx
@@ -7,7 +7,7 @@ meta:
 <ProductHeader
    productName="Key Manager"
    productLogo="kms"
-   description="Key Manager allows you to conveniently store, access, and share sensitive data such as passwords, API keys, and certificates."
+   description="Key Manager helps you create and manage encryption keys to securely store all your important data."
    url="/key-manager/quickstart/"
    label="Key Manager Quickstart"
 />


### PR DESCRIPTION
There was a small mistake in product description in the doc page Key Manager overview, this fixes it