### PR TITLE
fix(genapi): vscode tutorial titles

### DIFF
--- a/pages/generative-apis/reference-content/adding-ai-to-vscode-using-continue.mdx
+++ b/pages/generative-apis/reference-content/adding-ai-to-vscode-using-continue.mdx
@@ -27,9 +27,9 @@ You can install Continue directly from the [Visual Studio Marketplace](https://m
 code --install-extension continue.continue
 ```
 
-### Configure Continue to use Scaleway’s Generative APIs
+## Configure Continue to use Scaleway’s Generative APIs
 
-#### Configure Continue through the graphical interface
+### Configure Continue through the graphical interface
 
 To link Continue with Scaleway's Generative APIs, you can use built-in menus from Continue in VS Code.
 
@@ -48,7 +48,7 @@ These actions will automatically edit your `config.yaml` file. To edit it manual
   Agents, embeddings, and autocomplete models are not yet supported through graphical interface configuration. Manually edit the configuration to enable them. See [Configure Continue through configuration file](#configure-continue-through-configuration-file) for more information.
 </Message>
 
-#### Configure Continue through a configuration file
+### Configure Continue through a configuration file
 
 To link Continue with Scaleway's Generative APIs, you can configure a settings file:
 
@@ -153,7 +153,7 @@ Alternatively, a `config.json` file can be used with the following format. Note 
 </Message>
 
 
-### Activate Continue in VS Code
+## Activate Continue in VS Code
 
 After configuring the API, open VS Code and activate Continue:
 


### PR DESCRIPTION
Fix heading level to align it with similar tutorial for integration within IntelliJ (and make it more readable).
See other tutorial for comparison here:  https://github.com/scaleway/docs-content/edit/main/pages/generative-apis/reference-content/adding-ai-to-intellij-using-continue.mdx
