### PR TITLE
fix(instances): rearrage toc structure in use-flexips howto

### DIFF
--- a/pages/instances/how-to/use-flexips.mdx
+++ b/pages/instances/how-to/use-flexips.mdx
@@ -141,7 +141,7 @@ Instead, we return the SLAAC address based on the EUI-64 of the interface.
 
 One consequence is that, if you move your `routed_ipv6` **prefix** to another Instance (hence, with another MAC address), the `public_ips` list will show you a **different** address because its EUI-64 will differ.
 
-## Workaround
+### Workaround
 
 Since the whole `/64` prefix is routed to your Instance, it is possible to define a second IPv6 address within the prefix that may be used to reach your Instance. However, this requires some custom settings.
 
@@ -157,7 +157,7 @@ The cloud-init configuration can be uploaded with the Scaleway CLI:
 scw instance server update <SERVER_UUID> cloud-init=@ipv6-cloud-init.txt
 ```
 
-### Debian >= 11 and Ubuntu >= 20.04
+#### Debian >= 11 and Ubuntu >= 20.04
 
 First of all, create a file with the following content:
 
@@ -181,7 +181,7 @@ EOF
 
 This cloud-init configuration file will add the `netplan` definition of a second IPv6 address within the /64 prefix (you can choose any /128 contained in your prefix). It will then apply the `netplan` configuration so the new IPv6 address becomes available.
 
-### CentOS Stream 9, AlmaLinux >= 8 and RockyLinux >= 8
+#### CentOS Stream 9, AlmaLinux >= 8 and RockyLinux >= 8
 
 For CentOS Stream 9, AlmaLinux >= 8, and RockyLinux >= 8, you must interact with `NetworkManager` instead of `netplan`.
 
@@ -199,7 +199,7 @@ nmcli connection up eth0-ipv6
 EOF
 ```
 
-### Fedora
+#### Fedora
 
 Fedora also uses `NetworkManager` but with different configuration names.
 


### PR DESCRIPTION
### Description

The depth level of some titles has been increased so that the _Flexible IPv6_ section makes sense as a whole.
