### PR TITLE
fix(serverless-functions): fix default go handler package ext-fix-serverless-functions

### DIFF
--- a/pages/serverless-functions/how-to/package-function-dependencies-in-zip.mdx
+++ b/pages/serverless-functions/how-to/package-function-dependencies-in-zip.mdx
@@ -194,7 +194,7 @@ The example above will create a `.zip` archive that contains the myFunction fold
         - For the file `handler.go` at the root of the project → `Handle`.
 
       <Message type="note">
-        By default, the handler path is `Handle` (package main at the root of the archive).
+        By default, the handler path is `Handle` (package handler at the root of the archive).
       </Message>
   </TabsTab>
   <TabsTab label="PHP">


### PR DESCRIPTION
### Your checklist for this pull request

- [X] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

Please describe what you added or changed.

When deploying a go function by uploading a zip file, the package containing the Handle function should be package *handler* and not package *main*.  Using package main will result in a failed deployment.

Compare with line 182, where it is correct.