### PR TITLE
chore(k8s): remove note about allowed IP configuration

### DIFF
--- a/pages/kubernetes/how-to/manage-allowed-ips.mdx
+++ b/pages/kubernetes/how-to/manage-allowed-ips.mdx
@@ -22,10 +22,6 @@ The default entry `0.0.0.0/0` enables any host to establish a connection.
   Every cluster created after March 8th 2025 has this feature enabled by default. If you do not see the **Network** tab in your cluster's dashboard in the Scaleway console, then the feature is not enabled on your cluster. You can [open a support ticket](https://console.scaleway.com/support/tickets/create) to have it enabled manually.
 </Message>
 
-<Message type="note">
-  Allowed IP configuration is available for [fully isolated Kapsule clusters](/kubernetes/reference-content/secure-cluster-with-private-network/#what-is-the-difference-between-controlled-isolation-and-full-isolation), and Kosmos clusters.
-</Message>
-
 ## How to add an IP address
 
 1. Click **Kubernetes** in the **Containers** section of the [Scaleway console](https://console.scaleway.com). The **Kubernetes dashboard** appears.


### PR DESCRIPTION
Note is wrong, feature is also available on classic kapsule