### PR TITLE
docs(fix): fix typo 

### DIFF
--- a/pages/cockpit/reference-content/cockpit-product-integration.mdx
+++ b/pages/cockpit/reference-content/cockpit-product-integration.mdx
@@ -9,7 +9,7 @@ dates:
 
 The following page provides details about the Scaleway products that are integrated into Cockpit. This means that you can have metrics and/or logs in your Cockpit for the products mentioned below.
 
-Some products offer optional [preconfigured alerts](https://console.scaleway.com/cockpit/fr-par/alerts). Alerts must be enabled manually and will become billable in a future update.
+Some products offer optional [preconfigured alerts](https://console.scaleway.com/cockpit/fr-par/alerts). Alerts must be enabled manually.
 
 **Sending metrics and logs using an external path is a billable feature**. As such, any additional data that you may push yourself will be billed, even if you send data from Scaleway products that are **integrated into Cockpit**. Refer to the [product pricing](https://www.scaleway.com/en/pricing/managed-services/#cockpit) for more information.
 
@@ -61,7 +61,7 @@ Some products offer optional [preconfigured alerts](https://console.scaleway.com
 | **Product Name**           | **Metrics**     | **Logs**        |
 |----------------------------|-----------------|-----------------|
 | Data Warehouse for ClickHouse            | Planned| Not integrated  |
-| Data Warehouse for Apache Spark            | **Integrated***   | Not integrated  |
+| Data Lab for Apache Spark            | **Integrated***   | Not integrated  |
 | NATS           | **Integrated***  | Not integrated  |
 
 


### PR DESCRIPTION
Fixed product naming + removed mention that alerts will become billable.
