### PR TITLE
docs(cockpit): k8s-monitoring autodiscovery annotations placement. ext-fix-cockpit

### DIFF
--- a/pages/cockpit/how-to/send-metrics-from-k8s-to-cockpit.mdx
+++ b/pages/cockpit/how-to/send-metrics-from-k8s-to-cockpit.mdx
@@ -70,20 +70,20 @@ alloy-singleton:
 
 ## Add annotations for auto-discovery
 
-Annotations in Kubernetes provide a way to attach metadata to your resources. For `k8s-monitoring`, these annotations signal which Pods should be scraped for metrics, and what port to use. In this documentation we are adding annotations to specify we want `k8s-monitoring` to scrape the Pods from our deployment. Make sure that you replace `$METRICS_PORT` with the port where your application exposes Prometheus metrics.
+Annotations in Kubernetes provide a way to attach metadata to your resources. For `k8s-monitoring`, these annotations signal which Pods should be scraped for metrics, and what port to use. These annotations have to be on the Pods that the deployement will spawn so they have to be in the Pod template, not the deployement itself.
+In this documentation we are adding annotations to specify we want `k8s-monitoring` to scrape the Pods from our deployment. Make sure that you replace `$METRICS_PORT` with the port where your application exposes Prometheus metrics.
 
 ### Kubernetes deployment template
 
 ```yaml
 apiVersion: apps/v1
 kind: Deployment
-metadata:
-  ...
-  annotations:
-    "k8s.grafana.com/metrics.portNumber" = "$METRICS_PORT"
-    "k8s.grafana.com/scrape" = "true"
 spec:
-  ...
+  template:
+    metadata:
+      annotations:
+        "k8s.grafana.com/metrics.portNumber" = "$METRICS_PORT"
+        "k8s.grafana.com/scrape" = "true"
 ```
 
 ### Terraform/OpenTofu deployment template


### PR DESCRIPTION
ext-fix-cockpit

alloy-metric agent looks at annotation at the Pod level, not deployment.

### Your checklist for this pull request

- [x] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

Changed the deployment example and added a little warning in the preceding explanation.

You can refer here for the original helm chart [documentation](https://github.com/grafana/k8s-monitoring-helm/tree/main/charts/k8s-monitoring/charts/feature-annotation-autodiscovery) which clearly state : 

> With this feature enabled, any Kubernetes Pods or Services with the k8s.grafana.com/scrape annotation set to true will be automatically discovered and scraped by the collector.
