### PR TITLE
feat(dedibox): fix concepts

### DIFF
--- a/pages/dedibox-account/concepts.mdx
+++ b/pages/dedibox-account/concepts.mdx
@@ -33,12 +33,22 @@ The Dedibox console allows you to view and manage your Scaleway Dedibox products
 
 On this page you can see a list of connections made to your account. Each connection attempt is tracked with its associated status. It can either be **Login** for successful connections or **Connection refused** for failed logins.
 
-## Messages: The messages section of the Scaleway Dedibox console contains important messages regarding your account or your services. You will find information regarding planned maintenance or other important information in this section of the console.
+## Messages
 
-## Notifications: The notification section lets you define for which services you want to receive notifications by email. By default, you receive notifications for all your services requiring renewal (domain names and Webhosting services). You can opt out if you do not want to receive renewal notifications for certain services.
+The messages section of the Scaleway Dedibox console contains important messages regarding your account or your services. You will find information regarding planned maintenance or other important information in this section of the console.
 
-## Outsourcing: Outsourcing allows you to provide access to your services to third parties. You can define another Scaleway Dedibox user who will have access to specific resources of your account, without needing to provide access to your full account. Scaleway Dedibox maintains a portfolio of [certified outsourcing partners](https://www.scaleway.com/en/dedibox/outsourcing/) for webmastering and administration of your dedicated servers.
+## Notifications
 
-## Personal information: The personal information section of the Scaleway Dedibox console allows you to view and update certain personal information related to your account. You can also update your password or email address from this section of the Dedibox console.
+The notification section lets you define for which services you want to receive notifications by email. By default, you receive notifications for all your services requiring renewal (domain names and Webhosting services). You can opt out if you do not want to receive renewal notifications for certain services.
 
-## Security: The security section of the Scaleway Dedibox console allows you to configure optional multifactor authentication to increase the security of your account. You can configure MFA using authentications applications such as Authy or Google Authenticator. French residents cans optionally also configure MFA by SMS.
+## Outsourcing
+
+Outsourcing allows you to provide access to your services to third parties. You can define another Scaleway Dedibox user who will have access to specific resources of your account, without needing to provide access to your full account. Scaleway Dedibox maintains a portfolio of [certified outsourcing partners](https://www.scaleway.com/en/dedibox/outsourcing/) for webmastering and administration of your dedicated servers.
+
+## Personal information
+
+The personal information section of the Scaleway Dedibox console allows you to view and update certain personal information related to your account. You can also update your password or email address from this section of the Dedibox console.
+
+## Security
+
+The security section of the Scaleway Dedibox console allows you to configure optional multifactor authentication to increase the security of your account. You can configure MFA using authentications applications such as Authy or Google Authenticator. French residents cans optionally also configure MFA by SMS.


### PR DESCRIPTION
The concepts do not appear correctly on Dedibox account page: in the end, they are all included in "Logs" while they should not. 
<img width="911" height="616" alt="Capture d’écran 2025-09-23 à 13 50 00" src="https://github.com/user-attachments/assets/fd79d295-5582-4ed0-aaa3-57307ee2daf2" />
