### PR TITLE
fix(vpc): fix serverless stuff

### DIFF
--- a/pages/vpc/how-to/attach-resources-to-pn.mdx
+++ b/pages/vpc/how-to/attach-resources-to-pn.mdx
@@ -114,7 +114,7 @@ You can also attach a managed resource to a Private Network from the resource's 
 - [Serverless Functions](/serverless-functions/how-to/use-private-networks/)
 - [Serverless Containers](/serverless-containers/how-to/use-private-networks/)
 
-Note that for Kubernetes Kapsules and Managed Databases for Redis™, you can only attach the resource to a Private Network at the time of creating the resource itself. Serverless Functions and Containers can only be attached to Private Networks if they have been created in a namespace that supports VPC.
+Note that for Kubernetes Kapsules and Managed Databases for Redis™, you can only attach the resource to a Private Network at the time of creating the resource itself.
 </Message>
 
 For Elastic Metal servers and Apple silicon Mac minis, manual configuration of the network interface is required. This is not required for Instances or other types of managed resource. See the relevant documentation for [Elastic Metal](/elastic-metal/how-to/use-private-networks/#how-to-configure-the-network-interface-on-your-elastic-metal-server-for-private-networks) or [Apple silicon](/apple-silicon/how-to/use-private-networks/) for full instructions.


### PR DESCRIPTION
Remove stuff about VPC enabled namespaces for serverless
