### PR TITLE
docs(add) Dedibox FTP-backup curl note

### DIFF
--- a/pages/dedibox/how-to/use-dedibackup-ftp-backup.mdx
+++ b/pages/dedibox/how-to/use-dedibackup-ftp-backup.mdx
@@ -156,7 +156,6 @@ curl -T "path_to_your_file.7z" -u "sd-XXXXX:your_password" ftp://dedibackup-dc3.
 </Message>
 
 <Message type="note">
-  Since curl version 7.74.0 the default behavior is to not get a new IP from the server for the passive connection.
-  You have to use --no-ftp-skip-pasv-ip for curl to make the passive connection required. 
+  Starting with **curl 7.74.0**, the default behavior in FTP passive mode is to ignore the IP address returned by the server. To make curl use the server’s `PASV IP` (the previous behavior), use the option `--no-ftp-skip-pasv-ip`.
 </Message>
 


### PR DESCRIPTION
Added note regarding curls default behavior in newer versions, to ignore IP given from server for passive connection.
