### PR TITLE
docs(instances): add GitLab runner Terraform tutorial ext-add-instances

### DIFF
--- a/tutorials/terraform-dynamic-gitlab-runner/index.mdx
+++ b/tutorials/terraform-dynamic-gitlab-runner/index.mdx
@@ -5,23 +5,24 @@ tags: automation terraform instances GitLab ci-cd
 categories:
   - instances
   - devtools
+dates:
+  validation: 2025-08-05
 ---
 
 import Requirements from '@macros/iam/requirements.mdx'
 
-## Gitlab runner overview
 
 GitLab runners are the components that execute the jobs defined in your GitLab CI/CD pipelines. They can be installed on various operating systems and can run jobs on different platforms. Runners can be configured to be specific to a project or shared across multiple projects.
-With terraform Scaleway provider and GitLab one, runners can be dynamically created and destroyed.
+With the Terraform Scaleway provider and GitLab one, runners can be dynamically created and destroyed.
 
 <Requirements />
 
 - A Scaleway account logged into the [console](https://console.scaleway.com)
 - [Owner](/iam/concepts/#owner) status or [IAM permissions](/iam/concepts/#permission) allowing you to perform actions in the intended Organization
-- [Created IAM API key](/iam/how-to/create-api-keys/)
+- [Created an API key](/iam/how-to/create-api-keys/)
 - A GitLab account and project
 
-## Provision a GitLab runner on a Scaleway instance with terraform.
+## Provision a GitLab runner on a Scaleway Instance with Terraform/OpenTofu.
 
 ### Gitlab setup
 
@@ -31,13 +32,13 @@ The following GitLab CI/CD needs 3 secret variables:
 - SCW_ACCES_KEY
 
 The `GITLAB_TOKEN` needs to be a GitLab personal access token with the **Owner** role, and `create_runner` scope.
-Create the environment variables in your [project cicd settings](https://docs.gitlab.com/ci/variables/)
+Create the environment variables in your [project CI/CD settings](https://docs.gitlab.com/ci/variables/)
 
-### terraform setup
+### Terraform/OpenTofu setup
 
-Start by providing a basic Terraform setup: 
+Start by providing a basic Terraform/OpenTofu setup: 
 
-1. Create the `main.tf` file:
+1. Create a `main.tf` file and paste the following content into it:
         ```hcl
         //providers
         terraform {
@@ -108,7 +109,7 @@ Start by providing a basic Terraform setup:
             value = gitlab_user_runner.project_runner.id
         }
         ```
-2. Create the `var.tf` file:
+2. Create a `var.tf` file and paste the following content into it:
         ```hcl
         variable "project_id" {
             type        = string
@@ -117,7 +118,7 @@ Start by providing a basic Terraform setup:
 
         variable "scw_org_id" {
             type        = string
-            description = "Your scaleway organisation ID"
+            description = "Your Scaleway Organization ID"
         }
 
         variable "secret_key" {
@@ -167,7 +168,7 @@ Start by providing a basic Terraform setup:
             description = "volume in Gb"
         }
         ```
-3. Create the `cloud-init.yml` file:
+3. Create a `cloud-init.yml` file and paste the following content into it:
         ```yml
         #cloud-config
         package_update: true
@@ -192,7 +193,7 @@ Start by providing a basic Terraform setup:
 
 ### Gitlab setup
 
-1. Create the .gitlab-ci.yml :
+1. Create the `.gitlab-ci.yml` configuration file:
         ```yml
         stages:
             - provision
@@ -203,7 +204,7 @@ Start by providing a basic Terraform setup:
             cat <<EOF > env.tfvars
             scw_org_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
             project_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-            access_key = "$SCW_ACCES_KEY"
+            access_key = "$SCW_ACCESS_KEY"
             secret_key = "$SCW_SECRET_KEY"
             gitlab_token = "$GITLAB_TOKEN"
             gitlab_project_id = "$CI_PROJECT_ID"
@@ -299,7 +300,7 @@ Start by providing a basic Terraform setup:
         ```
 
 With this setup, GitLab-CI/CD creates an Instance and registers it as a GitLab runner, runs the workload on the Instance, then deletes the Instance and the runner.
-This setup allows you to dynamically provide high-computation runners in a cost-effective way. You can also customize the cloud init to fit your business needs, such as connecting to your company's VPN.
+This setup allows you to dynamically provide high-computation runners in a cost-effective way. You can also customize the cloud-init to fit your business needs, such as connecting to your company's VPN.
 
 ## Going further
 


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

Added a new tutorial showing how to dynamically create and destroy GitLab runners on Scaleway instances using Terraform. This tutorial provides a cost-effective solution for teams needing high-computation runners on-demand.

**Key features covered:**
- Setting up Terraform configuration with Scaleway and GitLab providers
- Creating cloud-init scripts for automatic GitLab runner registration
- Implementing a complete GitLab CI/CD pipeline that provisions runners, executes jobs, and cleans up resources
- Using custom instance images for specialized use cases

**Target audience:** DevOps engineers and developers looking to optimize CI/CD costs by provisioning runners only when needed.

linked to the #4969 issue
