### PR TITLE
docs(ins): adds troubleshouting for scaleway-vmagent metrics 

### DIFF
--- a/pages/instances/troubleshooting/filling-memory-and-gpu-metrics-on-the-cockpit-dashboard.mdx
+++ b/pages/instances/troubleshooting/filling-memory-and-gpu-metrics-on-the-cockpit-dashboard.mdx
@@ -1,0 +1,50 @@
+---
+title: Missing memory and GPU metrics on the Cockpit dashboard
+description: Steps to troubleshoot Instance metrics visibility on Cockpit.
+tags: cockpit instance
+dates:
+  validation: 2025-11-13
+  posted: 2025-11-13
+---
+
+## Problem
+The memory pane in the `Instance Overview` dashboard or the `Instance GPUs`
+dashboard do not display any metrics.
+
+### Symptoms
+- No metrics are displayed in the `Instance Overview` Cockpit dashboard.
+- No GPU metrics appear in the `Instances GPUs` Cockpit dashboard (for offers with GPUs only)
+
+## Cause
+The `scaleway-vmagent` service is either:
+- Not installed on the instance, or
+- Not running properly.
+<Message type="important">
+  The `scaleway-vmagent` is necessary to collect and report some system metrics (including memory and GPU usage) to the Cockpit Instance dashboards.
+</Message>
+
+## Solution
+- Verify that the `scaleway-vmagent` service is running and enabled:
+    ```bash
+    systemctl status scaleway-vmagent
+    ```
+- If missing, install the `scaleway-vmagent` package:
+
+    For Ubuntu: Check that the [Scaleway PPA](https://launchpad.net/~scaleway/+archive/ubuntu/stable) is added before installing:
+
+    ```bash
+    sudo add-apt-repository ppa:scaleway/stable
+    sudo apt update
+    sudo apt install scaleway-vmagent
+    ```
+
+    For RHEL-based distributions: check that the [Scaleway COPR repository](https://copr.fedorainfracloud.org/coprs/g/scaleway/stable/) is enabled before installing:
+    ```bash
+    dnf copr enable @scaleway/instance
+    dnf install scaleway-vmagent
+    ```
+<Message type="note">
+  On RHEL, services are not started after install. You may either start `scaleway-vmagent` manually, or wait for the next boot.
+</Message>
+
+Once the service is running, metrics should begin appearing in the Cockpit dashboards within a few minutes.

--- a/pages/instances/troubleshooting/index.mdx
+++ b/pages/instances/troubleshooting/index.mdx
@@ -74,4 +74,5 @@ productIcon: InstanceProductIcon
   - [Fix unreachable IPv6 RHEL-based Instances after transitioning to routed IP](/instances/troubleshooting/fix-unreachable-ipv6-rhel-based-instance)
   - [Fix unreachable Ubuntu Noble Instances following a reboot](/instances/troubleshooting/fix-unreachable-noble-after-reboot)
   - [Troubleshooting issues with faulty kernel installations](/instances/troubleshooting/reboot-from-faulty-kernel)
+  - [Missing memory and GPU metrics on the Cockpit dashboard](/instances/troubleshooting/filling-memory-and-gpu-metrics-on-the-cockpit-dashboard)
 </LinksList>


### PR DESCRIPTION
Added fixing infos for users finding the soon-to-come agent-based cockpit dashboards empty.