### PR TITLE
fix(blocks): put absolute links for highlight tutorials WDOC-1135

### DIFF
--- a/blocks/highlighted-tutorials.mdx
+++ b/blocks/highlighted-tutorials.mdx
@@ -2,18 +2,18 @@ import plausible from "./assets/scaleway-plausible-tutorial-time.webp"
 import sentry from "./assets/scaleway-sentry-tutorial-time.webp"
 
 <Grid>
-	<Card
-		image={plausible}
-		title="Running web analytics with Plausible on Ubuntu Linux"
-		tags="Analytics Plausible Ubuntu"
-		label="Open Plausible tutorial"
-		url="tutorials/plausible-analytics-ubuntu"
-	/>
-	<Card
-		image={sentry}
-		title="Configuring Sentry error tracking"
-		tags="Sentry"
-		label="Open Sentry tutorial"
-		url="tutorials/sentry-error-tracking"
-	/>
+  <Card
+    image={plausible}
+    title="Running web analytics with Plausible on Ubuntu Linux"
+    tags="Analytics Plausible Ubuntu"
+    label="Open Plausible tutorial"
+    url="/tutorials/plausible-analytics-ubuntu"
+  />
+  <Card
+    image={sentry}
+    title="Configuring Sentry error tracking"
+    tags="Sentry"
+    label="Open Sentry tutorial"
+    url="/tutorials/sentry-error-tracking"
+  />
 </Grid>


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

Please describe what you added or changed.

- Links in highlight cards should be absolute, so this PR change it