### PR TITLE
feat(changelog): apple-silicon-added-public-bandwidth-up-to-10gbps 2025-08-25

### DIFF
--- a/changelog/august2025/2025-08-25-apple-silicon-added-public-bandwidth-up-to-10gbps.mdx
+++ b/changelog/august2025/2025-08-25-apple-silicon-added-public-bandwidth-up-to-10gbps.mdx
@@ -1,5 +1,5 @@
 ---
-title: Public bandwidth up to 10Gbps
+title: Public bandwidth up to 10 Gbps
 status: added
 date: 2025-08-25
 category: bare-metal


### PR DESCRIPTION
Reporter: Alexia Valais

This PR is a new changelog contribution. It has been created automatically.

Make sure to review it carefully before merging it.