### PR TITLE
feat(changelog): generative-apis-added-holo2-and-qwen3-embedding-are-now 2025-12-02

### DIFF
--- a/changelog/december2025/2025-12-02-generative-apis-added-holo2-and-qwen3-embedding-are-now.mdx
+++ b/changelog/december2025/2025-12-02-generative-apis-added-holo2-and-qwen3-embedding-are-now.mdx
@@ -6,6 +6,6 @@ category: ai-data
 product: generative-apis
 ---
 
-[Qwen3 Embedding 8B](/generative-apis/reference-content/supported-models/) is a state-of-the-art embedding model, ranking 3rd on the MTEB leaderboard as of November 2025, and supports custom embedding dimensions (also known as [Matryoshka embeddings](https://huggingface.co/blog/matryoshka)).
+[Qwen3 Embedding 8B](/generative-apis/reference-content/supported-models/) is a state-of-the-art embedding model, ranking 3rd on the MTEB leaderboard as of November 2025. It supports custom embedding dimensions (also known as [Matryoshka embeddings](https://huggingface.co/blog/matryoshka)).
 [Holo2](/generative-apis/reference-content/supported-models/) is a frontier model designed to analyze user interfaces and interact with them. Holo2 enables browser automation, as well as interaction with thick-client and mobile applications.
 


### PR DESCRIPTION
Reporter: Franck Pagny

This PR is a new changelog contribution. It has been created automatically.

Make sure to review it carefully before merging it.