### PR TITLE
fix(external-secrets): add required Secret Manager permissions

### DIFF
--- a/pages/kubernetes/api-cli/external-secrets-kubernetes.mdx
+++ b/pages/kubernetes/api-cli/external-secrets-kubernetes.mdx
@@ -24,7 +24,7 @@ In this tutorial you will learn how to deploy External Secrets and its services 
 - Configured [kubectl](/kubernetes/how-to/connect-cluster-kubectl/)
 - Installed `helm`, the Kubernetes [package manager](https://helm.sh/), on your local machine (version 3.2 or latest)
 
-If you plan to create a dedicated application with custom IAM policy. The minimum set of permissions required is:
+If you plan to create a dedicated application with a custom IAM policy, the minimum set of permissions required is:
 - `SecretManagerReadOnly`
 - `SecretManagerSecretAccess`
 

--- a/pages/secret-manager/api-cli/external-secrets.mdx
+++ b/pages/secret-manager/api-cli/external-secrets.mdx
@@ -23,7 +23,7 @@ In this tutorial you will learn how to deploy External Secrets and its services 
 - Configured [kubectl](/kubernetes/how-to/connect-cluster-kubectl/)
 - Installed `helm`, the Kubernetes [package manager](https://helm.sh/), on your local machine (version 3.2 or latest)
 
-If you plan to create a dedicated application with custom IAM policy. The minimum set of permissions required is:
+If you plan to create a dedicated application with a custom IAM policy, the minimum set of permissions required is:
 - `SecretManagerReadOnly`
 - `SecretManagerSecretAccess`
 


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

Add the required permissions to run external-secrets on a Kubernetes cluster with Secret Manager provider.
