### PR TITLE
feat(audittrail): adding warsaw in audit trail doc

### DIFF
--- a/pages/audit-trail/faq.mdx
+++ b/pages/audit-trail/faq.mdx
@@ -34,4 +34,3 @@ Audit Trail events are stored in the same region where the activity occurred. Th
 
 Events from global products which are not region-specific such as [IAM](/iam/), are stored in the Paris region.
 Find out more about product availability in the [dedicated documentation](/account/reference-content/products-availability/).
-Audit Trail is not available for the Poland - Warsaw region.


### PR DESCRIPTION
Audit Trail is now available in Warsaw. This MR removes mentions of Audit Trail not being present in Warsaw.