### PR TITLE
docs: replace old components page with sb url WDOC-1186

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -182,7 +182,7 @@ MDX components are useful for adding rich content and interactions within your c
 
 This section shows code details listed on a full page.
 
-🔎 [See the full Components page](https://scaleway.com/en/docs/components/).
+🔎 [See the full Components page](https://storybook-docs.scaleway.com/).
 
 Feel free to explore this page in your markdown editor to see how the components were used, or in `.mdx` content files that already use MDX components.
 

--- a/docs/DOC_PAGE_TEMPLATE.mdx
+++ b/docs/DOC_PAGE_TEMPLATE.mdx
@@ -10,7 +10,7 @@ categories:
 ---
 
 <Message type="note">
-Refer to the [MDX Components page](https://www.scaleway.com/en/docs/components/docs/) for a comprehensive list of available MDX components.
+Refer to the [MDX Components page](https://storybook-docs.scaleway.com/) for a comprehensive list of available MDX components.
 </Message>
 
 ## H2 Title


### PR DESCRIPTION
### Why

Since the migration to next.js we don't have the components page, but now that we have storybook we can use it instead

### How to test

go to https://storybook-docs.scaleway.com/ it should work, you should have access to every components

