### PR TITLE
docs(Cockpit): add new federation documentation for Cockpit - int-add-observability-federate-doc

### DIFF
--- a/pages/cockpit/how-to/federate-scaleway-metrics.mdx
+++ b/pages/cockpit/how-to/federate-scaleway-metrics.mdx
@@ -19,7 +19,7 @@ In this page, we will show you how to federate your Scaleway metrics using the `
 
  - A Scaleway account logged into the [console](https://console.scaleway.com)
  - [Owner](/iam/concepts/#owner) status or [IAM permissions](/iam/concepts/#permission) allowing you to perform actions in the intended Organization
- - [Created](/cockpit/how-to/create-token/) a Cockpit token with read access in the same region as the metrics data source
+ - [Created](/cockpit/how-to/create-token/) a Cockpit token that have query metrics priviledge in the same region as the metrics data source
  - A running [Prometheus](https://prometheus.io) instance
 
 <Message type="info">
@@ -83,8 +83,8 @@ Once you have configured your `prometheus.yml` file, you can use docker-compose 
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
     ```
-
-2. Go to `http://localhost:9090/targets` and you should see your newly created target, federating your Scaleway metrics.
+2. Run `docker-compose up -d` to start your Prometheus instance
+3. Go to `http://localhost:9090/targets` and you should see your newly created target, federating your Scaleway metrics.
 
 ## Monitor your federation volumes
 

