### PR TITLE
fix(pgw): update v2 info

### DIFF
--- a/pages/public-gateways/concepts.mdx
+++ b/pages/public-gateways/concepts.mdx
@@ -1,18 +1,14 @@
 ---
 title: Public Gateways - Concepts
 description: Learn about Public Gateways on Scaleway, a managed network service that enables secure and scalable connectivity to your cloud resources and applications.
-tags: network availability-zone dns flexible-ip nat private-ip ssh-bastion egress ipam legacy ipam_config
+tags: network availability-zone dns flexible-ip nat private-ip ssh-bastion egress ipam ipam_config
 dates:
-  validation: 2025-05-14
+  validation: 2025-11-24
 ---
 import RegionAndAz from '@macros/console/region-and-az.mdx'
 
 
 ## Allowed IPs
-
-<Message>
-The Allowed IPs feature is only available to [IPAM-mode](#ipam) Public Gateways. Legacy gateways are not compatible with this feature.
-</Message>
 
 Allowed IPs is a feature of [SSH bastion](#ssh-bastion). It allows you to specify a list of IP address ranges which should be allowed to connect to the SSH bastion and the resources behind it. All other IP addresses will be blocked from connecting. Find out more in the [SSH bastion](/public-gateways/how-to/use-ssh-bastion/#how-to-configure-allowed-ips) documentation.
 
@@ -36,7 +32,7 @@ DHCP was previously a functionality of Scaleway Public Gateways, but has now bee
 
 The **D**omain **N**ame **S**ystem (DNS) is a naming system for devices connected to the internet or Private Networks. Most prominently, DNS servers translate text-based domain names (e.g. www.scaleway.com) to numerical IP addresses (e.g. 51.158.66.220).
 
-[Private Networks](/vpc/concepts#private-networks) benefit from managed DNS, which resolves the hostnames of attached resources into their IP addresses. The hostname for a given device is generally the name defined when creating the resource (and which in the case of an Instance, for example, displays in the shell when connected to that resource by SSH). When a Private Network is attached to a [legacy Public Gateway](#ipam) however, the gateway's DNS takes priority over that of the Private Network, to allow hostname resolution across different Private Networks.
+[Private Networks](/vpc/concepts#private-networks) benefit from managed DNS, which resolves the hostnames of attached resources into their IP addresses. The hostname for a given device is generally the name defined when creating the resource (and which in the case of an Instance, for example, displays in the shell when connected to that resource by SSH).
 
 ## Flexible IP
 
@@ -55,34 +51,7 @@ Scaleway is implementing [IP mobility](https://www.scaleway.com/en/blog/ip-mobil
 
 ## IPAM
 
-IPAM is Scaleway's **IP** **A**ddress **M**anager tool. Read more about it in our [dedicated IPAM documentation](/ipam/).
-
-Scaleway Public Gateways are either in **Legacy mode** or **IPAM mode**. The mode of each of your gateways is displayed via a badge in the [gateway listing](https://console.scaleway.com/public-gateway/public-gateways) page of the Scaleway console. 
-
-**Legacy** Public Gateways use a [workaround](/vpc/reference-content/vpc-migration/#public-gateways-and-vpc) to ensure IPAM compatibility. Your gateway is a legacy gateway if:
-- You created it via the Scaleway console prior to 17 October 2023
-- You created it via the Scaleway API or developer tools prior to 17 October 2023, and you did not use the `ipam_config` object when creating the [GatewayNetwork](https://www.scaleway.com/en/developers/api/public-gateways/#path-gateway-networks-attach-a-public-gateway-to-a-private-network) (attachment to a Private Network).
-
-The auto-calculated `is_legacy` [Gateway parameter](https://www.scaleway.com/en/developers/api/public-gateways/#path-gateways-create-a-public-gateway) will have a value of `true`. 
-
-<Message type="tip">
-Private Networks attached to legacy Public Gateways must stay in the gateway's auto-created VPC to ensure basic IPAM compatibility.
-</Message>
-
-**IPAM** Public Gateways are fully and natively integrated with the Scaleway IPAM without any workaround. Your gateway is in IPAM mode if:
-- You created it via the Scaleway console on or after 17 October 2023 
-- You created it via the Scaleway API or devtools using the `ipam_config` object, and the auto-calculated `is_legacy` [Gateway parameter](https://www.scaleway.com/en/developers/api/public-gateways/#path-gateways-create-a-public-gateway) has a value of `false`. 
-- You moved it from legacy mode to IPAM mode using the dedicated button in the console, or the dedicated API call.
-
-<Message type="note">
-When creating a Kubernetes Kapsule cluster with [full isolation](/kubernetes/reference-content/secure-cluster-with-private-network/#can-i-use-a-public-gateway-with-my-private-network-to-exit-all-outgoing-traffic-from-the-nodes) you are required to attach a Public Gateway to the cluster's Private Network, and this **cannot** be a legacy Public Gateway - it must be an IPAM-mode gateway.
-</Message>
-
-See also our dedicated documentation on [moving Public Gateways to IPAM-mode](/public-gateways/reference-content/understanding-v2/) to ensure compatibility with our new API v2.
-
-## Legacy gateway
-
-See [IPAM](#ipam).
+IPAM is Scaleway's **IP** **A**ddress **M**anager tool. Read more about it in our [dedicated IPAM documentation](/ipam/). Public Gateways are fully and natively integrated with the Scaleway IPAM.
 
 ## NAT
 

--- a/pages/public-gateways/faq.mdx
+++ b/pages/public-gateways/faq.mdx
@@ -24,28 +24,11 @@ Pre-existing static leases created via the Public Gateway were fully migrated an
 
 Read our [dedicated documentation](/public-gateways/reference-content/understanding-v2/) to learn how to put your gateway into IPAM-mode and replicate static DHCP reservation functionality with Scaleway IPAM.
 
-### Why is my Public Gateway labeled as Legacy?
-
-**Legacy** Public Gateways use a [workaround](/vpc/reference-content/vpc-migration/#public-gateways-and-vpc) to ensure compatibility with Scaleway's IPAM (**I** **P** **A**ddress **M**anagement) tool. IPAM acts as a single source of truth for the IP addresses of Scaleway resources
-
-Your gateway is a legacy gateway if you created it prior to 17 October 2023 and you never recreated it in IPAM mode. Legacy gateways are now deprecated, as they are incompatible with v2 of the Public Gateways API. Such gateways must be [moved to IPAM mode](/public-gateways/reference-content/understanding-v2/) before October 2025 to ensure ongoing functionality.
-
 ### I received a message about v1 of the Public Gateways API being deprecated, do I need to take action?
 
-The Public Gateways API v1 is now deprecated, and will be removed on 1 November 2025. Only IPAM-mode gateways will be compatible with the new version of the API (v2). Whether or not you need to take action depends on the following two points:
+The Public Gateways API v1 was removed on 3 November 2025, and all remaining legacy gateways were automatically migrated to IPAM-mode. 
 
-- Consider whether you manage your Public Gateway uniquely via the Scaleway console, or via calls to the API/devtools in code and scripts:
-
-  - **Code and scripts**: If you have any code or scripts that call v1 of the API, or use devtool functionality that is [removed from v2](/public-gateways/reference-content/understanding-v2/) such as DHCP object or entries, **you must take action before 1 Oct 2025**. Update your code and scripts so they point to v2 of the API. [Follow the examples provided for tools such as Terraform](https://github.com/scaleway/terraform-provider-scaleway/blob/master/docs/guides/migration_guide_vpcgw_v2.md) to rewrite your devtool templates so they do not refer to removed functionalities. Do this in synchronization with moving your gateway to IPAM mode (if necessary).
-
-  - **Console-only**: You do not need to take any action, except ensuring that your gateway is in IPAM mode.
-
-- Check in the [Scaleway console](https://console.scaleway.com/public-gateway/public-gateways) whether your Public Gateway is in IPAM mode or legacy mode:
-
-  - **Legacy mode**: You must move the gateway to IPAM mode. Only IPAM mode gateways are compatible with v2. Use the **Move to IPAM mode** button in the console, the [dedicated API call](https://www.scaleway.com/en/developers/api/public-gateways/v1/#path-gateways-put-a-public-gateway-in-ipam-mode), or the `move_to_ipam` flag in [Terraform](https://github.com/scaleway/terraform-provider-scaleway/blob/master/docs/guides/migration_guide_vpcgw_v2.md).
-
-  - **IPAM mode**: You do not have any action to take, except updating any code and scripts that you have (see above).
-
+If you have any code or scripts that still call v1 of the API, or use devtool functionality that is [removed from v2](/public-gateways/reference-content/understanding-v2/) such as DHCP object or entries, **update your code and scripts so they point to v2 of the API.**
 See our [dedicated documentation](/public-gateways/reference-content/understanding-v2/) for full details.
 
 ## Specifications

--- a/pages/public-gateways/reference-content/understanding-v2.mdx
+++ b/pages/public-gateways/reference-content/understanding-v2.mdx
@@ -3,21 +3,19 @@ title: Understanding and preparing for Public Gateways v2
 description: Find out what to expect from Public Gateways v2, and get ready for deprecation of DHCP entries and the DHCP object, as well as new default behavior for IPAM mode.
 tags: public-gateways dhcp dhcp-entries api v2 ipam-mode legacy
 dates:
-  creation: 2025-09-22
+  creation: 2025-11-24
   validation: 2025-08-07
 ---
 import image from './assets/scaleway-pgw-listing.webp'
 
 
-Scaleway's VPC offering is evolving, and with this comes changes for the Public Gateway product.
-
-This document explains what to expect and how to prepare for the upcoming changes.
+This document explains changes that took effect for the Scaleway Public Gateway Product as it migrated to v2 in 2025.
 
 ## Summary (TL;DR)
 
-All Scaleway Public Gateways until now have been created and managed with the version 1 of the [Public Gateways API](https://www.scaleway.com/en/developers/api/public-gateways/v1/), either explicitly via the API itself, or implicitly behind the scenes of the Scaleway console or other developer tools. 
+Until the second half of 2025, all Scaleway Public Gateways were created and managed with the version 1 of the [Public Gateways API](https://www.scaleway.com/en/developers/api/public-gateways/v1/), either explicitly via the API itself, or implicitly behind the scenes of the Scaleway console or other developer tools. 
 
-**We are now deprecating v1 of the API and transitioning to v2.**
+**We then deprecated v1 of the API and transitioned to v2.**
 
 |  | **PGW API v1** | **PGW API v2** |
 |---|---|---|
@@ -25,16 +23,16 @@ All Scaleway Public Gateways until now have been created and managed with the ve
 | Supports [IPAM-mode PGWs](/public-gateways/concepts/#ipam) | Yes ✅ | Yes ✅|
 | Supports SSH bastion allowed IPs, and future new features | No ❌| Yes ✅ |
 | Deprecated? | Yes ✅ | No ❌|
-| Removal date | 1 Nov 2025 | --- |
-| Compatible with PGW management via Scaleway console? | Only until 1 Nov 2025 | Yes ✅ |
+| Removal date | 3 Nov 2025 | --- |
+| Compatible with PGW management via Scaleway console? | Only until 3 Nov 2025 | Yes ✅ |
 
-After a deprecation period ending on 1 Nov 2025, the Public Gateways API v1 and associated developer tools will be removed. 
+After a deprecation period ending on 3 Nov 2025, the Public Gateways API v1 and associated developer tools were removed.
 
-**What you need to do before 1 Nov 2025:**
+**What you were prompted to do before 3 Nov 2025:**
 
 - Ensure that your Public Gateway is in [IPAM mode](#ipam-mode-becomes-default). Only IPAM-mode gateways are compatible with v2.
 
-- Put any non-IPAM mode ([legacy](/public-gateways/concepts/#ipam)) Public Gateways in IPAM mode. You can do this in several ways:
+- Put any non-IPAM mode ([legacy](/public-gateways/concepts/#ipam)) Public Gateways in IPAM mode by doing one of the following:
     - Use the **Move to IPAM mode** button in the console 
     - Use the [dedicated API call](https://www.scaleway.com/en/developers/api/public-gateways/v1/#path-gateways-put-a-public-gateway-in-ipam-mode).
     - Use the `move_to_ipam` flag in [Terraform](https://github.com/scaleway/terraform-provider-scaleway/blob/master/docs/guides/migration_guide_vpcgw_v2.md)
@@ -45,7 +43,7 @@ After a deprecation period ending on 1 Nov 2025, the Public Gateways API v1 and 
 If you manage your Public Gateway via Terraform, see our [dedicated guide](https://github.com/scaleway/terraform-provider-scaleway/blob/master/docs/guides/migration_guide_vpcgw_v2.md)
 </Message>
 
-If your Public Gateway is already in IPAM mode, and you only manage it via the console, you will not be affected by these changes and you do not need to take any action.
+If your Public Gateway was already in IPAM mode, and you only managed it via the console, you were not affected by these changes and you did not need to take any action.
 
 ## Background: DHCP and IPAM
 
@@ -59,7 +57,7 @@ Whether you choose a custom or default CIDR block, automatic address assignment 
 
 ## Introducing Public Gateways API v2
 
-Since the assignment and management of IP addresses on Private Networks is now managed by IPAM and the Private Networks themselves, we must complete the removal of the DHCP functionality from Public Gateways. This means releasing a new version (v2) of the [Public Gateways API](https://www.scaleway.com/en/developers/api/public-gateways/), which has until now retained a number of legacy DHCP functions. From this new version, you can observe:
+Since the assignment and management of IP addresses on Private Networks is now managed by IPAM and the Private Networks themselves, we had to complete the removal of the DHCP functionality from Public Gateways. This meant releasing a new version (v2) of the [Public Gateways API](https://www.scaleway.com/en/developers/api/public-gateways/), which previously retained a number of legacy DHCP functions. From this new version, you can observe:
 
 - IPAM mode becomes default
 - Removal of the DHCP object
@@ -71,7 +69,7 @@ Full details of each change are explained below.
 
 ### IPAM mode becomes default
 
-Scaleway Public Gateways are either in **Legacy mode** or **IPAM mode**. You can see the mode of a given gateway by:
+Scaleway Public Gateways had previously been either in **Legacy mode** or **IPAM mode**. You could see the mode of a given gateway by:
 
 - Checking its badge in the gateway listing page of the [Scaleway console](https://console.scaleway.com/public-gateway/public-gateways) (see screenshot below).
 - Checking the value of the `is_legacy` field via the [Public Gateways API](https://www.scaleway.com/en/developers/api/public-gateways/#path-gateways-get-a-public-gateway).
@@ -79,18 +77,18 @@ Scaleway Public Gateways are either in **Legacy mode** or **IPAM mode**. You can
 <Lightbox image={image} alt="A screen in the Scaleway console shows a listing of two Public Gateways, one of which has a badge saying IPAM, the other a badge saying Legacy." />
 
 <Message type="tip">
-All Public Gateways created via the Scaleway console since 17 November 2023 are necessarily in IPAM mode.
+All Public Gateways created via the Scaleway console since 17 November 2023 were necessarily in IPAM mode.
 </Message>
 
-Legacy Public Gateways use a [workaround](/vpc/reference-content/vpc-migration/#public-gateways-and-vpc) to ensure IPAM compatibility. IPAM-mode Public Gateways are fully integrated with Scaleway's [IPAM](/ipam/concepts/#ipam), which manages the coherent assignment of IP addresses to the gateway itself, and resources on attached Private Networks.
+Legacy Public Gateways used a [workaround](/vpc/reference-content/vpc-migration/#public-gateways-and-vpc) to ensure IPAM compatibility. IPAM-mode Public Gateways are fully integrated with Scaleway's [IPAM](/ipam/concepts/#ipam), which manages the coherent assignment of IP addresses to the gateway itself, and resources on attached Private Networks.
 
-Legacy mode will be deprecated going forward, and will not be compatible with v2 of the Public Gateway API. It will no longer be possible to create legacy-mode Public Gateways, all new gateways will necessarily be in IPAM mode.
+Legacy mode was deprecated, and incompatible with v2 of the Public Gateway API. It is no longer possible to create legacy-mode Public Gateways, all new gateways will necessarily be in IPAM mode.
 
-If you still have a legacy gateway, you must [transition it to IPAM mode](#how-do-i-move-my-legacy-public-gateway-to-ipam-mode) so that it is compatible with v2 of the API. This will update the auto-calculated `is_legacy` field and put your gateway in IPAM mode.
+If you still have a legacy gateway, you had to [transition it to IPAM mode](#how-do-i-move-my-legacy-public-gateway-to-ipam-mode) so that it is compatible with v2 of the API. This updated the auto-calculated `is_legacy` field and put your gateway in IPAM mode.
 
 ### Removal of the DHCP object
 
-The DHCP object has remained present in v1 of the API, despite the [migration of DHCP to Private Networks](/vpc/reference-content/vpc-migration/), which replaced DHCP on Public Gateways.
+The DHCP object remained present in v1 of the API, despite the [migration of DHCP to Private Networks](/vpc/reference-content/vpc-migration/), which replaced DHCP on Public Gateways.
 
 **The DHCP object does not exist in v2 of the API**. Instead, IPAM configuration, where auto-configuration of `GatewayNetwork` is managed by IPAM and DHCP is managed by Private Networks, replaces any need for DHCP configuration via the Public Gateway.
 
@@ -98,7 +96,7 @@ Remember that you can define a [custom CIDR block](/vpc/how-to/create-private-ne
 
 ### Removal of the address field
 
-For some time now, this functionality has been available via the API and developer tools only (not the Scaleway console).
+For some time, this functionality was available via the API and developer tools only (not the Scaleway console).
 
 When attaching a Public Gateway to a Private Network (creating a [Gateway Network](https://www.scaleway.com/en/developers/api/public-gateways/v1/#path-gateway-networks-attach-a-public-gateway-to-a-private-network)) via the API, you could use the `address` field to define a single static IP address to assign to the Public Gateway on that Private Network.
 
@@ -108,77 +106,65 @@ When you [use a dedicated method](#how-do-i-move-my-legacy-public-gateway-to-ipa
 
 ### Removal of DHCP entries
 
-For some time now, this functionality has been available via the API and developer tools only (not the Scaleway console).
+For some time, this functionality was available via the API and developer tools only (not the Scaleway console).
 
 [DHCP entries](https://www.scaleway.com/en/developers/api/public-gateways/v1/#path-dhcp-entries-list-dhcp-entries) could be created, belonging to a specified `GatewayNetwork` (Public Gateway / Private Network attachment), holding dynamic DHCP leases or static, user-created DHCP reservations. They have effectively allowed the Public Gateway to assign certain IP addresses to certain resources on the Private Network.
 
-**DHCP entries do not exist in v2 of the API**. Instead, you can rely on the default IPAM/DHCP functionality as described [above](#background-dhcp-and-ipam). The default behavior will auto-assign IP addresses to resources on the Private Network from the network's CIDR block, or you can use the IP reservation functionality to specify the IP address(es) to assign to each resource.
+**DHCP entries do not exist in v2 of the API**. Instead, you can rely on the default IPAM/DHCP functionality as described [above](#background-dhcp-and-ipam). The default behavior auto-assigns IP addresses to resources on the Private Network from the network's CIDR block, or you can use the IP reservation functionality to specify the IP address(es) to assign to each resource.
 
 For custom resources, such as VMs hosted on Elastic Metal servers, we now provide [dedicated functionality](https://www.scaleway.com/en/docs/vpc/how-to/attach-resources-to-pn/) for attaching these to Private Networks. When choosing the **Custom Resource** type, you can specify a MAC address and hostname at the moment of attachment.
 
-We will automatically migrate any existing DHCP entries to IPAM for you, at the moment you put a legacy Public Gateway into IPAM mode.
+We automatically migrated any existing DHCP entries to IPAM for you, at the moment you put a legacy Public Gateway into IPAM mode.
 
 ### SSH bastion allowed IPs
 
-Allowed IPs is a new functionality of the Public Gateways API v2, that will also be available to all IPAM-mode Public Gateways via the Scaleway console. This feature allows you to specify a list of IP address ranges which should be allowed to connect to the gateway's SSH bastion and the resources behind it. All other IP addresses will be blocked from connecting. Find out more in the [SSH bastion](/public-gateways/how-to/use-ssh-bastion/) documentation.
+Allowed IPs is a new functionality of the Public Gateways API v2, that is also available to all IPAM-mode Public Gateways via the Scaleway console. This feature allows you to specify a list of IP address ranges which should be allowed to connect to the gateway's SSH bastion and the resources behind it. All other IP addresses will be blocked from connecting. Find out more in the [SSH bastion](/public-gateways/how-to/use-ssh-bastion/) documentation.
 
 ## Timeline and action to take
 
-- **March 2025 - V2 release**: The Public Gateway v2 API is released, co-existing with v1. 
-- **8 April 2025 - V1 deprecation**: The Public Gateway v1 API is deprecated. Deprecation means that the API will still function, but it is slated for removal and we do not recommended that you keep using it.
+- **March 2025 - V2 release**: The Public Gateway v2 API was released, co-existing with v1. 
+- **8 April 2025 - V1 deprecation**: The Public Gateway v1 API was deprecated. Deprecation means that the API still functioned, but was slated for removal, and we did not recommended that you keep using it.
 
     <Message type="note">
-    You will be able to list and manage all gateways with the **Scaleway console**, which will adapt to use v1 or v2 of the API as necessary depending on whether or not the gateway is in IPAM mode.
+    You were able to list and manage all gateways with the **Scaleway console**, which adapted to use v1 or v2 of the API as necessary depending on whether or not the gateway was in IPAM mode.
     </Message>
 
-- **8 April 2025 - 1 Nov 2025: Migration period**: You have a six month migration period to complete the following actions
+- **8 April 2025 - 3 Nov 2025: Migration period**: You had a six month migration period to complete the following actions
 
-    - Ensure that your Public Gateway is in [IPAM mode](/public-gateways/concepts/#ipam). Only IPAM mode gateways are compatible with v2.
+    - Ensure that your Public Gateway was in [IPAM mode](/public-gateways/concepts/#ipam). Only IPAM mode gateways would be compatible with v2.
     - Put any non-IPAM mode ([legacy](/public-gateways/concepts/#ipam)) Public Gateways in IPAM-mode, by using the **Move to IPAM mode** button in the console, the [dedicated API call](https://www.scaleway.com/en/developers/api/public-gateways/v1/#path-gateways-put-a-public-gateway-in-ipam-mode), or the `move_to_ipam` flag in [Terraform](https://github.com/scaleway/terraform-provider-scaleway/blob/master/docs/guides/migration_guide_vpcgw_v2.md).
-    - Ensure that [DHCP is activated](/vpc/how-to/activate-dhcp/) on all Private Networks attached to your IPAM-mode Public Gateways.
-    - Update any code or scripts you have that call version 1 of the Public Gateways API, so that they call version 2 instead. This includes removing any use of the DHCP entries, DHCP objects or address fields as mentioned above.
+    - Ensure that [DHCP was activated](/vpc/how-to/activate-dhcp/) on all Private Networks attached to your IPAM-mode Public Gateways.
+    - Update any code or scripts you had that called version 1 of the Public Gateways API, so that they called version 2 instead. This included removing any use of the DHCP entries, DHCP objects or address fields as mentioned above.
 
-    If your Public Gateway is already in IPAM mode, and you only manage it via the console, you will not be affected by these changes and you do not need to take any action.
+    If your Public Gateway was already in IPAM mode, and you only managed it via the console, you were not affected by these changes and you did not need to take any action.
 
-- **1 Nov 2025 - V1 removal**: The Public Gateway v1 API will be removed. Any code or scripts still pointing to v1 will cease to function. We will automatically put any existing legacy Public Gateways into IPAM mode.
+- **3 Nov 2025 - V1 removal**: The Public Gateway v1 API was removed. Any code or scripts still pointing to v1 have ceased to function. We have automatically put all existing legacy Public Gateways into IPAM mode.
 
 ## FAQ
 
-### How do I know if I have to take action?
-
-- Consider whether you manage your Public Gateway uniquely via the Scaleway console, or via calls to the API/devtools in code and scripts:
-
-  - **Code and scripts**: If you have any code or scripts that call v1 of the API, or use devtool functionality that is removed from v2 such as DHCP object or entries, **you must take action before 1 Nov 2025**. Update your code and scripts so they point to v2 of the API. [Follow the examples provided for tools such as Terraform](https://github.com/scaleway/terraform-provider-scaleway/blob/master/docs/guides/migration_guide_vpcgw_v2.md) to rewrite your devtool templates so they do not refer to removed functionalities. Do this in synchronization with moving your gateway to IPAM mode (if necessary).
-
-  - **Console-only**: You do not need to take any action, except ensuring that your gateway is in IPAM mode.
-
-- Check in the [Scaleway console](https://console.scaleway.com/public-gateway/public-gateways) whether your Public Gateway is in IPAM mode or legacy mode:
-
-  - **Legacy mode**: You must move the gateway to IPAM mode. Only IPAM mode gateways are compatible with v2. Use the **Move to IPAM mode** button in the console, the [dedicated API call](https://www.scaleway.com/en/developers/api/public-gateways/v1/#path-gateways-put-a-public-gateway-in-ipam-mode), or the `move_to_ipam` flag in [Terraform](https://github.com/scaleway/terraform-provider-scaleway/blob/master/docs/guides/migration_guide_vpcgw_v2.md).
-
-  - **IPAM mode**: You do not have any action to take, except updating any code and scripts that you have (see above).
-
 ### How do I move my legacy Public Gateway to IPAM mode?
 
-You can do this in several ways:
+You were previously invited (during the migration period) to do this in several ways:
 
     - Use the **Move to IPAM mode** button in the console 
     - Use the [dedicated API call](https://www.scaleway.com/en/developers/api/public-gateways/v1/#path-gateways-put-a-public-gateway-in-ipam-mode).
     - Use the `move_to_ipam` flag in [Terraform](https://github.com/scaleway/terraform-provider-scaleway/blob/master/docs/guides/migration_guide_vpcgw_v2.md)
 
-### What happens when I move my legacy Public Gateway to IPAM mode?
+As of 3 November 2025, all legacy Public Gateways were automatically put into IPAM mode by Scaleway.
 
-We will detach your Public Gateway from all attached Private Networks, and reattach it in IPAM mode. You can expect downtime of about 10-20 seconds. We will ensure that the IP address used for the new attachment is the same as the old one.
+### What happened when mu legacy Public Gateway was moved into IPAM mode?
 
-### My Public Gateway is already in IPAM mode, do I need to take any action?
+We detached your Public Gateway from all attached Private Networks, and reattached it in IPAM mode. This entailed downtime of about 10-20 seconds. We ensured that the IP address used for the new attachment was the same as the old one.
+
+### My Public Gateway is now in IPAM mode, do I need to take any action?
 
 If you only manage your gateway via the Scaleway console, you do not need to take any action once your gateway is in IPAM mode.
 
-If you have any code or scripts that call v1 of the Scaleway Public Gateways API, you must update these to point towards [v2](https://www.scaleway.com/en/developers/api/public-gateways/) before 1 Nov 2025.
+If you have any code or scripts that still call v1 of the Scaleway Public Gateways API, you must update these to point towards [v2](https://www.scaleway.com/en/developers/api/public-gateways/). v1 has been removed as of 3 November 2025.
 
 ### What if I want to keep using my custom gateway DHCP configuration from v1 of the API?
 
-After version 1 of the Public Gateways API is removed on 1 Nov 2025, these functionalities will no longer be available.
+These functionalities are no longer available.
 
 Going forward, we expect users who were previously using custom DHCP with a Public Gateway to move to the standard set-up of IPAM and Private Networks' inbuilt DHCP for private IP assignment. Remember that you can define a [custom CIDR block](/vpc/how-to/create-private-network/#how-to-configure-cidr) for a Private Network at the time of creation, and use [reserved IP addresses](/ipam/how-to/reserve-ip/#how-to-reserve-a-private-ip-address) with IPAM when attaching both standard and custom resources.
 
@@ -196,14 +182,6 @@ resource "scaleway_vpc_public_gateway" "main" {
 ```
 
 Refer to our [Terraform migration guide](https://github.com/scaleway/terraform-provider-scaleway/blob/master/docs/guides/migration_guide_vpcgw_v2.md) for full details and help moving legacy gateways to IPAM mode.
-
-### Can't I just wait for Scaleway to force the move to IPAM mode?
-
-After 1 Nov 2025 we will carry out a forced action which will move all existing legacy Public Gateways to IPAM mode, and we will remove v1 of the Public Gateways API.
-
-We highly recommend that you move to IPAM mode **before** this date, so that you can plan a smooth and synchronized transition at a time that suits you. 
-
-If you still have code or scripts pointing to v1 of the API after the 1 Nov 2025, these will cease to function.
 
 ## Further help and support
 

--- a/pages/public-gateways/troubleshooting/index.mdx
+++ b/pages/public-gateways/troubleshooting/index.mdx
@@ -49,9 +49,9 @@ productIcon: PublicGatewayProductIcon
       label="See more"
     />
     <Card
-      title="IPAM-mode vs Legacy gateways"
-      description="What's the difference?"
-      url="/public-gateways/concepts/#ipam"
+      title="Limitations"
+      description="Limits of Public Gateways"
+      url="/public-gateways/troubleshooting/gw-limitations/"
       label="See more"
     />
 </Grid>

--- a/pages/vpc/menu.ts
+++ b/pages/vpc/menu.ts
@@ -81,11 +81,7 @@ export const vpcMenu = {
         {
           label: 'VPC use case 1: basic infrastructure',
           slug: 'use-case-basic',
-        },
-        {
-          label: 'Understanding VPC GA and migration',
-          slug: 'vpc-migration',
-        },
+        }
       ],
       label: 'Additional Content',
       slug: 'reference-content',

--- a/pages/vpc/reference-content/vpc-migration.mdx
+++ b/pages/vpc/reference-content/vpc-migration.mdx
@@ -3,7 +3,7 @@ title: Understanding VPC GA and Migration
 description: This page outlines the changes that arrived with the VPC product going into General Availability, and how existing configurations were migrated.
 tags: vpc regional zoned zonal private-networks public-gateway dhcp migration migrate subnet general-availability ga
 dates:
-  validation: 2025-07-16
+  validation: 2025-11-24
   posted: 2023-06-20
 ---
 import image from './assets/scaleway-gateway-mode.webp'
@@ -111,7 +111,9 @@ You may have observed the following behavior when during the period directly fol
 
 **Public Gateways created before October 17 2023 are legacy gateways, and their attached Private Networks must stay in the gateway's auto-created VPC to ensure IPAM compatibility.** 
 
-You can tell whether your Public Gateway is in legacy mode or IPAM mode, by referring to the "mode" badge in the [listing of your Public Gateway in the Scaleway console](https://console.scaleway.com/public-gateway/public-gateways).
+<Message type="important">
+As of November 2025, all Public Gateways are now in IPAM-mode, regardless of their creation date. [Find out more](https://www.scaleway.com/en/docs/public-gateways/reference-content/understanding-v2/).
+</Message>
 
 <Lightbox image={image} alt="" />
 


### PR DESCRIPTION
Forced migration has now been carried out for Legacy mode gateways to IPAM mode gateways, and v1 API has been removed.

This doc updates the info.

We agreed to keep the two pages (VPC GA and Understanding v2) for a further six months before deleting them from the doc.
