### PR TITLE
fix(instances): remove concept of routed flexible IP

### DIFF
--- a/pages/instances/concepts.mdx
+++ b/pages/instances/concepts.mdx
@@ -111,11 +111,6 @@ Rescue mode restarts your server via the network on a minimal operating system. 
 
 Reverse DNS is the opposite of classic "forward" DNS, and maps an IP address to a hostname. This can be useful if, for example, you want to send emails from your Instance. Find out how to [configure reverse DNS on your Instance](/instances/how-to/configure-reverse-dns/) with our how-to documentation.
 
-## Routed flexible IP
-
-A routed flexible IP means assigning a public IP address to an Instance (virtual machine) that is reachable directly from the internet. This means there is no address translation, and the Instance uses the public IP as its identity on the internet.
-The Instance can be accessed or can communicate directly using this public IP, which helps to make network configuration straightforward, with unrestricted inbound and outbound connections, crucial for services like web hosting or email servers.
-
 ## Security group
 
 Security groups allow you to [create rules to drop or allow public traffic coming to and from your Instances](/instances/how-to/use-security-groups/). You can set default policies for inbound and outbound traffic, and/or define rules to deal with traffic differently depending on its source. Security groups can be [stateful](#stateful-security-groups) or [stateless](#stateless-security-groups). Note that security groups for Elastic Metal servers cannot be stateful.


### PR DESCRIPTION
### Description

Routed flexible IPs are now the only type of flexible IP available. No distinction should be made in the documentation anymore.
