### PR TITLE
feat(changelog): apple-silicon-added-macos-26-now-available 2025-09-22

### DIFF
--- a/changelog/september2025/2025-09-22-apple-silicon-added-macos-26-now-available.mdx
+++ b/changelog/september2025/2025-09-22-apple-silicon-added-macos-26-now-available.mdx
@@ -1,0 +1,10 @@
+---
+title: macOS 26 now available
+status: added
+date: 2025-09-22
+category: bare-metal
+product: apple-silicon
+---
+
+macOS Tahoe 26 is now available for installation on Mac minis M2 and M4.
+


### PR DESCRIPTION
Reporter: Alexia Valais

This PR is a new changelog contribution. It has been created automatically.

Make sure to review it carefully before merging it.