### PR TITLE
feat(changelog): generative-apis-deprecated-devstral-small-is-now-deprec 2025-10-14

### DIFF
--- a/changelog/october2025/2025-10-14-generative-apis-deprecated-devstral-small-is-now-deprec.mdx
+++ b/changelog/october2025/2025-10-14-generative-apis-deprecated-devstral-small-is-now-deprec.mdx
@@ -8,5 +8,5 @@ product: generative-apis
 
 [Devstral small](https://www.scaleway.com/en/docs/generative-apis/reference-content/supported-models/) will not exit Preview stage and is now deprecated.
 
-Following our [model lifecycle policy](https://www.scaleway.com/en/docs/generative-apis/reference-content/model-lifecycle/), this model will remain accessible up to November 14th, 2025. After this date, requests will be routed automatically to a similar model: [Qwen3 Coder](https://www.scaleway.com/en/docs/generative-apis/reference-content/supported-models/).
+Following our [model lifecycle policy](https://www.scaleway.com/en/docs/generative-apis/reference-content/model-lifecycle/), this model will remain accessible until November 14th, 2025. After this date, requests will be routed automatically to a similar model: [Qwen3 Coder](https://www.scaleway.com/en/docs/generative-apis/reference-content/supported-models/).
 


### PR DESCRIPTION
Reporter: Franck Pagny

This PR is a new changelog contribution. It has been created automatically.

Make sure to review it carefully before merging it.