### PR TITLE
fix(menu): apply strict menu naming

### DIFF
--- a/menu/navigation.ts
+++ b/menu/navigation.ts
@@ -1,65 +1,67 @@
+// please use precise camel case versions of each product slug
+// for its associated menu naming, to avoid breaking tooling
 import { accountMenu } from '../pages/account/menu'
-import { billingMenu } from '../pages/billing/menu'
-import { environmentalFootprintMenu } from '../pages/environmental-footprint/menu'
-import { iamMenu } from '../pages/iam/menu'
-import { keyManagerMenu } from '../pages/key-manager/menu'
-import { organizationsNProjectsMenu } from '../pages/organizations-and-projects/menu'
-import { secretManagerMenu } from "../pages/secret-manager/menu"
-import { generativeApisMenu } from "../pages/generative-apis/menu"
-import { managedInferenceMenu } from "../pages/managed-inference/menu"
 import { appleSiliconMenu } from "../pages/apple-silicon/menu"
-import { ddxScwMenu } from "../pages/dedibox-scaleway/menu"
-import { elasticMetalMenu } from "../pages/elastic-metal/menu"
-import { instanceMenu } from '../pages/instances/menu'
-import { gpuMenu } from "../pages/gpu/menu"
-import { containerRegistryMenu } from "../pages/container-registry/menu"
-import { kubernetesMenu } from "../pages/kubernetes/menu"
-import { managedDatabasePostgresMySqlMenu } from "../pages/managed-databases-for-postgresql-and-mysql/menu"
-import { managedDatabaseRedisMenu } from "../pages/managed-databases-for-redis/menu"
-import { managedDatabaseMongoDbMenu } from "../pages/managed-mongodb-databases/menu"
-import { openSearchMenu } from "../pages/opensearch/menu"
-import { serverlessSqlDatabasesMenu } from "../pages/serverless-sql-databases/menu"
-import { dataWarehouseMenu } from "../pages/data-warehouse/menu"
-import { dataLabMenu } from "../pages/data-lab/menu"
-import { natsMenu } from "../pages/nats/menu"
-import { scwCliMenu } from "../pages/scaleway-cli/menu"
-import { scwSdkMenu } from "../pages/scaleway-sdk/menu"
-import { terraformMenu } from "../pages/terraform/menu"
-import { domainsAndDnsMenu } from "../pages/domains-and-dns/menu"
-import { transactionalEmailMenu } from "../pages/transactional-email/menu"
-import { webHostingMenu } from "../pages/webhosting/menu"
-import { iotHubMenu } from "../pages/iot-hub/menu"
-import { topicsAndEventsMenu } from "../pages/topics-and-events/menu"
-import { queuesMenu } from "../pages/queues/menu"
 import { auditTrailMenu } from "../pages/audit-trail/menu"
+import { billingMenu } from '../pages/billing/menu'
+import { blockStorageMenu } from "../pages/block-storage/menu"
+import { classicHostingMenu } from "../pages/classic-hosting/menu"
 import { cockpitMenu } from "../pages/cockpit/menu"
+import { containerRegistryMenu } from "../pages/container-registry/menu"
+import { cpanelHostingMenu } from "../pages/cpanel-hosting/menu"
+import { dataLabMenu } from "../pages/data-lab/menu"
+import { dataWarehouseMenu } from "../pages/data-warehouse/menu"
+import { dediboxMenu } from "../pages/dedibox/menu"
+import { dediboxAccountMenu } from "../pages/dedibox-account/menu"
+import { dediboxDnsMenu } from "../pages/dedibox-dns/menu"
+import { dediboxDomainsMenu } from "../pages/dedibox-domains/menu"
+import { dediboxHardwareMenu } from "../pages/dedibox-hardware/menu"
+import { dediboxIpFailoverMenu } from "../pages/dedibox-ip-failover/menu"
+import { dediboxIpv6Menu } from "../pages/dedibox-ipv6/menu"
+import { dediboxKvmOverIpMenu } from "../pages/dedibox-kvm-over-ip/menu"
+import { dediboxNetworkMenu } from "../pages/dedibox-network/menu"
+import { dediboxRpnMenu } from "../pages/dedibox-rpn/menu"
+import { dediboxScalewayMenu } from "../pages/dedibox-scaleway/menu"
+import { dediboxVpsMenu } from "../pages/dedibox-vps/menu"
+import { domainsAndDnsMenu } from "../pages/domains-and-dns/menu"
 import { edgeServicesMenu } from "../pages/edge-services/menu"
