### PR TITLE
fix(vpc): update for deletion of default VPC, and lazy-VPC-create

### DIFF
--- a/pages/elastic-metal/how-to/use-private-networks.mdx
+++ b/pages/elastic-metal/how-to/use-private-networks.mdx
@@ -63,13 +63,8 @@ You can also attach custom resources, such as virtual machines hosted on your El
 3. Click the **Private Networks** tab.
 4. Click **Attach to a Private Network** and continue to step 5. Otherwise, to detach your server from a Private Network, click the <Icon type="unlink" /> icon next to the Private Network and confirm the action when prompted.
 5. Either:
-    - Select **Attach to an existing Private Network**, and choose a network from the drop-down list to attach your server to. Remember, only Private Networks in the same region as your server will be displayed.
-    - Select **Attach to a new Private Network**, and enter a name for the new Private Network you wish to create.
-    <Message type="note">
-    The Private Network will have default settings, meaning:
-      - It is created in your [default VPC](/vpc/concepts/#default-vpc) for the region, if you have one. If you do not have an existing VPC for the appropriate region, you must [create one](/vpc/how-to/create-vpc/#how-to-create-a-vpc) first.
-      - It has an auto-generated [CIDR block](/vpc/concepts/#cidr-block) used to allocate private IP addresses to servers attached to the network. Each attached Elastic Metal server will get an IPv4 and an IPv6 address on the Private Network.
-    </Message>
+    - Select a Private Network from the drop-down list to attach your server to. Remember, only Private Networks in the same region as your server will be displayed.
+    - Alternatively, select **Create a new Private Network** in the list. You are prompted to enter a name and tags for the Private Network, and to select the VPC it should be created in. The Private Network will be created with default configuration, meaning its [CIDR block](/vpc/concepts#cidr-block) will be automatically defined.
 6. Choose whether to **auto-allocate an available IP from the pool** (the [CIDR block](/vpc/concepts/#cidr-block) defined at the time of creating the Private Network), or use a [reserved IP address](/ipam/concepts/#reserved-ip-address) for the attachment. You must make this choice for both the IPv4 and IPv6 address that the Elastic Metal server will have on this Private Network.
 7. Click **Attach to Private Network** to confirm.
 

--- a/pages/instances/how-to/use-private-networks.mdx
+++ b/pages/instances/how-to/use-private-networks.mdx
@@ -40,9 +40,9 @@ If you want to create a Private Network without immediately attaching any resour
 7. Select the VPC to create the Private Network in.
 8. Click **Attach to a Private Network** to finish.
 
-    The Private Network will have default settings, meaning an auto-generated [CIDR block](/vpc/concepts/#cidr-block).
+The Private Network will have default settings, meaning an auto-generated [CIDR block](/vpc/concepts/#cidr-block).
 
-    You are taken back to the Private Networks tab, where your new Private Network is now displayed in the list and you can see the IP address for your Instance on the network. For more information about resources' private IP addresses on a Private Network, see our [dedicated documentation](/vpc/how-to/attach-resources-to-pn/#how-to-view-the-resources-ip-address).
+You are taken back to the Private Networks tab, where your new Private Network is now displayed in the list and you can see the IP address for your Instance on the network. For more information about resources' private IP addresses on a Private Network, see our [dedicated documentation](/vpc/how-to/attach-resources-to-pn/#how-to-view-the-resources-ip-address).
 
 ## How to attach Instances to an existing Private Network
 

--- a/pages/instances/how-to/use-private-networks.mdx
+++ b/pages/instances/how-to/use-private-networks.mdx
@@ -35,11 +35,12 @@ If you want to create a Private Network without immediately attaching any resour
 2. Click the Instance you want to add a Private Network to.
 3. Click the **Private Networks** tab.
 4. Click the **Attach to a Private Network** button. A pop-up displays.
-5. Select **Attach to a new Private Network**.
-6. Enter a **Name** for your Private Network, or leave the randomly-generated name in place.
-7. Click **Attach to a Private Network** to finish.
+5. Click the **Select a Private Network** drop-down, then click **Create a new Private Network**.
+6. Enter a **Name** for your Private Network, or leave the randomly-generated name in place. Optionally, you can also enter tags.
+7. Select the VPC to create the Private Network in.
+8. Click **Attach to a Private Network** to finish.
 
-    Your Private Network is created in your [default VPC](/vpc/concepts/#default-vpc) for the region, if one exists. If you do not have an existing VPC for the appropriate region, you must [create one](/vpc/how-to/create-vpc/#how-to-create-a-vpc) first. The Private Network will have default settings, meaning an auto-generated [CIDR block](/vpc/concepts/#cidr-block).
+    The Private Network will have default settings, meaning an auto-generated [CIDR block](/vpc/concepts/#cidr-block).
 
     You are taken back to the Private Networks tab, where your new Private Network is now displayed in the list and you can see the IP address for your Instance on the network. For more information about resources' private IP addresses on a Private Network, see our [dedicated documentation](/vpc/how-to/attach-resources-to-pn/#how-to-view-the-resources-ip-address).
 
@@ -49,13 +50,12 @@ If you want to create a Private Network without immediately attaching any resour
 2. Click the Instance you want to add a Private Network to.
 3. Click the **Private Networks** tab.
 4. Click the **Attach to a Private Network** button. A pop-up displays.
-5. Select **Attach to an existing Private Network**.
-6. Select the Private Network you want to attach the Instance to.
+5. Select the existing Private Network you want to attach the Instance to from the drop-down list.
     <Message type="note">
       Only Instances from the same region as your Private Network will be available in the drop-down menu.
     </Message>
-7. Choose whether to **auto-allocate an available IP from the pool** (the [CIDR block](/vpc/concepts/#cidr-block) defined at the time of creating the Private Network), or use a **[reserved IP address](/ipam/concepts/#reserved-ip-address)** for the attachment. You must make this choice for both the IPv4 and IPv6 address that the Instance will have on this Private Network.
-8. Click **Attach to Private Network**.
+6. Choose whether to **auto-allocate an available IP from the pool** (the [CIDR block](/vpc/concepts/#cidr-block) defined at the time of creating the Private Network), or use a **[reserved IP address](/ipam/concepts/#reserved-ip-address)** for the attachment. You must make this choice for both the IPv4 and IPv6 address that the Instance will have on this Private Network.
+7. Click **Attach to Private Network**.
 
     You are taken back to the **Private Networks** tab, where you can see the private IP address for the Instance you just attached. For more information about resources' private IP addresses on a Private Network, see our [dedicated documentation](/vpc/how-to/attach-resources-to-pn/#how-to-view-the-resources-ip-address).
 

--- a/pages/load-balancer/how-to/use-with-private-network.mdx
+++ b/pages/load-balancer/how-to/use-with-private-network.mdx
@@ -35,10 +35,9 @@ The Private Network feature of the managed Load Balancers product lets you attac
 2. Click on the Load Balancer that you want to add to a Private Network. The Load Balancer's overview page displays.
 3. Click the **Private Networks** tab.
 4. Click **Attach to a Private Network**. A pop-up displays.
-
-    <Lightbox image={image} alt="" />
-
-5. Select whether to attach to a new Private Network, or an existing one.
+5. Either:
+    - Select a Private Network from the drop-down list to attach your Load Balancer to. Remember, only Private Networks in the same region as your server will be displayed.
+    - Alternatively, select **Create a new Private Network** in the list. You are prompted to enter a name and tags for the Private Network, and to select the VPC it should be created in. The Private Network will be created with default configuration, meaning its [CIDR block](/vpc/concepts#cidr-block) will be automatically defined.
 6. Choose whether to **auto-allocate an available IP from the pool** (the [CIDR block](/vpc/concepts/#cidr-block) defined at the time of creating the Private Network), or use a **[reserved IP address](/ipam/concepts/#reserved-ip-address)** for the attachment.
 7. Click **Attach to Private Network** to validate the form. The Private Network is attached to the Load Balancer and displays in the **Private Network** tab.
 

--- a/pages/public-gateways/how-to/configure-a-public-gateway.mdx
+++ b/pages/public-gateways/how-to/configure-a-public-gateway.mdx
@@ -36,11 +36,11 @@ This page shows you how to attach a [Public Gateway](/public-gateways/concepts/#
 4. Click **Attach to a Private Network** to attach a new Private Network to the Public Gateway.
 
 5. Choose to attach an existing or a new Private Network.
-    - If you want to attach an existing Private Network, select **Attach to an existing Private Network** and choose the desired network from the drop-down list.
+    - If you want to attach an existing Private Network, select the desired network from the drop-down list.
       <Message type="note">
         Only Private Networks which are in the same region as the Public Gateway are displayed in this list.
       </Message>
-    - If you want to create and attach a new Private Network, select **Attach to a new Private Network**. The Private Network will be created with default configuration (a [CIDR block](/vpc/concepts#cidr-block) will be automatically defined), in your default VPC for the region, if one exists. If you do not have an existing VPC for the appropriate region, you must [create one](/vpc/how-to/create-vpc/#how-to-create-a-vpc) first. A name for the Private Network will be suggested, but feel free to overwrite this with a new name of your choice. Dynamic NAT will be automatically activated on the Public Gateway for the Private Network.
+    - If you want to create and attach a new Private Network, select **Create a new Private Network**. You are prompted to enter a name and tags for the Private Network, and to select the VPC it should be created in. The Private Network will be created with default configuration, meaning its [CIDR block](/vpc/concepts#cidr-block) will be automatically defined. Dynamic NAT will be automatically activated on the Public Gateway for the Private Network.
 6. Choose whether to **auto-allocate an available IP from the pool** (the [CIDR block](/vpc/concepts/#cidr-block) defined at the time of creating the Private Network), or use a **[reserved IP address](/ipam/concepts/#reserved-ip-address)** for the attachment.
 7. Use the toggle to select whether to tell the gateway whether or not it should [advertise the default route](/public-gateways/concepts/#default-route) to the internet for attached resources. When activated, other resources on this Private Network will learn the default route through the Public Gateway via DHCP. The route will also be installed in the VPC’s route table, and other Private Networks can [opt in](/vpc/how-to/manage-routing/#how-to-manage-default-route-scope) to receive it. 
 8. Click **Attach to Private Network** to finish. You are taken back to the Private Networks tab, where the network you attached now appears, along with the services configured and the IP address of the Public Gateway.

--- a/pages/vpc/concepts.mdx
+++ b/pages/vpc/concepts.mdx
@@ -32,8 +32,7 @@ An IPv4 CIDR block and an IPv6 CIDR block are defined for each Scaleway Private 
 #### Projects created before 13 May 2025
 <br/>
 - One default VPC was automatically created for each region (Paris, Amsterdam and Warsaw).
-- New Private Networks that you create without specifying a VPC are added to the default VPC for their region.
-
+- You can now choose to delete one or all of your default VPCs. If you do, the behavior for newer Project described below will apply.
 
 #### Projects created after 13 May 2025
 

--- a/pages/vpc/concepts.mdx
+++ b/pages/vpc/concepts.mdx
@@ -32,7 +32,7 @@ An IPv4 CIDR block and an IPv6 CIDR block are defined for each Scaleway Private 
 #### Projects created before 13 May 2025
 <br/>
 - One default VPC was automatically created for each region (Paris, Amsterdam and Warsaw).
-- You can now choose to delete one or all of your default VPCs. If you do, the behavior for newer Project described below will apply.
+- You can now choose to delete one or all of your default VPCs. If you do, the behavior for newer Projects described below will apply.
 
 #### Projects created after 13 May 2025
 

--- a/pages/vpc/faq.mdx
+++ b/pages/vpc/faq.mdx
@@ -20,17 +20,13 @@ A VPC offers layer 3 network isolation. Within each VPC, you can create multiple
 
 <Lightbox image={image} alt="A diagram shows that several Private Networks exist within a single VPC" size="small" />
 
-### What is a default VPC and why can I not delete it?
+### What is a default VPC?
 
-If you created your Scaleway [Project](/organizations-and-projects/concepts/#project) before 13 May 2025, one **default VPC** was automatically created in it for each region (Paris, Amsterdam and Warsaw). Any new Private Networks that you create will be added to the default VPC for their region, unless you override this by specifying a different VPC.
+If you created your Scaleway [Project](/organizations-and-projects/concepts/#project) before 13 May 2025, one **default VPC** was automatically created in it for each region (Paris, Amsterdam and Warsaw). You can now opt to delete these default VPCs, if you wish.
 
-You cannot delete a default VPC, but you can rename it, and/or create other VPCs and use those rather than the default VPCs, if you prefer. Watch this space for upcoming functionality to delete default VPCs.
+If you created your Scaleway Project after 13 May 2025, default VPCs are no longer pre-created for the Project. 
 
-<Message type="note">
-Default VPCs do not prevent you from deleting an otherwise empty Project.
-</Message>
-
-If you created your Scaleway Project after 13 May 2025, default VPCs are no longer pre-created for the Project. Find out more in our [dedicated documentation](/vpc/concepts/#default-vpc).
+Find out more in our [dedicated documentation](/vpc/concepts/#default-vpc).
 
 ## VPC routing
 

--- a/pages/vpc/how-to/create-vpc.mdx
+++ b/pages/vpc/how-to/create-vpc.mdx
@@ -31,7 +31,7 @@ VPC allows you to build your own **V**irtual **P**rivate **C**loud on top of Sca
 
 ### Before 13 May 2025
 
-If you created your Scaleway [Project](/organizations-and-projects/concepts/#project) before 13 May 2025, one **default VPC** was automatically created in it for each region (Paris, Amsterdam and Warsaw). Any new Private Networks that you create without specifying a VPC will be added to the default VPC for their region.
+If you created your Scaleway [Project](/organizations-and-projects/concepts/#project) before 13 May 2025, one **default VPC** was automatically created in it for each region (Paris, Amsterdam and Warsaw).
 
 Click **VPC** in the **Network** section of the Scaleway console side menu. Your VPC [dashboard](https://console.scaleway.com/vpc/vpc) displays:
 
@@ -43,9 +43,7 @@ You see three default VPCs (each with a **DEFAULT** badge next to it), one for e
 - Amsterdam `AMS`
 - Warsaw `WAW`
 
-Each of these VPCs is named `default` (though you can [edit](#how-to-edit-a-vpcs-name-and-tags) the name if you wish). Any new Private Networks that you create will be added to the default VPC for their region, unless you override this by specifying a different VPC.
-
-It is currently not possible to change the default VPC for a region, nor to delete a VPC.
+Each of these VPCs is named `default`, though you can [edit](#how-to-edit-a-vpcs-name-and-tags) the name if you wish, or delete the default VPCs.
 
 ### After 13 May 2025
 
@@ -87,7 +85,4 @@ If you created your Scaleway Project after 13 May 2025, default VPCs are no long
 
     - Hover your mouse over the VPC's name at the top of the page, and click the <Icon name="edit" /> icon that displays. Edit the name as required, and click <Icon name="validate" /> when you're done.
     - Click into the box marked **Tags** and start typing. Hit the spacebar to create the tag. Click the **X** next to any tag to delete it.
-
-It is currently not possible to change the default VPC for a region.
-
 

--- a/pages/vpc/how-to/delete-vpc.mdx
+++ b/pages/vpc/how-to/delete-vpc.mdx
@@ -23,9 +23,7 @@ import image from './assets/scaleway-default-vpc.webp'
 
 ## How to delete a VPC
 
-You can only delete VPCs that:
-- Do not contain any Private Networks or IPAM reserved IPs
-- Are not the [default VPC](/vpc/concepts/#default-vpc) for their region
+You can only delete VPCs that do not contain any Private Networks or IPAM reserved IPs.
 
 1. Click **VPC** in the **Network** section of the Scaleway console side menu. The list of your VPCs displays:
 

--- a/pages/vpc/quickstart.mdx
+++ b/pages/vpc/quickstart.mdx
@@ -56,7 +56,7 @@ Discover the VPC interface on the Scaleway console.
 ## How to create a VPC
 
 <Message type="tip">
-If you created your Scaleway [Project](/organizations-and-projects/concepts/#project) before 13 May 2025, one **default VPC** was automatically created in it for each region (Paris, Amsterdam and Warsaw). [Find out more](/vpc/faq/#what-is-a-default-vpc-and-why-can-i-not-delete-it). 
+If you created your Scaleway [Project](/organizations-and-projects/concepts/#project) before 13 May 2025, one **default VPC** was automatically created in it for each region (Paris, Amsterdam and Warsaw). [Find out more](/vpc/faq/#what-is-a-default-vpc). 
 </Message>
 
 1. Click **VPC** in the **Network** section of the Scaleway console side menu.

--- a/pages/vpc/troubleshooting/cant-delete-vpc-pn.mdx
+++ b/pages/vpc/troubleshooting/cant-delete-vpc-pn.mdx
@@ -54,20 +54,14 @@ The VPC must contain no Private Networks before you can delete it.
 
 In order to successfully delete a Private Network, you must ensure no resources are attached to it, and there are no private IPs reserved within the network. See the [information below](#i-cant-delete-my-private-network) for full details.
 
-**Ensure you are not trying to delete a default VPC**. Each Scaleway Project created before 13 May 2025 has three auto-created default VPCs, one for each region. These VPCs cannot be deleted. They are free of charge. The existence of default VPCs does not block the deletion of a Scaleway account or Project, as long as the default VPCs do not contain Private Networks with associated/attached resources.
-
-    You can identify default VPCs by the **Default** badge in the VPC listing, even if you have changed the name of the VPC itself.
-
-    <Lightbox image={image2} alt="A screenshot of the Scaleway console highlights the DEFAULT badges next to certain VPCs on the VPC listing" />
-
 ## I can't delete my Private Network
 
 ### PN deletion problems
 
-You may be attempting to delete a Private Network VPC via the [Scaleway console](/vpc/how-to/delete-private-network/), [API](https://www.scaleway.com/en/developers/api/vpc/#path-private-networks-delete-a-private-network) or other developer tool, and see one of the following error messages:
+You may be attempting to delete a Private Network via the [Scaleway console](/vpc/how-to/delete-private-network/), [API](https://www.scaleway.com/en/developers/api/vpc/#path-private-networks-delete-a-private-network) or other developer tool, and see one of the following error messages:
 
 - `resource_still_in_use`
-- `Detach resources from this Private to delete it`
+- `Detach resources from this Private Network to delete it`
 - `Private Network must be empty to be deleted`
 - `precondition failed: resource_still_in_use`
 


### PR DESCRIPTION
Two new behaviours are coming:

- Possibility to delete default VPCs, and removal of the whole concept of default VPCs from the console
- Possibliity to create a new VPC "inline" while attaching a resource to a new Private Network