### PR TITLE
feat(genapi): update deprecated models

### DIFF
--- a/pages/generative-apis/reference-content/supported-models.mdx
+++ b/pages/generative-apis/reference-content/supported-models.mdx
@@ -76,7 +76,7 @@ Deprecated models should not be queried anymore. We recommend to use newer model
 
 <Message type="note">
     `mistral-small-3.1-24b-instruct-2503` has been deprecated as of November 14th, 2025. Requests to this model are now redirected to a more recent version of this model: `mistral-small-3.2-24b-instruct-2506`.
-    `qwen2.5-coder-32b-instruct and `devstral-small-2505` have been deprecated as of November 14th, 2025. Requests to these models are now redirected to version offering similar or improved performance in most use cases: `qwen3-coder-30b-a3b-instruct`.
+    `qwen2.5-coder-32b-instruct and `devstral-small-2505` have been deprecated as of November 14th, 2025. Requests to these models are now redirected to a version offering similar or improved performance in most use cases: `qwen3-coder-30b-a3b-instruct`.
 </Message>
 
 ## End of Life (EOL) models


### PR DESCRIPTION
Updated deprecation notices for mistral small 3.1, devstral and qwen2.5 coder models and added recommendations for alternatives.
