### PR TITLE
feat(data-warehouse): add doc to connect to Tableau Online

### DIFF
--- a/pages/data-warehouse/how-to/connect-applications.mdx
+++ b/pages/data-warehouse/how-to/connect-applications.mdx
@@ -38,7 +38,7 @@ To connect your deployment with BI tools, refer to the [dedicated documentation]
     Select the appropriate protocol, then run the displayed command in a terminal. Remember to replace the placeholders with the appropriate values, and to specify the correct path to the certificate file.
 
         <Tabs>
-            <TabsTab label="ClicHouse® CLI">
+            <TabsTab label="ClickHouse® CLI">
             ```bash
             clickhouse client \
             --host <YOUR_DEPLOYMENT_ID>.dtwh.<REGION>.scw.cloud \

--- a/pages/data-warehouse/how-to/connect-bi-tools.mdx
+++ b/pages/data-warehouse/how-to/connect-bi-tools.mdx
@@ -21,17 +21,23 @@ This page explains how to integrate your Data Warehouse for ClickHouse® deploym
 
 Tableau is a powerful data visualization and business intelligence tool that enables users to transform complex data into interactive and shareable dashboards and reports, providing actionable insights through intuitive drag-and-drop interfaces.
 
-### Download and install the ClickHouse® connector for Tableau
+### Tableau Desktop
+
+#### Download and install the ClickHouse® connector for Tableau
 
 1. Download and install [Tableau Desktop](https://www.tableau.com/products/desktop/download).
 
-2. Follow the instructions for `clickhouse-tableau-connector-jdbc` to [download the compatible version](https://github.com/ClickHouse/clickhouse-java/releases/) of the ClickHouse® JDBC driver.
+2. Follow the instructions for `clickhouse-tableau-connector-jdbc` to [download the compatible version](https://github.com/ClickHouse/clickhouse-tableau-connector-jdbc) of the ClickHouse® JDBC driver.
 
-3. Store the JDBC driver in the `Drivers` folder. If the directory does not exist, create it:
+3. Download the Clickhouse JDBC Driver (version `0.9.X` required), and store the `clickhouse-jdbc-0.9.X-all-dependencies.jar` file in:
     - macOS/Linux: `~/Library/Tableau/Drivers`
     - Windows: `C:\Program Files\Tableau\Drivers`
 
-### Configure a ClickHouse® data source in Tableau
+4. Download the latest `clickhouse-jdbc.taco` file from the Releases page, and store it in:
+    - macOS: `~/Documents/My Tableau Repository/Connectors`
+    - Windows: `C:\Users\[Windows User]\Documents\My Tableau Repository\Connectors`
+
+#### Configure a ClickHouse® data source in Tableau Desktop
 
 1. Start or restart Tableau.
 
@@ -51,10 +57,6 @@ Tableau is a powerful data visualization and business intelligence tool that ena
     | Username | default                                                |
     | Password | Password set at deployment creation                    |
 
-    <Message type="note">
-      Make sure to enable the SSL if you are using ClickHouse® Cloud. 
-    </Message>
-
 6. Click **Sign In**. A new Tableau workbook appears.
 
 7. Select **default** from the **Schema** dropdown menu in the left side panel. A list of tables appears.
@@ -62,6 +64,58 @@ Tableau is a powerful data visualization and business intelligence tool that ena
 8. Your Data Warehouse for ClickHouse® is now integrated into your Tableau platform.
 
 Refer to the official [ClickHouse®](https://clickhouse.com/docs/integrations/tableau) and [Tableau](https://exchange.tableau.com/products/1064) documentation portals for more information.
+
+### Tableau Online
+
+Tableau Online requires the MySQL connector.
+
+#### Create a dedicated MySQL user with the appropriate grants
+
+1. Create a dedicated MySQL [user](https://www.scaleway.com/en/docs/data-warehouse/how-to/manage-users/#how-to-create-a-user-using-the-scaleway-console).
+
+2. [Connect](https://www.scaleway.com/en/docs/data-warehouse/how-to/connect-applications/?tab=clickhouser-cli-0) to the ClickHouse CLI as `scwadmin` or any user with admin rights.
+
+3. Grant the following priviliges to your newly created MySQL user:
+
+```sql
+GRANT SELECT ON information_schema.* TO your_mysql_user;
+GRANT SELECT ON INFORMATION_SCHEMA.* TO your_mysql_user;
+```
+
+<Message type="note">
+    Make sure to grant on these two schemas, both with and without caps. 
+</Message>
+
+4. Finally, grant the `SELECT` privilege on the tables you want to see in Tableau Online:
+
+```sql
+GRANT SELECT ON your_table TO your_mysql_user;
+```
+
+#### Configure a ClickHouse® data source in Tableau
+
+1. Log into Tableau Online.
+
+2. From the **Home** menu, click on **New** and select **Published Data Source** from the drop-down menu. 
+
+3. Click on the **Connectors** tab and then select **MySQL** from the connectors list.
+
+4. Enter the following connection parameters:
+
+    | Setting  | Value                                                   |
+    | -------- |---------------------------------------------------------|
+    | Server   | Your ClickHouse® host (with no prefixes or suffix)      |
+    | Port     | 9004                                                    |
+    | Database | default                                                 |
+    | Username | Username of the dedicated MySQL user previously created |                                               |
+    | Password | Password for this user                     |
+
+5. Click **Sign In**. A new Tableau workbook appears.
+
+6. Select **default** from the **Schema** dropdown menu in the left side panel. A list of tables appears.
+
+7. Your Data Warehouse for ClickHouse® is now integrated into your Tableau platform.
+
 
 ## Metabase
 


### PR DESCRIPTION
### Description

- added a doc to connect a Data Warehouse for ClickHouse deployment to Tableau Online
- improved the Tableau Desktop connection doc
- fixed a typo
