### PR TITLE
fix(dedibox): Mention Redfish and don’t use “Dell” or “iDRAC” for HPE and iLO

### DIFF
--- a/pages/dedibox/how-to/use-ipmi-on-server.mdx
+++ b/pages/dedibox/how-to/use-ipmi-on-server.mdx
@@ -1,6 +1,6 @@
 ---
-title: How to use IPMI on a Dedibox server
-description: This page explains how to use IPMI on a Scaleway Dedibox server
+title: How to use the BMC (IPMI/Redfish) on a Dedibox server
+description: This page explains how to connect to the BMC of a Scaleway Dedibox server
 tags: dedibox ipmi server
 dates:
   validation: 2025-09-03
@@ -12,9 +12,9 @@ import image from './assets/scaleway-idrac.webp'
 import image2 from './assets/scaleway-ilo.webp'
 
 
-An **I**ntelligent **P**latform **M**anagement **I**nterface (IPMI) is an industry standard to describe the subsystem of a server providing remote management and monitoring capabilities. IPMI gives you a way to manage and monitor a server even if it is powered off or unresponsive, by using a network connection to the hardware. IPMI is made possible by the **B**aseboard **M**anagement **C**ontroller, an independent piece of hardware connected to your network card, composed of an I2C bus and a dedicated processor.
+**I**ntelligent **P**latform **M**anagement **I**nterface (IPMI) and **Redfish** are industry standards to describe the subsystem of a server providing remote management and monitoring capabilities. IPMI and Redfish you a way to manage and monitor a server even if it is powered off or unresponsive, by using a network connection to the hardware. IPMI is made possible by the **B**aseboard **M**anagement **C**ontroller, an independent piece of hardware connected to a network card, composed of an I2C bus and a dedicated processor.
 
-Some examples of features that can be remotely monitored via the IPMI include:
+Some examples of features that can be remotely monitored via the BMC include:
 
   - Ventilation,
   - Temperature,
@@ -29,16 +29,16 @@ Actions that can be carried out via IPMI include:
   - Viewing of logs from the BIOS,
   - Accessing the serial port and BIOS over the network via serial console.
 
-In this document, we show you how to access the IPMI for a Dell or HP server. See the [KVM-over-IP](/dedibox-kvm-over-ip/) documentation for information about other server models.
+In this document, we show you how to access the BMC for a Dell or HPE server. See the [KVM-over-IP](/dedibox-kvm-over-ip/) documentation for information about other server models.
 
 <Requirements />
 
 - A Dedibox account logged into the [console](https://console.online.net)
 - [Created](/dedibox/how-to/order-a-server/) and [installed](/dedibox/how-to/install-a-server/) a Dedibox server with a dedicated KVM over IP device
 
-## How to use IPMI via Dell iDRAC
+## How to use a Dell iDRAC
 
-IPMI is a standard specification for a remote management subsystem. On a Dell server, IPMI is realized through the iDRAC: the **I**ntegrated **D**ell **R**emote **A**ccess **C**ontroller.
+On a Dell server, the BMC is known as the iDRAC: the **I**ntegrated **D**ell **R**emote **A**ccess **C**ontroller.
 
 1. From the console, click **Server** > **Server list**. A list of your servers displays.
 2. Click **Manage** next to the relevant server.
@@ -54,18 +54,18 @@ IPMI is a standard specification for a remote management subsystem. On a Dell se
     <Lightbox image={image} alt="" />
 6. Use the interface to monitor and manage your server's hardware:
     - The **System** tabs let you view various system information including system details, logs, and power status. You can also use the **Console/Media** > **Virtual Media** tab to install your server remotely with a custom OS by connecting virtual media. To launch the KVM, click **Remote Access Controller** under **System Details**.
-    - The **iDDRAC** tabs show you information about the iDRAC itself.
+    - The **iDRAC** tabs show you information about the iDRAC itself.
     - Click the other relevant links on the left sidebar to see information about **Batteries**, **Temperatures**, **Voltages**, etc., as required.
 
-## How to use IPMI via HP iLO
+## How to use a HPE iLO
 
-IPMI is a standard specification for a remote management subsystem. On a Dell server, IPMI is realized through the ILO: the **I**ntegrated **L**ights **O**ut processor.
+On an HPE server, the BMC is known as the iLO, the **I**ntegrated **L**ights-**O**ut processor.
 
 1. From the console, click **Server** > **Server list**. A list of your servers displays.
 2. Click **Manage** next to the relevant server.
-3. Click the **IDRAC** button on the right. A disclaimer displays.
+3. Click the **iLO** button on the right. A disclaimer displays.
 4. Click **I Accept** to agree with the terms of the disclaimer.
-5. Enter the authorized IPv4 address for the iDRAC connection. The IP address of your internet connection is already pre-filled in the form. Then click **Create** to generate your credentials.
+5. Enter the authorized IPv4 address for the iLO connection. The IP address of your internet connection is already pre-filled in the form. Then click **Create** to generate your credentials.
     <Message type="note">
       Currently, only IPv4 addresses are accepted.
     </Message>
@@ -78,5 +78,3 @@ IPMI is a standard specification for a remote management subsystem. On a Dell se
     - The **Remote Console** pages let you launch the KVM.
     - The **Virtual Media** pages let you install your server remotely with a custom OS by connecting virtual media.
     - Click the other relevant links on the left sidebar to see more information.
-
-


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

IPMI is a legacy standard largely replaced by Redfish.  HPE uses the term Integrated Lights-Out, or iLO, to refer to their BMCs.  Customer connections to the BMC do not use either IPMI or Redfish but rather a proprietary web UI.