### PR TITLE
feat(changelog): kubernetes-removed-end-of-support-kubernetes-versions-1 2025-06-25

### DIFF
--- a/changelog/june2025/2025-06-25-kubernetes-removed-end-of-support-kubernetes-versions-1.mdx
+++ b/changelog/june2025/2025-06-25-kubernetes-removed-end-of-support-kubernetes-versions-1.mdx
@@ -6,5 +6,5 @@ category: containers
 product: kubernetes
 ---
 
-Clusters using Kubernetes versions 1.27, 1.28, and 1.29 will be automatically upgraded to Kubernetes version 1.30 since April 7, 2025.
+From April 7, 2025, clusters using Kubernetes versions 1.27, 1.28, and 1.29 will be automatically upgraded to Kubernetes version 1.30.
 

--- a/changelog/june2025/2025-06-25-kubernetes-removed-end-of-support-kubernetes-versions-1.mdx
+++ b/changelog/june2025/2025-06-25-kubernetes-removed-end-of-support-kubernetes-versions-1.mdx
@@ -1,10 +1,10 @@
 ---
-title: End of support Kubernetes versions 1.27, 1.28, and 1.29
+title: End of support for Kubernetes versions 1.27, 1.28, and 1.29
 status: removed
 date: 2025-06-25
 category: containers
 product: kubernetes
 ---
 
-Clusters using the Kubernetes 1.27, 1.28, and 1.29 versions will be automatically upgraded to the Kubernetes 1.30 version after April 7th, 2025.
+Clusters using Kubernetes versions 1.27, 1.28, and 1.29 will be automatically upgraded to Kubernetes version 1.30 after April 7, 2025.
 

--- a/changelog/june2025/2025-06-25-kubernetes-removed-end-of-support-kubernetes-versions-1.mdx
+++ b/changelog/june2025/2025-06-25-kubernetes-removed-end-of-support-kubernetes-versions-1.mdx
@@ -1,0 +1,10 @@
+---
+title: End of support Kubernetes versions 1.27, 1.28, and 1.29
+status: removed
+date: 2025-06-25
+category: containers
+product: kubernetes
+---
+
+Clusters using the Kubernetes 1.27, 1.28, and 1.29 versions will be automatically upgraded to the Kubernetes 1.30 version after April 7th, 2025.
+

--- a/changelog/june2025/2025-06-25-kubernetes-removed-end-of-support-kubernetes-versions-1.mdx
+++ b/changelog/june2025/2025-06-25-kubernetes-removed-end-of-support-kubernetes-versions-1.mdx
@@ -6,5 +6,5 @@ category: containers
 product: kubernetes
 ---
 
-Clusters using Kubernetes versions 1.27, 1.28, and 1.29 will be automatically upgraded to Kubernetes version 1.30 after April 7, 2025.
+Clusters using Kubernetes versions 1.27, 1.28, and 1.29 will be automatically upgraded to Kubernetes version 1.30 since April 7, 2025.
 


### PR DESCRIPTION
Reporter: Louis Portay

This PR is a new changelog contribution. It has been created automatically.

Make sure to review it carefully before merging it.