### PR TITLE
fix(edge) update doc for case where no origin host provided

### DIFF
--- a/pages/edge-services/concepts.mdx
+++ b/pages/edge-services/concepts.mdx
@@ -53,7 +53,7 @@ The primary source from which a Scaleway Edge Services pipeline retrieves and ca
 
 ## Origin host
 
-In the case of a Load Balancer origin, the specific host for which Edge Services requests and caches data. This is an optional setting: when specified, this host (e.g. `mydomain.com`) is used in the HTTP Host Header when Edge Services requests data from the Load Balancer. If no origin host is specified, the Load Balancer's IP address is used in the Host Header.
+In the case of a Load Balancer origin, the specific host for which Edge Services requests and caches data. This is an optional setting: when specified, this host (e.g. `mydomain.com`) is used in the HTTP Host Header when Edge Services requests data from the Load Balancer. If no origin host is specified, the `Host` from the incoming request will be used.
 
 The origin host must be associated with the origin Load Balancer / its backend servers, and only one host may be set per pipeline. If your Load Balancer is in front of multiple hosts, you can create a separate Edge Services pipeline for each. Each host will therefore get its own Edge Services endpoint and cache.
 

--- a/pages/edge-services/how-to/create-pipeline-lb.mdx
+++ b/pages/edge-services/how-to/create-pipeline-lb.mdx
@@ -47,7 +47,7 @@ You can create an Edge Services pipeline from the Load Balancer section of the c
 
 4. Define the protocol and origin host for this pipeline:
     - Select the protocol that Edge Services should use when making requests to the origin, either `HTTP` or `HTTPS` (recommended). Choose the protocol that corresponds with your Load Balancer setup.
-    - Optionally, enter an [origin host](/edge-services/concepts/#origin-host) associated with your Load Balancer for this pipeline. When specified, this host replaces the Load Balancer IP address in the HTTP Host Header of the requests made from Edge Services to your Load Balancer.
+    - Optionally, enter an [origin host](/edge-services/concepts/#origin-host) associated with your Load Balancer for this pipeline. When specified, this host replaces the Load Balancer IP address in the HTTP Host Header of the requests made from Edge Services to your Load Balancer. If no origin host is specified, the Host from the incoming request will be used.
 
 5. Enter a name for this Edge Services pipeline, or leave the auto-generated name in place.
 

--- a/pages/edge-services/quickstart.mdx
+++ b/pages/edge-services/quickstart.mdx
@@ -76,7 +76,7 @@ You can create [pipelines](/edge-services/concepts/#pipeline) for either Object 
 
         5. Define the protocol and origin host for this pipeline:
             - Select the protocol that Edge Services should use when making requests to the origin, either `HTTP` or `HTTPS` (recommended). Choose the protocol that corresponds with your Load Balancer setup.
-            - Optionally, enter an [origin host](/edge-services/concepts/#origin-host) associated with your Load Balancer for this pipeline. When specified, this host replaces the Load Balancer IP address in the HTTP Host Header of the requests made from Edge Services to your Load Balancer.
+            - Optionally, enter an [origin host](/edge-services/concepts/#origin-host) associated with your Load Balancer for this pipeline. When specified, this host replaces the Load Balancer IP address in the HTTP Host Header of the requests made from Edge Services to your Load Balancer. If no origin host is specified, the Host from the incoming request will be used.
 
         6. Enter a name for this Edge Services pipeline, or leave the auto-generated name in place.
 


### PR DESCRIPTION
Update doc to correct info when no origin host is provided for Load Balancer pipelines