-import { interLinkMenu } from "../pages/interlink/menu"
+import { elasticMetalMenu } from "../pages/elastic-metal/menu"
+import { environmentalFootprintMenu } from '../pages/environmental-footprint/menu'
+import { fileStorageMenu } from "../pages/file-storage/menu"
+import { generativeApisMenu } from "../pages/generative-apis/menu"
+import { gpuMenu } from "../pages/gpu/menu"
+import { iamMenu } from '../pages/iam/menu'
+import { instancesMenu } from '../pages/instances/menu'
+import { interlinkMenu } from "../pages/interlink/menu"
+import { iotHubMenu } from "../pages/iot-hub/menu"
 import { ipamMenu } from "../pages/ipam/menu"
-import { loadBalancersMenu } from "../pages/load-balancer/menu"
+import { keyManagerMenu } from '../pages/key-manager/menu'
+import { kubernetesMenu } from "../pages/kubernetes/menu"
+import { loadBalancerMenu } from "../pages/load-balancer/menu"
+import { localStorageMenu } from "../pages/local-storage/menu"
+import { managedDatabasesForPostgresAndMysqlMenu } from "../pages/managed-databases-for-postgresql-and-mysql/menu"
+import { managedDatabasesForRedisMenu } from "../pages/managed-databases-for-redis/menu"
+import { managedInferenceMenu } from "../pages/managed-inference/menu"
+import { managedMongodbDatabasesMenu } from "../pages/managed-mongodb-databases/menu"
+import { natsMenu } from "../pages/nats/menu"
+import { objectStorageMenu } from "../pages/object-storage/menu"
+import { openSearchMenu } from "../pages/opensearch/menu"
+import { organizationsAndProjectsMenu } from '../pages/organizations-and-projects/menu'
+import { partnerSpaceMenu } from "../pages/partner-space/menu"
 import { publicGatewaysMenu } from "../pages/public-gateways/menu"
-import { vpcMenu } from "../pages/vpc/menu"
+import { queuesMenu } from "../pages/queues/menu"
+import { scalewayCliMenu } from "../pages/scaleway-cli/menu"
+import { scalewySdkMenu } from "../pages/scaleway-sdk/menu"
+import { secretManagerMenu } from "../pages/secret-manager/menu"
 import { serverlessContainersMenu } from "../pages/serverless-containers/menu"
 import { serverlessFunctionsMenu } from "../pages/serverless-functions/menu"
 import { serverlessJobsMenu } from "../pages/serverless-jobs/menu"
