### PR TITLE
docs(elastic-metal): Fix IPv6 details for PN ext-add-elastic-metal

### DIFF
--- a/pages/elastic-metal/how-to/use-private-networks.mdx
+++ b/pages/elastic-metal/how-to/use-private-networks.mdx
@@ -109,11 +109,16 @@ You must configure the virtual network interface on each Elastic Metal server yo
 
     <Message type="important">
     If you are running multiple virtual machines on an Elastic Metal server, our managed DHCP is not currently able to distribute IP addresses to your virtual machines. We recommend that you use the [IPAM API](https://www.scaleway.com/en/developers/api/ipam/) to book IP addresses for your virtual machines, and assign them manually.
+
+    Also, if you are using a IPv6 private network, your Elastic Metal server may contact the public DHCP server instead of your Private Network's one. If it occurs, you will not be able to communicate with other
+resources in your subnet, except by manually assign an IP address.
     </Message>
 
-6. Enter the following command to assign an IP address. Make the necessary replacements for `eno1` and `1234` as you did previously.
+6. Enter the following command to assign an IP address. Make the necessary replacements for `eno1` and `1234` as you did previously, and change IP to use one in your subnet mask.
     ```bash
     sudo ip addr add 10.10.10.10/24 dev eno1.1234
+    # Or, for IPv6
+    sudo ip -6 addr add 1000:1000:1000:1000:1000:1000:1000:1000/64 dev eno1.1234
     ```
 7. Optionally persist this configuration across reboots by creating a new netplan configuration. Make the necessary replacements for `eno1` and `1234` as you did previously.
     ```yaml
@@ -208,5 +213,4 @@ Below is an example of how to connect one Private Network to a virtual machine c
 </Message>
 
 See our dedicated documentation [how to delete a Private Network](/vpc/how-to/delete-private-network/).
-
 


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

Updated doc to explain for IPv6. Sometimes (not always, don't know why), when using a PN with IPv6, the server will contact the wrong DHCP server, leading in an invalid lease, preventing the server to communicate with others. In this case, we'll have to manually set an IP.