### PR TITLE
fix(genapi): add fixed version for openwebui deployment

### DIFF
--- a/tutorials/deploy-openwebui-with-generative-apis/index.mdx
+++ b/tutorials/deploy-openwebui-with-generative-apis/index.mdx
@@ -137,7 +137,7 @@ Run the following command to create the container with your **Docker image and s
 
 $ scw container container create name=open-webui \
     namespace-id=<YOUR_NAMESPACE_ID> \
-    registry-image="ghcr.io/open-webui/open-webui:main" \
+    registry-image="ghcr.io/open-webui/open-webui:0.5.10" \
     environment-variables.OPENAI_API_BASE_URL="https://api.scaleway.ai/<YOUR_PROJECT_ID>/v1" \
     secret-environment-variables.0.key="OPENAI_API_KEY" \
     secret-environment-variables.0.value="<YOUR_SECRET_KEY>" \
@@ -150,6 +150,10 @@ $ scw container container create name=open-webui \
 
    <Message type="note">
      Replace `<YOUR_PROJECT_ID>` and `<YOUR_API_KEY>` with your actual values.
+   </Message>
+
+   <Message type="tip">
+     This snippet deploys OpenWebUI version `0.5.10`. For latest version replace `open-webui:0.5.10` by `open-webui:main`. Note that storage and memory requirements often increase with latest versions, as new features or built-in models may be included in OpenWebUI container image. In this case, if container is in `Error` we recommend to increase `cpu-limit`, `memory-limit` or `local-storage-limit` values to recommended OpenWebUI values.
    </Message>
 
 For more information, refer to Scaleway's [Serverless Containers documentation](/serverless-containers/).

--- a/tutorials/deploy-openwebui-with-generative-apis/index.mdx
+++ b/tutorials/deploy-openwebui-with-generative-apis/index.mdx
@@ -153,7 +153,7 @@ $ scw container container create name=open-webui \
    </Message>
 
    <Message type="tip">
-     This snippet deploys OpenWebUI version `0.5.10`. For latest version replace `open-webui:0.5.10` by `open-webui:main`. Note that storage and memory requirements often increase with latest versions, as new features or built-in models may be included in OpenWebUI container image. In this case, if container is in `Error` we recommend to increase `cpu-limit`, `memory-limit` or `local-storage-limit` values to recommended OpenWebUI values.
+     This snippet deploys OpenWebUI version `0.5.10`. For the latest version replace `open-webui:0.5.10` by `open-webui:main`. Note that storage and memory requirements often increase with latest versions, as new features or built-in models may be included in the OpenWebUI container image. In this case, if the container is in `Error` state we recommend to increase `cpu-limit`, `memory-limit` or `local-storage-limit` values to recommended OpenWebUI values.
    </Message>
 
 For more information, refer to Scaleway's [Serverless Containers documentation](/serverless-containers/).


### PR DESCRIPTION
Add a fixed version for openwebui deployment with serverless container to ensure cpu and memory limits are right, and deployment will work.
