### PR TITLE
docs(ins): remove pricing info

### DIFF
--- a/pages/billing/faq.mdx
+++ b/pages/billing/faq.mdx
@@ -2,7 +2,7 @@
 title: Billing FAQ
 description: Discover billing methods, plans, and pricing for Scaleway products. Learn about invoicing details, billing events, pro-rata billing, invoice statuses, payment methods, and managing your billing efficiently.
 dates:
-  validation: 2025-08-18
+  validation: 2025-09-03
 productIcon: BillingProductIcon
 ---
 
@@ -16,12 +16,6 @@ Your monthly invoice is calculated at the end of each month and based on your ho
 <Message type="important">
   Some of our products are invoiced separately.
 </Message>
-
-For example:
-The Stardust1-s indicated at €0,0025 excl/hour can be split up as follows:
-- €0.00198/hour for the IP
-- €0.0004/hour for the 10 GB of Local Storage
-- €0.00012/hour for the instance
 
 For more information, refer to our dedicated [pricing page](https://www.scaleway.com/en/pricing/).
 

--- a/pages/dedibox/faq.mdx
+++ b/pages/dedibox/faq.mdx
@@ -2,7 +2,7 @@
 title: Dedibox FAQ
 description: Discover Scaleway Dedibox dedicated servers.
 dates:
-  validation: 2025-03-03
+  validation: 2025-09-03
 productIcon: DediboxProductIcon
 ---
 
@@ -64,12 +64,4 @@ Windows Server 2019 and 2022 licenses are billed monthly (no prorating) based on
 - Number of cores per CPU
 - Operating System version: Standard or Datacenter
 
-**Important:**
-Starting **February 1, 2025**, the price of Windows licenses for new and existing Dedibox customers will increase due to a price adjustment from Microsoft.
-
-Below is a comparison of the current and updated pricing for Windows licenses on Dedibox servers:
-
-| **License Type**           | **Current Price per Core** | **New Price per Core (Feb 1, 2025)** |
-|----------------------------|----------------------------|--------------------------------------|
-| Windows Server Standard    | €2.75 /month              | €3.15 /month                         |
-| Windows Server Datacenter  | €17.88 /month             | €21.00 /month                        |
+Refer to the [Pricing page](https://www.scaleway.com/en/pricing/dedibox-options/#windows-licences) to learn about the current costs for Windows licenses.

--- a/pages/elastic-metal/faq.mdx
+++ b/pages/elastic-metal/faq.mdx
@@ -3,7 +3,7 @@ title: Elastic Metal FAQ
 description: Explore Scaleway Elastic Metal servers, pioneering 100% cloud bare metal solutions. Learn about billing, server ranges, installation guides, and more.
 hero: assets/elasticmetal.webp
 dates:
-  validation: 2025-06-23
+  validation: 2025-09-03
 productIcon: ElasticMetalProductIcon
 ---
 
@@ -78,15 +78,7 @@ Windows Server 2019 and 2022 licenses are billed monthly (no prorating) based on
 - Number of cores per CPU
 - Operating System version: Standard or Datacenter
 
-**Important:**
-Starting **February 1, 2025**, the price of Windows licenses for new and existing Elastic Metal customers will increase due to a price adjustment from Microsoft.
-
-Below is a comparison of the current and updated pricing for Windows licenses on Elastic Metal servers:
-
-| **License type**           | **Current price per core** | **New price per core (Feb 1, 2025)** |
-|----------------------------|----------------------------|--------------------------------------|
-| Windows Server Standard    | €2.75 /month              | €3.15 /month                         |
-| Windows Server Datacenter  | €17.88 /month             | €21.00 /month                        |
+*Refer to the [Pricing page](https://www.scaleway.com/en/pricing/elastic-metal/#windows-licences) to learn about the current costs for Windows licenses.
 
 <Message type="note">
   Licenses are billed monthly, regardless of whether your Elastic Metal server is billed on an hourly or monthly basis.
@@ -195,4 +187,3 @@ After installing the OS, you can manually enable Hyper-V roles from the Roles an
 ### How many virtual machines can I install under Hyper-V?
 
 Hyper-V is a hypervisor for hosting virtual machines. The Standard version of Microsoft Server allows you to install 2 virtual machines per host (per Elastic Metal server). The number of virtual machines (VM) on the Datacenter version is unlimited.
-

--- a/pages/instances/faq.mdx
+++ b/pages/instances/faq.mdx
@@ -3,7 +3,7 @@ title: Instances FAQ
 description: Discover Scaleway Instances and learn the difference between images and snapshots.
 tags: instances pricing scaleway
 dates:
-  validation: 2025-03-25
+  validation: 2025-09-03
 productIcon: InstanceProductIcon
 ---
 
@@ -53,116 +53,11 @@ You can change the storage type and flexible IP after the Instance creation, whi
 
 ### What are the prices for Instances?
 
-<Message type="note">
-  * Prices indicated below do not include storage or IP.
-  * *All regions refer to `PAR1`, `PAR2`, `AMS1`, `AMS2`, `AMS3`, `WAW1`, `WAW2`, and `WAW3`. Some ranges might not be available in some of these regions. Check the [Instances availability guide](/account/reference-content/products-availability/) to discover where each Instance type is available.
-  * PAR3 prices are shown separately.
-</Message>
-
-
-| Range             | Price for all regions* | Price for PAR3    |
-|-------------------|------------------------|-------------------|
-| STARDUST1-S       | €0.0046/hour           | Not available     |
-| COPARM1-2C-8G     | €0.0426/hour           | Not available     |
-| COPARM1-4C-16G    | €0.0857/hour           | Not available     |
-| COPARM1-8C-32G    | €0.1724/hour           | Not available     |
-| COPARM1-16C-64G   | €0.3454/hour           | Not available     |
-| COPARM1-32C-128G  | €0.6935/hour           | Not available     |
-| PRO2-XXS          | €0.055/hour            | €0.082/hour       |
-| PRO2-XS           | €0.11/hour             | €0.164/hour       |
-| PRO2-S            | €0.219/hour            | €0.329/hour       |
-| PRO2-M            | €0.438/hour            | €0.658/hour       |
-| PRO2-L            | €0.877/hour            | €1.315/hour       |
-| PLAY2-PICO        | €0.014/hour            | Not available     |
-| PLAY2-NANO        | €0.027/hour            | Not available     |
-| PLAY2-MICRO       | €0.054/hour            | Not available     |
-| GP1-XS            | €0.1016/hour           | Not available     |
-| GP1-S             | €0.2042/hour           | Not available     |
-| GP1-M             | €0.4064/hour           | Not available     |
-| GP1-L             | €0.7894/hour           | Not available     |
-| GP1-XL            | €1.6714/hour           | Not available     |
-| DEV1-S            | €0.0137/hour           | Not available     |
-| DEV1-M            | €0.0256/hour           | Not available     |
-| DEV1-L            | €0.0495/hour           | Not available     |
-| DEV1-XL           | €0.0731/hour           | Not available     |
-| POP2-2C-8G        | €0.0735/hour           | €0.1103/hour      |
-| POP2-4C-16G       | €0.147/hour            | €0.2205/hour      |
-| POP2-8C-32G       | €0.29/hour             | €0.435/hour       |
-| POP2-16C-64G      | €0.59/hour             | €0.885/hour       |
-| POP2-32C-128G     | €1.18/hour             | €1.77/hour        |
-| POP2-48C-192G     | €1.77/hour             | €2.655/hour       |
-| POP2-64C-256G     | €2.35/hour             | €3.525/hour       |
-
-**General Purpose Instances with Windows Server operating system**
-
-| Range             | Price for all regions* | Price for PAR3    |
-|-------------------|------------------------|-------------------|
-| POP2-2C-8G-WIN    | €0.1823/hour           | Not available     |
-| POP2-4C-16G-WIN   | €0.3637/hour           | Not available     |
-| POP2-8C-32G-WIN   | €0.7233/hour           | Not available     |
-| POP2-16C-64G-WIN  | €1.4567/hour           | Not available     |
-| POP2-32C-128-WIN  | €2.9133/hour           | Not available     |
-
-**Specialized Instances**
-
-| Range             | Price for all regions* | Price for PAR3    |
-|-------------------|------------------------|-------------------|
-| POP2-HM-2C-16G    | €0.103/hour            | €0.1545/hour      |
-| POP2-HM-4C-32G    | €0.206/hour            | €0.309/hour       |
-| POP2-HM-8C-64G    | €0.412/hour            | €0.618/hour       |
-| POP2-HM-16C-128G  | €0.824/hour            | €1.236/hour       |
-| POP2-HM-32C-256G  | €1.648/hour            | €2.472/hour       |
-| POP2-HM-48C-384G  | €2.47/hour             | €3.705/hour       |
-| POP2-HM-64C-512G  | €3.296/hour            | €4.944/hour       |
-| POP2-HC-2C-4G     | €0.0532/hour           | €0.0798/hour      |
-| POP2-HC-4C-8G     | €0.1064/hour           | €0.1596/hour      |
-| POP2-HC-8C-16G    | €0.2128/hour           | €0.3192/hour      |
-| POP2-HC-16C-32G   | €0.4256/hour           | €0.6384/hour      |
-| POP2-HC-32C-64G   | €0.8512/hour           | €1.2768/hour      |
-| POP2-HC-48C-96G   | €1.27/hour             | €1.905/hour       |
-| POP2-HC-64C-128G  | €1.7024/hour           | €2.5536/hour      |
-| POP2-HN-3         | €0.2554/hour           | €0.3831/hour      |
-| POP2-HC-5         | €0.4524/hour           | €0.6786/hour      |
-| POP2-HC-10        | €0.7264/hour           | €1.0896/hour      |
-
-**GPU Instances**
-
-| Range             | Available in           | Price             |
-|-------------------|------------------------|-------------------|
-| H100-SXM-2-80G    | PAR2                   | €6.018/hour¹       |
-| H100-SXM-4-80G    | PAR2                   | €11.61/hour¹       |
-| H100-SXM-8-80G    | PAR2                   | €23.028/hour¹      |
-| H100-1-80G        | PAR2, WAW2             | €2.52/hour¹       |
-| H100-2-80G        | PAR2, WAW2             | €5.04/hour¹       |
-| L40S-1-48G        | PAR2                   | €1.40/hour¹       |
-| L40S-2-48G        | PAR2                   | €2.80/hour¹       |
-| L40S-4-48G        | PAR2                   | €5.60/hour¹       |
-| L40S-8-48G        | PAR2                   | €11.20/hour¹      |
-| L4-1-24G          | PAR2, WAW2             | €0.75/hour¹       |
-| L4-2-24G          | PAR2, WAW2             | €1.50/hour¹       |
-| L4-4-24G          | PAR2, WAW2             | €3.00/hour¹       |
-| L4-8-24G          | PAR2, WAW2             | €6.00/hour¹       |
-| RENDER-S          | PAR1, PAR2             | €1.2426/hour      |
-| GPU-3070-S        | PAR2                   | €0.98/hour        |
-
-¹= Billed per minute.
-
-<Message type="note">
-  `PLAY2-PICO` and `DEV1-S` Instances are not available for [Kubernetes Kapsule](/kubernetes/quickstart/) due to RAM constraints.
-</Message>
-
+Refer to the [Pricing page](https://www.scaleway.com/en/pricing/virtual-instances/) to learn about the cost of each Instance type.
 
 ### What are the storage prices for Instances?
 
-| Product           | All regions*           | PAR3              |
-|-------------------|------------------------|-------------------|
-| Local Storage     | €0.000044 GB/hour      | Not available     |
-| Local snapshot    | €0.000044 GB/hour      | Not available     |
-| Block Storage     | €0.000118 GB/hour      | €0.000177 GB/hour |
-| Block snapshot    | €0.000044 GB/hour      | €0.000066 GB/hour |
-
-*All regions include `PAR1`, `PAR2`, `AMS1`, `AMS2`, `AMS3`, `WAW1`, `WAW2`, and `WAW3`. `PAR3` prices are shown separately.
-
+Refer to the [Pricing page](https://www.scaleway.com/en/pricing/storage/) to learn about the storage fees for Instances.
 
 ### How much does a flexible IP cost?
 


### PR DESCRIPTION
### Description

Removed pricing detailing from doc pages and replaced the info with a link to the Pricing page on the Scaleway main website.
