### PR TITLE
fix(sm): update external-secrets.io apiVersion

### DIFF
--- a/pages/kubernetes/api-cli/external-secrets-kubernetes.mdx
+++ b/pages/kubernetes/api-cli/external-secrets-kubernetes.mdx
@@ -67,7 +67,7 @@ Secret Manager is a regionalized product, so you will need to specify the [regio
 
     ```
     ---
-    apiVersion: external-secrets.io/v1beta1
+    apiVersion: external-secrets.io/v1
     kind: SecretStore
     metadata:
       name: secret-store
@@ -100,7 +100,7 @@ Create an `ExternalSecret` resource to specify which secret to fetch from Secret
 
     ```
     ---
-    apiVersion: external-secrets.io/v1beta1
+    apiVersion: external-secrets.io/v1
     kind: ExternalSecret
     metadata:
         name: secret


### PR DESCRIPTION


### Your checklist for this pull request

- [x] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

v1beta1 does not work anymore, and the official external-secrets.io documentation (https://external-secrets.io/latest/guides/generator/ for example) states to use v1. Using the old apiVersion gives error messages when applying with the latest Helm release and having followed each step in the Scaleway docs.