### PR TITLE
fix(tutorial): add missing import of image

### DIFF
--- a/tutorials/bash-christmas-tree/index.mdx
+++ b/tutorials/bash-christmas-tree/index.mdx
@@ -12,6 +12,7 @@ dates:
   validation: 2025-03-27
   posted: 2019-11-26
 ---
+import animatedTree from './assets/scaleway-animated-tree.gif'
 
 **Bash**, short for Bourne Again Shell, represents an improved version of Sh (Bourne Shell) and comes built-in with Linux and macOS operating systems. Serving as a shell, it furnishes a command line interface (CLI) for engaging with the computer's operating system. This interface deciphers commands in plain text format, conveying the instructions to the operating system to execute corresponding actions.
 
@@ -122,7 +123,7 @@ ssh root@<Instance Public IP>
     ```
     The script writes an animated tree on the terminal window:
 
-    <Lightbox src="scaleway-animated-tree.gif" alt="" />
+    <Lightbox image={animatedTree} alt="" />
 2. Exit the script by pressing `CTRL` + `c`.
 
 <ClickableBanner


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

Please describe what you added or changed.

Use import of image to get the image and pass it to lightbox image props
