### PR TITLE
docs(cpt): add info on new retention period

### DIFF
--- a/pages/cockpit/concepts.mdx
+++ b/pages/cockpit/concepts.mdx
@@ -7,7 +7,7 @@ content:
   paragraph: Explore Scaleway Observability concepts including metrics, logs, and alerts management through Cockpit. Learn about agents, alerting rules, Grafana integration, and data types for comprehensive monitoring.
 tags: observability alert-manager contact-points endpoint grafana loki logql prometheus promql tokens
 dates:
-  validation: 2025-04-03
+  validation: 2025-06-04
 categories:
   - observability
 ---
@@ -153,11 +153,9 @@ The minimum and maximum retention periods for each data source type are as follo
 
 | Retention period  | Custom metrics    | Custom logs/traces | Scaleway metrics  | Scaleway logs        |
 |-------------------|-------------------|--------------------|-------------------|----------------------|
-| Minimum retention | 1 day             | 1 days             | 31 days           | 1 day                |
-| Maximum retention | 365 days (1 year) | 31 days            | 365 days (1 year) | 31 days              |
+| Minimum retention | 1 day             | 1 day             | 31 days           | 1 day                |
+| Maximum retention | 1825 days (5 years) | 1825 days (5 years)            | 1825 days (5 years) | 1825 days (5 years)              |
 | Default retention | 31 days           | 7 days             | 31 days           | 7 days               |
-
-**Starting May 1, 2025, the maximum retention period for custom and Scaleway metrics, logs and traces will be of 1825 days (5 years)**. The information on the table above will be updated accordingly.
 
 ## Samples
 

--- a/pages/cockpit/faq.mdx
+++ b/pages/cockpit/faq.mdx
@@ -5,7 +5,7 @@ meta:
 content:
   h1: Cockpit FAQ
 dates:
-  validation: 2025-05-02
+  validation: 2025-06-04
 category: observability
 productIcon: CockpitProductIcon
 ---
@@ -52,14 +52,14 @@ If you are using Scaleway’s preconfigured dashboards in Grafana, make sure you
 
 Scaleway data is collected and available in Cockpit for free.
 
-Retention is also free as long as it stays within the default period: 31 days for metrics and 7 days for logs.
-You can [adjust the retention period](/cockpit/how-to/change-data-retention) from 1 day (for logs) or 31 days (for metrics) to 1 year. Refer to the [dedicated documentation](/cockpit/concepts/#retention) for more information on available retention periods. However, starting May 1, 2025, data stored beyond the default period will incur charges based on daily storage volume.
+Retention is also free as long as it stays within the default period: 31 days for metrics and 7 days for logs. Data stored beyond the default period will incur charges based on daily storage volume.
+You can [adjust the retention period](/cockpit/how-to/change-data-retention) from 1 day (for logs) or 31 days (for metrics) to 5 years. Refer to the [dedicated documentation](/cockpit/concepts/#retention) for more information on available retention periods.
 
 ## How am I billed for using Cockpit with custom data?
 
 Sending custom data to Cockpit incurs ingestion costs.
 
-Retention of custom data is free within the default period: 31 days for custom metrics and 7 days for custom logs and traces. You can [adjust the retention period](/cockpit/how-to/change-data-retention) from 1 day to 1 year. However, starting May 1, 2025, data stored beyond the default period will be charged based on daily storage volume.
+Retention of custom data is free within the default period: 31 days for custom metrics and 7 days for custom logs and traces. Data stored beyond the default period will incur charges based on daily storage volume. You can [adjust the retention period](/cockpit/how-to/change-data-retention) from 1 day to 5 years.
 
 Ingestion of custom data is billed as follows:
 
@@ -96,7 +96,7 @@ All ingested data, whether from Scaleway or custom sources, is retained for free
 - Metrics: 31 days
 - Logs and traces: 7 days
 
-**Starting May 1, 2025, data retained beyond these periods will be charged** based on daily storage volume:
+**Data stored beyond the default period will incur charges based on daily storage volume**:
 
 - Metrics: €0.0002 per 10 million samples/day
 - Logs and traces: €0.002 per GB/day
@@ -116,14 +116,6 @@ If you delete your data source or reduce its retention period below the default 
   **Monthly estimated cost:**
    `retention_cost` = 2 GB x (90 - 7) x 0.002€ x 30 days = 9.96€/month
 </Concept>
-
-## Why are Cockpit pricing plans being deprecated?
-
-From January 1st 2025, Cockpit is transitioning away from fixed pricing plans to offer you more flexibility and granularity for managing data [retention](/cockpit/concepts/#retention).
-
-This change allows you to tailor retention settings to your specific needs and only be charged for the volume of data you effectively store.
-
-Find out [how to change data retention period](/cockpit/how-to/change-data-retention/) in the dedicated documentation.
 
 ## How do I send my own data to my Cockpit?
 


### PR DESCRIPTION
Updated "Retention" concept to add the new maximum retention (5 years)
Update FAQ with info that data stored beyond the default period is charged based on daily storage volume.
Removed question about pricing plans