-import { blockStorageMenu } from "../pages/block-storage/menu"
-import { fileStorageMenu } from "../pages/file-storage/menu"
-import { localStorageMenu } from "../pages/local-storage/menu"
-import { objectStorageMenu } from "../pages/object-storage/menu"
-import { classicHostingMenu } from "../pages/classic-hosting/menu"
-import { cpanelHostingMenu } from "../pages/cpanel-hosting/menu"
-import { ddxAccountMenu } from "../pages/dedibox-account/menu"
-import { ddxHardwareMenu } from "../pages/dedibox-hardware/menu"
-import { ddxVpsMenu } from "../pages/dedibox-vps/menu"
-import { ddxMenu } from "../pages/dedibox/menu"
-import { ddxKvmOverIpMenu } from "../pages/dedibox-kvm-over-ip/menu"
-import { ddxDomainsMenu } from "../pages/dedibox-domains/menu"
-import { ddxDnsMenu } from "../pages/dedibox-dns/menu"
-import { ddxIpFailoverMenu } from "../pages/dedibox-ip-failover/menu"
-import { ddxIpv6Menu } from "../pages/dedibox-ipv6/menu"
-import { ddxNetworkMenu } from "../pages/dedibox-network/menu"
-import { ddxRpnMenu } from "../pages/dedibox-rpn/menu"
-import { partnerSpaceMenu } from "../pages/partner-space/menu"
+import { serverlessSqlDatabasesMenu } from "../pages/serverless-sql-databases/menu"
+import { terraformMenu } from "../pages/terraform/menu"
+import { topicsAndEventsMenu } from "../pages/topics-and-events/menu"
+import { transactionalEmailMenu } from "../pages/transactional-email/menu"
+import { vpcMenu } from "../pages/vpc/menu"
+import { webHostingMenu } from "../pages/webhosting/menu"
 
 export default [
   {
@@ -86,7 +88,7 @@ export default [
         items: [
           iamMenu,
           keyManagerMenu,
-          organizationsNProjectsMenu,
+          organizationsAndProjectsMenu,
           secretManagerMenu,
         ],
         label: 'Security & Identity',
@@ -110,7 +112,7 @@ export default [
         icon: 'BaremetalCategoryIcon',
         items: [
           appleSiliconMenu,
-          ddxScwMenu,
+          dediboxScalewayMenu,
           elasticMetalMenu,
         ],
         label: 'Bare Metal',
@@ -119,7 +121,7 @@ export default [
       {
         icon: 'ComputeCategoryIcon',
         items: [
-          instanceMenu,
+          instancesMenu,
           gpuMenu,
         ],
         label: 'Compute',
@@ -137,9 +139,9 @@ export default [
       {
         icon: 'DatabaseCategoryIcon',
         items: [
-          managedDatabasePostgresMySqlMenu,
-          managedDatabaseRedisMenu,
-          managedDatabaseMongoDbMenu,
+          managedDatabasesForPostgresAndMysqlMenu,
+          managedDatabasesForRedisMenu,
+          managedMongodbDatabasesMenu,
           openSearchMenu,
           serverlessSqlDatabasesMenu,
         ],
@@ -159,8 +161,8 @@ export default [
       {
         icon: 'DevToolsCategoryIcon',
         items: [
-          scwCliMenu,
-          scwSdkMenu,
+          scalewayCliMenu,
+          scalewySdkMenu,
           terraformMenu,
         ],
         label: 'Developer Tools',
@@ -199,9 +201,9 @@ export default [
         icon: 'NetworkCategoryIcon',
         items: [
           edgeServicesMenu,
-          interLinkMenu,
+          interlinkMenu,
           ipamMenu,
-          loadBalancersMenu,
+          loadBalancerMenu,
           publicGatewaysMenu,
           vpcMenu,
         ],
@@ -239,7 +241,7 @@ export default [
         items: [
           classicHostingMenu,
           cpanelHostingMenu,
-          ddxAccountMenu,
+          dediboxAccountMenu,
         ],
         label: 'Dedibox Console',
         category: 'dedibox-console',
@@ -247,10 +249,10 @@ export default [
       {
         icon: 'DedicatedServerCategoryIcon',
         items: [
-          ddxHardwareMenu,
-          ddxMenu,
-          ddxVpsMenu,
-          ddxKvmOverIpMenu
+          dediboxHardwareMenu,
+          dediboxMenu,
+          dediboxVpsMenu,
+          dediboxKvmOverIpMenu
         ],
         label: 'Dedibox Servers',
         category: 'dedibox',
@@ -258,12 +260,12 @@ export default [
       {
         icon: 'NetworkCategoryIcon',
         items: [
-          ddxDomainsMenu,
-          ddxDnsMenu,
-          ddxIpFailoverMenu,
-          ddxIpv6Menu,
-          ddxNetworkMenu,
-          ddxRpnMenu,
+          dediboxDomainsMenu,
+          dediboxDnsMenu,
+          dediboxIpFailoverMenu,
+          dediboxIpv6Menu,
+          dediboxNetworkMenu,
+          dediboxRpnMenu,
         ],
         label: 'Dedibox Network',
         category: 'dedibox-network',

--- a/pages/dedibox-account/menu.ts
+++ b/pages/dedibox-account/menu.ts
@@ -1,4 +1,4 @@
-export const ddxAccountMenu = {
+export const dediboxAccountMenu = {
   items: [
     {
       label: 'Overview',

--- a/pages/dedibox-dns/menu.ts
+++ b/pages/dedibox-dns/menu.ts
@@ -1,4 +1,4 @@
-export const ddxDnsMenu = {
+export const dediboxDnsMenu = {
   items: [
     {
       label: 'Overview',

--- a/pages/dedibox-domains/menu.ts
+++ b/pages/dedibox-domains/menu.ts
@@ -1,4 +1,4 @@
-export const ddxDomainsMenu = {
+export const dediboxDomainsMenu = {
   items: [
     {
       label: 'Overview',

--- a/pages/dedibox-hardware/menu.ts
+++ b/pages/dedibox-hardware/menu.ts
@@ -1,4 +1,4 @@
-export const ddxHardwareMenu = {
+export const dediboxHardwareMenu = {
   items: [
     {
       label: 'Overview',

--- a/pages/dedibox-ip-failover/menu.ts
+++ b/pages/dedibox-ip-failover/menu.ts
@@ -1,4 +1,4 @@
-export const ddxIpFailoverMenu = {
+export const dediboxIpFailoverMenu = {
   items: [
     {
       label: 'Overview',

--- a/pages/dedibox-ipv6/menu.ts
+++ b/pages/dedibox-ipv6/menu.ts
@@ -1,4 +1,4 @@
-export const ddxIpv6Menu = {
+export const dediboxIpv6Menu = {
   items: [
     {
       label: 'Overview',

--- a/pages/dedibox-kvm-over-ip/menu.ts
+++ b/pages/dedibox-kvm-over-ip/menu.ts
@@ -1,4 +1,4 @@
-export const ddxKvmOverIpMenu = {
+export const dediboxKvmOverIpMenu = {
   items: [
     {
       label: 'Overview',

--- a/pages/dedibox-network/menu.ts
+++ b/pages/dedibox-network/menu.ts
@@ -1,4 +1,4 @@
-export const ddxNetworkMenu = {
+export const dediboxNetworkMenu = {
   items: [
     {
       label: 'Overview',

--- a/pages/dedibox-rpn/menu.ts
+++ b/pages/dedibox-rpn/menu.ts
@@ -1,4 +1,4 @@
-export const ddxRpnMenu = {
+export const dediboxRpnMenu = {
   items: [
     {
       label: 'Overview',

--- a/pages/dedibox-scaleway/menu.ts
+++ b/pages/dedibox-scaleway/menu.ts
@@ -1,4 +1,4 @@
-export const ddxScwMenu = {
+export const dediboxScalewayMenu = {
   items: [
     {
       label: 'Overview',

--- a/pages/dedibox-vps/menu.ts
+++ b/pages/dedibox-vps/menu.ts
@@ -1,4 +1,4 @@
-export const ddxVpsMenu = {
+export const dediboxVpsMenu = {
   items: [
     {
       label: 'Overview',

--- a/pages/dedibox/menu.ts
+++ b/pages/dedibox/menu.ts
@@ -1,4 +1,4 @@
-export const ddxMenu = {
+export const dediboxMenu = {
   items: [
     {
       label: 'Overview',

--- a/pages/instances/menu.ts
+++ b/pages/instances/menu.ts
@@ -1,4 +1,4 @@
-export const instanceMenu = {
+export const instancesMenu = {
   "items": [
     {
       "label": "Overview",

--- a/pages/interlink/menu.ts
+++ b/pages/interlink/menu.ts
@@ -1,4 +1,4 @@
-export const interLinkMenu = {
+export const interlinkMenu = {
   items: [
     {
       label: 'Overview',

--- a/pages/load-balancer/menu.ts
+++ b/pages/load-balancer/menu.ts
@@ -1,4 +1,4 @@
-export const loadBalancersMenu = {
+export const loadBalancerMenu = {
   items: [
     {
       label: 'Overview',

--- a/pages/managed-databases-for-postgresql-and-mysql/menu.ts
+++ b/pages/managed-databases-for-postgresql-and-mysql/menu.ts
@@ -1,4 +1,4 @@
-export const managedDatabasePostgresMySqlMenu = {
+export const managedDatabasesForPostgresAndMysqlMenu = {
   items: [
     {
       label: 'Overview',

--- a/pages/managed-databases-for-redis/menu.ts
+++ b/pages/managed-databases-for-redis/menu.ts
@@ -1,4 +1,4 @@
-export const managedDatabaseRedisMenu = {
+export const managedDatabasesForRedisMenu = {
   items: [
     {
       label: 'Overview',

--- a/pages/managed-mongodb-databases/menu.ts
+++ b/pages/managed-mongodb-databases/menu.ts
@@ -1,4 +1,4 @@
-export const managedDatabaseMongoDbMenu = {
+export const managedMongodbDatabasesMenu = {
   items: [
     {
       label: 'Overview',

--- a/pages/organizations-and-projects/menu.ts
+++ b/pages/organizations-and-projects/menu.ts
@@ -1,4 +1,4 @@
-export const organizationsNProjectsMenu = {
+export const organizationsAndProjectsMenu = {
   items: [
     {
       label: 'Overview',

--- a/pages/scaleway-cli/menu.ts
+++ b/pages/scaleway-cli/menu.ts
@@ -1,4 +1,4 @@
-export const scwCliMenu = {
+export const scalewayCliMenu = {
   items: [
     {
       label: 'Quickstart',

--- a/pages/scaleway-sdk/menu.ts
+++ b/pages/scaleway-sdk/menu.ts
@@ -1,4 +1,4 @@
-export const scwSdkMenu = {
+export const scalewySdkMenu = {
   items: [
     {
       label: 'Python SDK quickstart',


### PR DESCRIPTION
The current version of the product menu import names, uses naming that is not a strict camel case version of the product slug.
This is problematic for associated tooling such as the review bot.
This PR applies strict naming rules that should be followed in the future.
An update of the bot will follow.