### PR TITLE
feat(docs): update & move mainLinks.json - WDOC-1099

### DIFF
--- a/menu/mainLinks.json
+++ b/menu/mainLinks.json
@@ -1,0 +1,44 @@
+{
+  "foremostLinks": [
+    {
+      "icon": "DevToolsCategoryIcon",
+      "label": "API Documentation",
+      "slug": "https://www.scaleway.com/en/developers/"
+    },
+    {
+      "icon": "UseCaseCategoryIcon",
+      "label": "Tutorials",
+      "slug": "tutorials"
+    },
+    {
+      "icon": "BillingCategoryIcon",
+      "label": "Troubleshooting Hub",
+      "slug": "troubleshooting"
+    },
+    {
+      "icon": "BillingCategoryIcon",
+      "label": "Interactive Demos",
+      "slug": "demos"
+    },
+    {
+      "icon": "DocumentationCategoryIcon",
+      "label": "FAQs",
+      "slug": "faq"
+    },
+    {
+      "icon": "ManagementAndGovernanceCategoryIcon",
+      "label": "Changelog",
+      "slug": "changelog"
+    }
+  ],
+  "quickLinks": [
+    {
+      "label": "Scaleway Learning",
+      "slug": "https://www.scaleway.com/en/scaleway-learning/"
+    },
+    {
+      "label": "Docs Github",
+      "slug": "https://github.com/scaleway/docs-content"
+    }
+  ]
+}


### PR DESCRIPTION

### Description

- Update `mainLinks.json`
  - remove `package` entry
  - use up to date icons names 
- move from `block/` to `menu/`

The old `blocks/mainLinks.json` will be deleted after migration