--- a/pages/cockpit/how-to/federate-scaleway-metrics.mdx
+++ b/pages/cockpit/how-to/federate-scaleway-metrics.mdx
@@ -1,0 +1,85 @@
+---
+meta:
+  title: How to federate Scaleway metrics with your own Prometheus
+  description: Learn how to retrieve the Scaleway product metrics with federation to re-use them within your own Prometheus
+content:
+  h1: How to federate Scaleway metrics with your own Prometheus
+  paragraph: Learn how to retrieve the Scaleway product metrics with federation to re-use them within your own Prometheus using Scaleway's comprehensive guide. This tutorial covers retrieving your Scaleway product metrics by federation of your Cockpit datasources and retrieving those metrics within Prometheus.
+tags: federation cockpit metrics observability monitoring prometheus
+categories:
+  - observability
+dates:
+  validation: TBD
+  posted: TBD
+---
+
+In this page, we will show you how to federate your Scaleway product metrics using the `/federate` endpoint of your Scaleway datasources with a [Prometheus](https://prometheus.io) configuration.
+
+<Macro id="requirements" />
+
+ - A Scaleway account logged into the [console](https://console.scaleway.com)
+ - [Owner](/iam/concepts/#owner) status or [IAM permissions](/iam/concepts/#permission) allowing you to perform actions in the intended Organization
+ - [Created](/cockpit/how-to/create-token/) a Cockpit token with read access in the same region as the metrics data source
+ - [Created](/iam/how-to/create-api-keys/) an API key and retrieved your API secret key
+ - A running [Prometheus](https://prometheus.io) instance
+
+<Message type="info">
+  The `/federate` endpoint will not be charged during beta phase but please note that after the beta
+</Message>
+
+<Message type="important">
+  - Federating Scaleway product metrics is a billable feature. Refer to the [product pricing](https://www.scaleway.com/en/pricing/?tags=available,managedservices-observability-cockpit) page for more information.
+</Message>
+
+## Configure your Prometheus
+
+Create a `prometheus.yml` file to configure your Prometheus instance, using the example below.
+Make sure to replace `$SCW_DATASOURCE_URL` with the URL of your data source (you can find it under the "API URL" section in the [Data sources tab](https://console.scaleway.com/cockpit/dataSource) of the Scaleway console) and to replace `$SCW_READ_TOKEN` with your Cockpit token with read permissions.
+
+```yaml
+global:
+  scrape_interval: 60s
+
+scrape_configs:
+  - job_name: 'federate-scaleway-metrics'
+    honor_labels: true
+    metrics_path: '/federate'
+    http_headers:
+      X-Token:
+        values:
+          - '$SCW_READ_TOKEN'
+    params:
+      'match[]':
+        - '{__name__="my-scaleway-metrics"}'
+        - '{job="my-wanted-job"}'
+    static_configs:
+      - targets:
+        - '$SCW_DATASOURCE_URL'
+```
+
+<Message type="info">
+  Please note that you should not include `https://` in the `SCW_DATASOURCE_URL`
+</Message>
+
+Modify the different `match[]` parameters according to the metrics you want to retrive, in this example you will federate:
+  - All metrics called `my-scaleway-metrics`
+  - All metrics with the label `job` with the value `my-wanted-job`
+
+## Run your Prometheus instance
+
+Once you have configured your `prometheus.yml` file, you can use docker-compose to run your Prometheus instance with the configuration, and start federating Scaleway product metrics.
+
+1. Create a `docker-compose.yml` file with :
+    ```yaml
+    services:
+    prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    ports:
+      - 9090:9090
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+    ```
+2. Go to http://localhost:9090/targets and you should see your newly created target, federating your Scaleway product metrics

--- a/pages/cockpit/how-to/federate-scaleway-metrics.mdx
+++ b/pages/cockpit/how-to/federate-scaleway-metrics.mdx
@@ -5,24 +5,24 @@ meta:
 content:
   h1: How to federate Scaleway metrics with your own Prometheus
   paragraph: Learn how to retrieve your Scaleway metrics with federation and reuse them within your own Prometheus with this step-by-step guide.
-tags: federation cockpit metrics observability monitoring prometheus
+tags: federation cockpit metrics monitoring prometheus
 categories:
   - observability
 dates:
-  validation: TBD
-  posted: TBD
+  validation: 2025-07-04
+  posted: 2025-07-04
 ---
 
-In this page, we will show you how to federate your Scaleway metrics using the `/federate` endpoint of your Scaleway datasources with a [Prometheus](https://prometheus.io) configuration.
+In this page, we will show you how to federate your Scaleway metrics using the `/federate` endpoint of your Scaleway data sources with a [Prometheus](https://prometheus.io) configuration. Metrics federation cnsists of collecting metrics from multiple sources or systems into a central place so you can visualize everything at once.
 
 <Macro id="requirements" />
 
  - A Scaleway account logged into the [console](https://console.scaleway.com)
  - [Owner](/iam/concepts/#owner) status or [IAM permissions](/iam/concepts/#permission) allowing you to perform actions in the intended Organization
- - [Created](/cockpit/how-to/create-token/) a Cockpit token that have query metrics priviledge in the same region as the metrics data source
+ - [Created](/cockpit/how-to/create-token/) a Cockpit token with the `query` permission in the same region as the metrics data source
  - A running [Prometheus](https://prometheus.io) instance
 
-<Message type="info">
+<Message type="note">
   The `/federate` endpoint will not be billed during the beta phase. After the beta, the endpoint will incur additional costs.
 </Message>
 
@@ -32,7 +32,7 @@ Since you have full control over your Prometheus instance, you can also use fede
 ## Configure your Prometheus
 
 Create a `prometheus.yml` file to configure your Prometheus instance, using the example below.
-Make sure you replace `$SCW_DATASOURCE_URL` with the URL of your data source. The URL can be found under the "API URL" section in the [Data sources tab](https://console.scaleway.com/cockpit/dataSource) of the Scaleway console. Replace `$SCW_READ_TOKEN` with your Cockpit token with read permissions.
+Make sure you replace `$SCW_DATASOURCE_URL` with the URL of your data source. The URL can be found under the **API URL** section of the [Data sources tab](https://console.scaleway.com/cockpit/dataSource) in the Scaleway console. Replace `$SCW_COCKPIT_TOKEN` with your Cockpit token with the `query` permission.
 
 ```yaml
 global:
@@ -45,7 +45,7 @@ scrape_configs:
     http_headers:
       X-Token:
         values:
-          - '$SCW_READ_TOKEN'
+          - '$SCW_COCKPIT_TOKEN'
     params:
       'match[]':
         - '{__name__="instance_.*"}'
@@ -56,21 +56,21 @@ scrape_configs:
 ```
 
 <Message type="important">
-  Do not include `https://` in the `SCW_DATASOURCE_URL`.
+  Remove `https://` from the `SCW_DATASOURCE_URL`. Your URL should look like the following: `bc380fc1-9a64-4d51-a560-39c8754207de.metrics.cockpit.fr-par.scw.cloud`.
 </Message>
 
 Modify the different `match[]` parameters according to the metrics you want to retrieve. In this example, you will federate:
   - All metrics with a name that starts with `instance_`
   - All metrics with the label `region` with the value `fr-par`
 
-You can also set `honor_labels` to `false` if you prefer to not override the different labels that your Prometheus could set that conflict with Scaleway metrics label.
-For example, with `honor_labels` set to `false` the Scaleway label `job` will be relabelled as `exported_job` to avoid collision.
+You can also set `honor_labels` to `false` if you do not want to override the different labels set by your Prometheus that conflict with Scaleway metrics label.
+For example, with `honor_labels` set to `false`, the Scaleway label `job` will be relabelled as `exported_job` to avoid collision.
 
 ## Run your Prometheus instance
 
-Once you have configured your `prometheus.yml` file, you can use docker-compose to run your Prometheus instance with the configuration and start federating Scaleway metrics.
+Once you have configured your `prometheus.yml` file, you can use docker-compose to run your Prometheus instance with your configuration and start federating Scaleway metrics.
 
-1. Create a `docker-compose.yml` file with:
+Create a `docker-compose.yml` file and paste the following template into it:
     ```yaml
     services:
       prometheus:
@@ -83,19 +83,21 @@ Once you have configured your `prometheus.yml` file, you can use docker-compose 
         command:
           - '--config.file=/etc/prometheus/prometheus.yml'
     ```
-2. Run `docker-compose up -d` to start your Prometheus instance
-3. Go to `http://localhost:9090/targets` and you should see your newly created target, federating your Scaleway metrics.
+
+[Access your localhost](http://localhost:9090/targets) to see your newly created target federating your Scaleway metrics.
 
 ## Monitor your federation volumes
 
 You can monitor the amount of samples federated with the `/federate` endpoint by looking at the `observability_cockpit_federate_exported_sample_total:increase5m` in your Cockpit.
 This metric indicates the total volume of exported samples through the federation endpoint over a 5 minutes interval.
 
-1. Go to the Cockpit page on the Scaleway console
-2. Click on `Open dashboards` to open your Grafana
-3. Go to the Explore tab on the left panel
-4. Search for the `observability_cockpit_federate_exported_sample_total:increase5m` metrics
+1. Click **Cockpit** in the **Monitoring** section of the [console](https://console.scaleway.com/) side menu. The **Cockpit** overview page displays.
+2. Click **Open dashboards** to access your Cockpit Grafana.
+3. Click the **Toggle menu** icon in the top left corner of your screen, then click **Explore**.
+4. In the **Metric** drop-down, select the `observability_cockpit_federate_exported_sample_total:increase5m` metrics and if necessary, update the time range in the top right corner of your screen.
 
-<Message type="info">
-  You can also federate this metrics to monitor your volume of federated metrics directly in your Prometheus instance.
+Your metrics should display in the graph.
+
+<Message type="note">
+  You can also federate this metrics data source to monitor your volume of federated metrics directly in your Prometheus instance.
 </Message>

--- a/pages/cockpit/how-to/federate-scaleway-metrics.mdx
+++ b/pages/cockpit/how-to/federate-scaleway-metrics.mdx
@@ -34,7 +34,7 @@ In this page, we will show you how to federate your Scaleway product metrics usi
 ## Configure your Prometheus
 
 Create a `prometheus.yml` file to configure your Prometheus instance, using the example below.
-Make sure to replace `$SCW_DATASOURCE_URL` with the URL of your data source (you can find it under the "API URL" section in the [Data sources tab](https://console.scaleway.com/cockpit/dataSource) of the Scaleway console) and to replace `$SCW_READ_TOKEN` with your Cockpit token with read permissions.
+Make sure you replace `$SCW_DATASOURCE_URL` with the URL of your data source. The URL can be found under the "API URL" section in the [Data sources tab](https://console.scaleway.com/cockpit/dataSource) of the Scaleway console. Replace `$SCW_READ_TOKEN` with your Cockpit token with read permissions.
 
 ```yaml
 global:

--- a/pages/cockpit/how-to/federate-scaleway-metrics.mdx
+++ b/pages/cockpit/how-to/federate-scaleway-metrics.mdx
@@ -48,7 +48,7 @@ scrape_configs:
           - '$SCW_READ_TOKEN'
     params:
       'match[]':
-        - '{__name__="instance_server_cpu_seconds_total"}'
+        - '{__name__="instance_.*"}'
         - '{region="fr-par"}'
     static_configs:
       - targets:
@@ -60,7 +60,7 @@ scrape_configs:
 </Message>
 
 Modify the different `match[]` parameters according to the metrics you want to retrieve. In this example, you will federate:
-  - All metrics called `instance_server_cpu_seconds_total`
+  - All metrics with a name that starts with `instance_`
   - All metrics with the label `region` with the value `fr-par`
 
 You can also set `honor_labels` to `false` if you prefer to not override the different labels that your Prometheus could set that conflict with Scaleway metrics label.

--- a/pages/cockpit/how-to/federate-scaleway-metrics.mdx
+++ b/pages/cockpit/how-to/federate-scaleway-metrics.mdx
@@ -26,7 +26,7 @@ In this page, we will show you how to federate your Scaleway metrics using the `
   The `/federate` endpoint will not be billed during the beta phase. After the beta, the endpoint will incur additional costs.
 </Message>
 
-Prometheus federation is usefull to gather all or your metrics in a unique Prometheus insance, or downsampling your different metrics to reduce the storage used by your metrics.
+Prometheus federation can be used to gather all your metrics in a unique Prometheus instance, or to downsample different metrics to reduce storage costs in the long run.
 Since you have full control over your Prometheus instance, you can also use federation to increase metrics retention.
 
 ## Configure your Prometheus
@@ -88,7 +88,7 @@ Once you have configured your `prometheus.yml` file, you can use docker-compose 
 
 ## Monitor your federation volumes
 
-You can monitor the amout of samples federated with the `/federate` endpoint by looking at the `observability_cockpit_federate_exported_sample_total:increase5m` in your Cockpit.
+You can monitor the amount of samples federated with the `/federate` endpoint by looking at the `observability_cockpit_federate_exported_sample_total:increase5m` in your Cockpit.
 The metrics indicate the total of exported metrics by federation, over 5 min interval.
 
 1. Go to the Cockpit page on the Scaleway console
@@ -97,5 +97,5 @@ The metrics indicate the total of exported metrics by federation, over 5 min int
 4. Search for the `observability_cockpit_federate_exported_sample_total:increase5m` metrics
 
 <Message type="info">
-  You can federate this metrics to have monitor your volume of federated metrics in your Prometheus instance.
+  You can also federate this metrics to monitor your volume of federated metrics directly in your Prometheus instance.
 </Message>

--- a/pages/cockpit/how-to/federate-scaleway-metrics.mdx
+++ b/pages/cockpit/how-to/federate-scaleway-metrics.mdx
@@ -24,7 +24,7 @@ In this page, we will show you how to federate your Scaleway product metrics usi
  - A running [Prometheus](https://prometheus.io) instance
 
 <Message type="info">
-  The `/federate` endpoint will not be charged during beta phase but please note that after the beta
+  The `/federate` endpoint will not be billed during the beta phase. After the beta, the endpoint will incur additional costs.
 </Message>
 
 <Message type="important">

--- a/pages/cockpit/how-to/federate-scaleway-metrics.mdx
+++ b/pages/cockpit/how-to/federate-scaleway-metrics.mdx
@@ -69,7 +69,7 @@ Modify the different `match[]` parameters according to the metrics you want to r
 
 Once you have configured your `prometheus.yml` file, you can use docker-compose to run your Prometheus instance with the configuration, and start federating Scaleway product metrics.
 
-1. Create a `docker-compose.yml` file with :
+1. Create a `docker-compose.yml` file with:
     ```yaml
     services:
     prometheus:

--- a/pages/cockpit/how-to/federate-scaleway-metrics.mdx
+++ b/pages/cockpit/how-to/federate-scaleway-metrics.mdx
@@ -1,10 +1,10 @@
 ---
 meta:
   title: How to federate Scaleway metrics with your own Prometheus
-  description: Learn how to retrieve your Scaleway product metrics with federation and reuse them within your own Prometheus with this step-by-step guide.
+  description: Learn how to retrieve your Scaleway metrics with federation and reuse them within your own Prometheus with this step-by-step guide.
 content:
   h1: How to federate Scaleway metrics with your own Prometheus
-  paragraph: Learn how to retrieve your Scaleway product metrics with federation and reuse them within your own Prometheus with this step-by-step guide.
+  paragraph: Learn how to retrieve your Scaleway metrics with federation and reuse them within your own Prometheus with this step-by-step guide.
 tags: federation cockpit metrics observability monitoring prometheus
 categories:
   - observability
@@ -13,23 +13,21 @@ dates:
   posted: TBD
 ---
 
-In this page, we will show you how to federate your Scaleway product metrics using the `/federate` endpoint of your Scaleway datasources with a [Prometheus](https://prometheus.io) configuration.
+In this page, we will show you how to federate your Scaleway metrics using the `/federate` endpoint of your Scaleway datasources with a [Prometheus](https://prometheus.io) configuration.
 
 <Macro id="requirements" />
 
  - A Scaleway account logged into the [console](https://console.scaleway.com)
  - [Owner](/iam/concepts/#owner) status or [IAM permissions](/iam/concepts/#permission) allowing you to perform actions in the intended Organization
  - [Created](/cockpit/how-to/create-token/) a Cockpit token with read access in the same region as the metrics data source
- - [Created](/iam/how-to/create-api-keys/) an API key and retrieved your API secret key
  - A running [Prometheus](https://prometheus.io) instance
 
 <Message type="info">
   The `/federate` endpoint will not be billed during the beta phase. After the beta, the endpoint will incur additional costs.
 </Message>
 
-<Message type="important">
-  - Federating Scaleway product metrics is a billable feature. Refer to the [product pricing](https://www.scaleway.com/en/pricing/?tags=available,managedservices-observability-cockpit) page for more information.
-</Message>
+Prometheus federation is usefull to gather all or your metrics in a unique Prometheus insance, or downsampling your different metrics to reduce the storage used by your metrics.
+Since you have full control over your Prometheus instance, you can also use federation to increase metrics retention.
 
 ## Configure your Prometheus
 
@@ -38,7 +36,7 @@ Make sure you replace `$SCW_DATASOURCE_URL` with the URL of your data source. Th
 
 ```yaml
 global:
-  scrape_interval: 60s
+  scrape_interval: 3m
 
 scrape_configs:
   - job_name: 'federate-scaleway-metrics'
@@ -50,8 +48,8 @@ scrape_configs:
           - '$SCW_READ_TOKEN'
     params:
       'match[]':
-        - '{__name__="my-scaleway-metrics"}'
-        - '{job="my-wanted-job"}'
+        - '{__name__="instance_server_cpu_seconds_total"}'
+        - '{region="fr-par"}'
     static_configs:
       - targets:
         - '$SCW_DATASOURCE_URL'
@@ -62,12 +60,15 @@ scrape_configs:
 </Message>
 
 Modify the different `match[]` parameters according to the metrics you want to retrieve. In this example, you will federate:
-  - All metrics called `my-scaleway-metrics`
-  - All metrics with the label `job` with the value `my-wanted-job`
+  - All metrics called `instance_server_cpu_seconds_total`
+  - All metrics with the label `region` with the value `fr-par`
+
+You can also set `honor_labels` to `false` if you prefer to not override the different labels that your Prometheus could set that conflict with Scaleway metrics label.
+For example, with `honor_labels` set to `false` the Scaleway label `job` will be relabelled as `exported_job` to avoid collision.
 
 ## Run your Prometheus instance
 
-Once you have configured your `prometheus.yml` file, you can use docker-compose to run your Prometheus instance with the configuration and start federating Scaleway product metrics.
+Once you have configured your `prometheus.yml` file, you can use docker-compose to run your Prometheus instance with the configuration and start federating Scaleway metrics.
 
 1. Create a `docker-compose.yml` file with:
     ```yaml
@@ -83,4 +84,18 @@ Once you have configured your `prometheus.yml` file, you can use docker-compose 
       - '--config.file=/etc/prometheus/prometheus.yml'
     ```
 
-2. Go to `http://localhost:9090/targets` and you should see your newly created target, federating your Scaleway product metrics.
+2. Go to `http://localhost:9090/targets` and you should see your newly created target, federating your Scaleway metrics.
+
+## Monitor your federation volumes
+
+You can monitor the amout of samples federated with the `/federate` endpoint by looking at the `observability_cockpit_federate_exported_sample_total:increase5m` in your Cockpit.
+The metrics indicate the total of exported metrics by federation, over 5 min interval.
+
+1. Go to the Cockpit page on the Scaleway console
+2. Click on `Open dashboards` to open your Grafana
+3. Go to the Explore tab on the left panel
+4. Search for the `observability_cockpit_federate_exported_sample_total:increase5m` metrics
+
+<Message type="info">
+  You can federate this metrics to have monitor your volume of federated metrics in your Prometheus instance.
+</Message>

--- a/pages/cockpit/how-to/federate-scaleway-metrics.mdx
+++ b/pages/cockpit/how-to/federate-scaleway-metrics.mdx
@@ -73,15 +73,15 @@ Once you have configured your `prometheus.yml` file, you can use docker-compose 
 1. Create a `docker-compose.yml` file with:
     ```yaml
     services:
-    prometheus:
-    image: prom/prometheus:latest
-    container_name: prometheus
-    volumes:
-      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
-    ports:
-      - 9090:9090
-    command:
-      - '--config.file=/etc/prometheus/prometheus.yml'
+      prometheus:
+        image: prom/prometheus:latest
+        container_name: prometheus
+        volumes:
+          - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+        ports:
+          - 9090:9090
+        command:
+          - '--config.file=/etc/prometheus/prometheus.yml'
     ```
 2. Run `docker-compose up -d` to start your Prometheus instance
 3. Go to `http://localhost:9090/targets` and you should see your newly created target, federating your Scaleway metrics.

--- a/pages/cockpit/how-to/federate-scaleway-metrics.mdx
+++ b/pages/cockpit/how-to/federate-scaleway-metrics.mdx
@@ -82,4 +82,5 @@ Once you have configured your `prometheus.yml` file, you can use docker-compose 
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
     ```
-2. Go to http://localhost:9090/targets and you should see your newly created target, federating your Scaleway product metrics
+
+2. Go to `http://localhost:9090/targets` and you should see your newly created target, federating your Scaleway product metrics.

--- a/pages/cockpit/how-to/federate-scaleway-metrics.mdx
+++ b/pages/cockpit/how-to/federate-scaleway-metrics.mdx
@@ -89,7 +89,7 @@ Once you have configured your `prometheus.yml` file, you can use docker-compose 
 ## Monitor your federation volumes
 
 You can monitor the amount of samples federated with the `/federate` endpoint by looking at the `observability_cockpit_federate_exported_sample_total:increase5m` in your Cockpit.
-The metrics indicate the total of exported metrics by federation, over 5 min interval.
+This metric indicates the total volume of exported samples through the federation endpoint over a 5 minutes interval.
 
 1. Go to the Cockpit page on the Scaleway console
 2. Click on `Open dashboards` to open your Grafana

--- a/pages/cockpit/how-to/federate-scaleway-metrics.mdx
+++ b/pages/cockpit/how-to/federate-scaleway-metrics.mdx
@@ -61,7 +61,7 @@ scrape_configs:
   Do not include `https://` in the `SCW_DATASOURCE_URL`.
 </Message>
 
-Modify the different `match[]` parameters according to the metrics you want to retrive, in this example you will federate:
+Modify the different `match[]` parameters according to the metrics you want to retrieve. In this example, you will federate:
   - All metrics called `my-scaleway-metrics`
   - All metrics with the label `job` with the value `my-wanted-job`
 

--- a/pages/cockpit/how-to/federate-scaleway-metrics.mdx
+++ b/pages/cockpit/how-to/federate-scaleway-metrics.mdx
@@ -4,7 +4,7 @@ meta:
   description: Learn how to retrieve your Scaleway product metrics with federation and reuse them within your own Prometheus with this step-by-step guide.
 content:
   h1: How to federate Scaleway metrics with your own Prometheus
-  paragraph: Learn how to retrieve the Scaleway product metrics with federation to re-use them within your own Prometheus using Scaleway's comprehensive guide. This tutorial covers retrieving your Scaleway product metrics by federation of your Cockpit datasources and retrieving those metrics within Prometheus.
+  paragraph: Learn how to retrieve your Scaleway product metrics with federation and reuse them within your own Prometheus with this step-by-step guide.
 tags: federation cockpit metrics observability monitoring prometheus
 categories:
   - observability

--- a/pages/cockpit/how-to/federate-scaleway-metrics.mdx
+++ b/pages/cockpit/how-to/federate-scaleway-metrics.mdx
@@ -1,7 +1,7 @@
 ---
 meta:
   title: How to federate Scaleway metrics with your own Prometheus
-  description: Learn how to retrieve the Scaleway product metrics with federation to re-use them within your own Prometheus
+  description: Learn how to retrieve your Scaleway product metrics with federation and reuse them within your own Prometheus with this step-by-step guide.
 content:
   h1: How to federate Scaleway metrics with your own Prometheus
   paragraph: Learn how to retrieve the Scaleway product metrics with federation to re-use them within your own Prometheus using Scaleway's comprehensive guide. This tutorial covers retrieving your Scaleway product metrics by federation of your Cockpit datasources and retrieving those metrics within Prometheus.

--- a/pages/cockpit/how-to/federate-scaleway-metrics.mdx
+++ b/pages/cockpit/how-to/federate-scaleway-metrics.mdx
@@ -57,8 +57,8 @@ scrape_configs:
         - '$SCW_DATASOURCE_URL'
 ```
 
-<Message type="info">
-  Please note that you should not include `https://` in the `SCW_DATASOURCE_URL`
+<Message type="important">
+  Do not include `https://` in the `SCW_DATASOURCE_URL`.
 </Message>
 
 Modify the different `match[]` parameters according to the metrics you want to retrive, in this example you will federate:

--- a/pages/cockpit/how-to/federate-scaleway-metrics.mdx
+++ b/pages/cockpit/how-to/federate-scaleway-metrics.mdx
@@ -67,7 +67,7 @@ Modify the different `match[]` parameters according to the metrics you want to r
 
 ## Run your Prometheus instance
 
-Once you have configured your `prometheus.yml` file, you can use docker-compose to run your Prometheus instance with the configuration, and start federating Scaleway product metrics.
+Once you have configured your `prometheus.yml` file, you can use docker-compose to run your Prometheus instance with the configuration and start federating Scaleway product metrics.
 
 1. Create a `docker-compose.yml` file with:
     ```yaml

--- a/pages/cockpit/reference-content/cockpit-supported-endpoints.mdx
+++ b/pages/cockpit/reference-content/cockpit-supported-endpoints.mdx
@@ -66,8 +66,8 @@ Refer to the [official Mimir documentation](https://grafana.com/docs/mimir/lates
 </Concept>
 
 <Message type="important">
-  The `/federate` endpoint will not be charged during beta phase but please note that after the beta, this endpoint will incurs additional costs.
-  For more information, you can check [this tutorial](../how-to/federate-scaleway-metrics.mdx)
+  The `/federate` endpoint will not be billed during the beta phase. After the beta, the endpoint will incur additional costs.
+    Refer to the [How to federate metrics](/cockpit/how-to/federate-scaleway-metrics) documentation page for more information.
 </Message>
 
 <Concept>

--- a/pages/cockpit/reference-content/cockpit-supported-endpoints.mdx
+++ b/pages/cockpit/reference-content/cockpit-supported-endpoints.mdx
@@ -62,11 +62,19 @@ Refer to the [official Mimir documentation](https://grafana.com/docs/mimir/lates
     - Path: `/prometheus/api/v1/metadata`
     - Path: `/prometheus/api/v1/read`
     - Path: `/prometheus/api/v1/status/buildinfo`
-    - Path: `/federate`
 </Concept>
 
+<Concept>
+  ## Additional endpoints
+
+  Methods: `GET`
+
+  - Path: `/federate`
+</Concept>
+
+
 <Message type="important">
-  The `/federate` endpoint will not be billed during the beta phase. After the beta, the endpoint will incur additional costs.
+  The `/federate` endpoint will not be billed during the beta phase. After the beta, the endpoint may incur additional costs.
     Refer to the [How to federate metrics](/cockpit/how-to/federate-scaleway-metrics) documentation page for more information.
 </Message>
 

--- a/pages/cockpit/reference-content/cockpit-supported-endpoints.mdx
+++ b/pages/cockpit/reference-content/cockpit-supported-endpoints.mdx
@@ -62,7 +62,13 @@ Refer to the [official Mimir documentation](https://grafana.com/docs/mimir/lates
     - Path: `/prometheus/api/v1/metadata`
     - Path: `/prometheus/api/v1/read`
     - Path: `/prometheus/api/v1/status/buildinfo`
+    - Path: `/federate`
 </Concept>
+
+<Message type="important">
+  The `/federate` endpoint will not be charged during beta phase but please note that after the beta, this endpoint will incurs additional costs.
+  For more information, you can check [this tutorial](../how-to/federate-scaleway-metrics.mdx)
+</Message>
 
 <Concept>
   ## Mimir rules endpoints

--- a/pages/cockpit/reference-content/cockpit-supported-endpoints.mdx
+++ b/pages/cockpit/reference-content/cockpit-supported-endpoints.mdx
@@ -72,7 +72,7 @@ Refer to the [official Mimir documentation](https://grafana.com/docs/mimir/lates
   - Path: `/federate`
 </Concept>
 
-<Message type="info">
+<Message type="note">
   The `/federate` endpoint aims to replicate the behavior of the classic Prometheus `/federate` endpoint, but it is not an official Mimir endpoint.
 </Message>
 

--- a/pages/cockpit/reference-content/cockpit-supported-endpoints.mdx
+++ b/pages/cockpit/reference-content/cockpit-supported-endpoints.mdx
@@ -72,6 +72,9 @@ Refer to the [official Mimir documentation](https://grafana.com/docs/mimir/lates
   - Path: `/federate`
 </Concept>
 
+<Message type="info">
+  The `/federate` endpoint aims to replicate the behavior of the classic Prometheus `/federate` endpoint, but it is not an official Mimir endpoint.
+</Message>
 
 <Message type="important">
   The `/federate` endpoint will not be billed during the beta phase. After the beta, the endpoint may incur additional costs.


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

Add a new documentation "How-to" on how to federate Scaleway product metrics with the new /federate endpoint on Cockpit datasources.

Also add the endpoint in the `supported endpoint` documentation with precision about beta phase