### PR TITLE
docs(tutorials): Fix typo in duplicity backup tutorial

### DIFF
--- a/tutorials/backup-dedicated-server-s3-duplicity/index.mdx
+++ b/tutorials/backup-dedicated-server-s3-duplicity/index.mdx
@@ -169,8 +169,8 @@ As everything is installed and ready, we will now configure and script our inter
     export SCW_ENDPOINT_URL="https://s3.${SCW_REGION}.scw.cloud"
     export SCW_BUCKET="s3://<YOUR BUCKET NAME>"
     # GPG Key information
-    export GPG_FINGERPRINT="<YOUR GPG KEY PASSPHRASE>"
-    export PASSPHRASE="<YOUR GPG KEY FINGERPRINT>"
+    export GPG_FINGERPRINT="<YOUR GPG KEY FINGERPRINT>"
+    export PASSPHRASE="<YOUR GPG KEY PASSPHRASE>"
 
     # Folder to backup
     export SOURCE="/path/to/backup"


### PR DESCRIPTION
### Description

Small error in the sample variable values that were switched
