### PR TITLE
fix(rdb): fix menu wording for review bot

### DIFF
--- a/menu/navigation.ts
+++ b/menu/navigation.ts
@@ -39,7 +39,7 @@ import { keyManagerMenu } from '../pages/key-manager/menu'
 import { kubernetesMenu } from "../pages/kubernetes/menu"
 import { loadBalancerMenu } from "../pages/load-balancer/menu"
 import { localStorageMenu } from "../pages/local-storage/menu"
-import { managedDatabasesForPostgresAndMysqlMenu } from "../pages/managed-databases-for-postgresql-and-mysql/menu"
+import { managedDatabasesForPostgresqlAndMysqlMenu } from "../pages/managed-databases-for-postgresql-and-mysql/menu"
 import { managedDatabasesForRedisMenu } from "../pages/managed-databases-for-redis/menu"
 import { managedInferenceMenu } from "../pages/managed-inference/menu"
 import { managedMongodbDatabasesMenu } from "../pages/managed-mongodb-databases/menu"
@@ -139,7 +139,7 @@ export default [
       {
         icon: 'DatabaseCategoryIcon',
         items: [
-          managedDatabasesForPostgresAndMysqlMenu,
+          managedDatabasesForPostgresqlAndMysqlMenu,
           managedDatabasesForRedisMenu,
           managedMongodbDatabasesMenu,
           openSearchMenu,

--- a/pages/managed-databases-for-postgresql-and-mysql/menu.ts
+++ b/pages/managed-databases-for-postgresql-and-mysql/menu.ts
@@ -1,4 +1,4 @@
-export const managedDatabasesForPostgresAndMysqlMenu = {
+export const managedDatabasesForPostgresqlAndMysqlMenu = {
   items: [
     {
       label: 'Overview',


### PR DESCRIPTION
Rename the menu component for MySQL/Postgresql, because it wasn't properly aligned with the slug as expected by review bot.

Have tested with a local build and all is fine.
