### PR TITLE
docs(dedibox-hardware): update smartctl troubleshooting ext-fix-dedibox-defective-disk-position

### DIFF
--- a/pages/dedibox-hardware/troubleshooting/diagnose-defective-disk.mdx
+++ b/pages/dedibox-hardware/troubleshooting/diagnose-defective-disk.mdx
@@ -191,7 +191,7 @@ Local Time is: Fri Oct 29 11:20:27 2010 CEST
 
 When you create a support ticket to replace a defective disk, you must also provide the **physical location** of the disk.
 
-Use the following command to retrieve the position of all disks, and copy/paste the result into your support ticket :
+Use the following command to retrieve the position of all disks, and copy/paste the result into your support ticket:
 
 <Message type="important">
   This command works **only for software RAID** setups.


### PR DESCRIPTION
### Description

This PR updates the troubleshooting documentation for defective disks:

- Added a section on how to retrieve the **physical position** of a disk.
- Added a warning note to clarify that the command works only for software RAID.