### PR TITLE
docs(srv): fix typo on serverless jobs pages

### DIFF
--- a/pages/serverless-jobs/how-to/automate-resources-management.mdx
+++ b/pages/serverless-jobs/how-to/automate-resources-management.mdx
@@ -10,9 +10,10 @@ categories:
   - developer-tools
   - jobs
 dates:
-  validation: 2025-06-13
+  validation: 2025-06-23
   posted: 2025-06-13
 ---
+
 [Scaleway Serverless Jobs](/serverless-jobs/quickstart/) allows you to create and automate recurring tasks. This page shows how to create jobs to perform any operation available with the [Scaleway CLI](https://github.com/scaleway/scaleway-cli/blob/master/docs/commands/config.md) to automate the management of your Scaleway resources.
 
 Serverless Jobs are perfectly adapted for these autonomous tasks, as we do not need autoscaling or exposure via a web server. Refer to the [documentation on differences between jobs, containers, and functions](/serverless-jobs/reference-content/difference-jobs-functions-containers/) for more information.
@@ -55,18 +56,18 @@ Serverless Jobs are perfectly adapted for these autonomous tasks, as we do not n
     - **Power on and off Instances**
         ```sh
         # Power on
-        scw instance server start 11111111-1111-1111-1111-111111111111
+        /scw instance server start 11111111-1111-1111-1111-111111111111
 
         # Power off
-        scw instance server stop 11111111-1111-1111-1111-111111111111
+        /scw instance server stop 11111111-1111-1111-1111-111111111111
         ```
     - **Create a snapshot of an Instance volume**
         ```sh
-        scw instance snapshot create volume-id=11111111-1111-1111-1111-111111111111
+        /scw instance snapshot create volume-id=11111111-1111-1111-1111-111111111111
         ```
     - **Create a backup of an Instance**
         ```sh
-        scw instance server backup 11111111-1111-1111-1111-111111111111
+        /scw instance server backup 11111111-1111-1111-1111-111111111111
         ```
 10. Click **Create job**.
 

--- a/tutorials/power-on-off-instances-jobs/index.mdx
+++ b/tutorials/power-on-off-instances-jobs/index.mdx
@@ -10,9 +10,10 @@ categories:
   - instances
   - jobs
 dates:
-  validation: 2025-06-09
+  validation: 2025-06-23
   posted: 2025-06-09
 ---
+
 [Scaleway Serverless Jobs](/serverless-jobs/quickstart/) allows you to create and automate recurring tasks. This tutorial will guide you through the process of powering a [Scaleway Instance](/instances/quickstart/) on and off, on a recurring schedule using a Serverless Job.
 
 Serverless Jobs are perfectly adapted for these autonomous tasks, as we do not need autoscaling or exposure via a web server. Refer to the [documentation on differences between jobs, containers, and functions](/serverless-jobs/reference-content/difference-jobs-functions-containers/) for more information.
@@ -57,7 +58,7 @@ Serverless Jobs are perfectly adapted for these autonomous tasks, as we do not n
 9. In the **Execution** tab, define the command below, and replace the placeholder with the ID of your Instance:
 
     ```
-    scw instance server start 11111111-1111-1111-1111-111111111111
+    /scw instance server start 11111111-1111-1111-1111-111111111111
     ```
 
 10. Click **Create job**.
@@ -94,7 +95,7 @@ Serverless Jobs are perfectly adapted for these autonomous tasks, as we do not n
 9. In the **Execution** tab, define the command below, and replace the placeholder with the ID of your Instance:
 
     ```sh
-    scw instance server stop 11111111-1111-1111-1111-111111111111
+    /scw instance server stop 11111111-1111-1111-1111-111111111111
     ```
 
 10. Click **Create job**.


### PR DESCRIPTION
### Description

Following customer feedback and a scaler request, I'm updating two Serverless Jobs pages to fix an error in a command. Thread: https://scaleway.slack.com/archives/C03ULE6BX0E/p1750674366609619
