### PR TITLE
feat(data-warehouse): remove paragraph about installing the clickhouse plugin for metabase

### DIFF
--- a/pages/data-warehouse/how-to/connect-bi-tools.mdx
+++ b/pages/data-warehouse/how-to/connect-bi-tools.mdx
@@ -70,22 +70,6 @@ Metabase is an open-source business intelligence tool that allows users to creat
 
 Integrating ClickHouse® into Metabase enhances query performance and scalability, for faster data analysis on large datasets, and provides robust support for complex queries and real-time analytics.
 
-### Download the ClickHouse® plugin for Metabase
-
-1. Download the latest version of the plugin (JAR file named `clickhouse.metabase-driver.jar`) from the [official CLickHouse® GitHub repository](https://github.com/clickhouse/metabase-clickhouse-driver/releases/latest).
-
-2. Save `clickhouse.metabase-driver.jar` in your Metabase plugins folder. 
-    <Message type="note">
-     If you do not have a **plugins** folder, create it in the same directory as the `metabase.jar` file. Refer to the [official Metabase documentation](https://www.metabase.com/docs/latest/developers-guide/drivers/basics) for more information on plugins.
-    </Message>
- 
-3. Start (or restart) Metabase to load the new plugin.
-
-4. Access your Metabase server.
-    <Message type="note">
-      On the initial startup, if prompted to select a database, select **I'll add my data later**.
-    </Message>
-
 ### Connect Metabase to ClickHouse®
 
 1. Click on the gear icon in the top-right corner and select **Admin Settings** to visit your Metabase admin page.


### PR DESCRIPTION
### Description

Removing the paragraph about installing the ClickHouse plugin for Metabase, as it is no longer needed because it is now bundled by default with Metabase.

More info: https://github.com/clickhouse/metabase-clickhouse-driver/releases/tag/1.53.4
