### PR TITLE
fix(db): guideflow in quickstarts

### DIFF
--- a/pages/container-registry/quickstart.mdx
+++ b/pages/container-registry/quickstart.mdx
@@ -15,6 +15,10 @@ categories:
 
 Scaleway [Container Registry](/container-registry/concepts/#container-registry) is a fully-managed mutualized container registry, designed to facilitate the storage, management, and deployment of container images. The service simplifies the development-to-production workflow, as there is no need to operate your own Container Registry or worry about the underlying infrastructure. You can create your Container Registry namespace, connect it to the Docker CLI, then use Docker to push and pull images to and from your registry. When you no longer need an image, you can delete it from your Container Registry.
 
+## Console overview
+Discover the Container Registry interface in the Scaleway console.
+<GuideFlow src="https://app.guideflow.com/embed/0p0m6d2fvk"/>
+
 <Macro id="requirements" />
 
 - A Scaleway account logged into the [console](https://console.scaleway.com)

--- a/pages/managed-databases-for-postgresql-and-mysql/quickstart.mdx
+++ b/pages/managed-databases-for-postgresql-and-mysql/quickstart.mdx
@@ -20,6 +20,10 @@ The resource allows you to focus on development rather than administration or co
 
 Compared to traditional database management, which requires customers to provide their infrastructure and resources to manage their databases, Managed Database for PostgreSQL and MySQL Instance offers the user access to Database Instances without setting up the hardware or configuring the software. Scaleway handles the provisioning, manages the configuration, and provides useful features, as high availability, automated backup, user management, and more.
 
+## Console overview
+Discover the Managed Database for PostgreSQL and MySQL interface in the Scaleway console.
+<GuideFlow src="https://app.guideflow.com/embed/mk6zm06s6p"/>
+
 <Macro id="requirements" />
 
 - A Scaleway account logged into the [console](https://console.scaleway.com)

--- a/pages/managed-databases-for-redis/quickstart.mdx
+++ b/pages/managed-databases-for-redis/quickstart.mdx
@@ -14,6 +14,10 @@ categories:
   - postgresql-and-mysql
 ---
 
+## Console overview
+Discover the Managed Database for Redis™ interface in the Scaleway console.
+<GuideFlow src="https://app.guideflow.com/embed/dr9odj8hnr"/>
+
 ## How to create a Redis™ Database Instance
 
 Managed Database for Redis™ is a low-latency caching solution based on in-memory data storage. It allows you to easily set up a secure cache and lighten the load on your main database.

--- a/pages/managed-mongodb-databases/quickstart.mdx
+++ b/pages/managed-mongodb-databases/quickstart.mdx
@@ -21,6 +21,10 @@ Managed MongoDB® provides fully-managed document Database Instances, with  Mong
 
 MongoDB® databases enable users to store and retrieve data in a document format, such as `json`. Compared to traditional relational databases where data is stored in a table-like format, document-type storage supports storing multiple nested keys and values in each document key.
 
+## Console overview
+Discover the Managed MongoDB® interface in the Scaleway console.
+<GuideFlow src="https://app.guideflow.com/embed/lpnm35zter"/>
+
 <Macro id="requirements" />
 
 - A Scaleway account logged into the [console](https://console.scaleway.com)

--- a/pages/serverless-jobs/quickstart.mdx
+++ b/pages/serverless-jobs/quickstart.mdx
@@ -22,6 +22,10 @@ Refer to the [differences between Jobs, Containers, and Functions](/serverless-j
 
 This page explains how to create a job definition with the latest Alpine Linux image, how to execute it, and delete it.
 
+## Console overview
+Discover the Serverless Jobs interface in the Scaleway console.
+<GuideFlow src="https://app.guideflow.com/embed/zkjln7diwp"/>
+
 <Macro id="requirements" />
 
 - A Scaleway account logged into the [console](https://console.scaleway.com)

--- a/pages/serverless-sql-databases/quickstart.mdx
+++ b/pages/serverless-sql-databases/quickstart.mdx
@@ -17,6 +17,10 @@ Scaleway Serverless SQL Databases are fully managed databases that automatically
 
 This page explains how to create, access, and delete a Serverless SQL Database using the Scaleway console.
 
+## Console overview
+Discover the Serverless SQL Databases interface in the Scaleway console.
+<GuideFlow src="https://app.guideflow.com/embed/zpez989f8p"/>
+
 <Macro id="requirements" />
 
 - A Scaleway account logged into the [console](https://console.scaleway.com)


### PR DESCRIPTION
Add Guideflows to Quickstart pages.
In this PR: 
- Container Registry - console overview
- PostgreSQL and MySQL - console overview
- Redis - console overview
- MongoDB - console overview
- SQL Databases - console overview
- Jobs - console overview

[Guideflow tracking](https://docs.google.com/spreadsheets/d/1rQZzpgAB7O57TMb5aHpS5_2EnOAeSt8knIZacMHfn1U/edit?gid=0#gid=0)