### PR TITLE
fix(instances): wrong use of `scw marketplace`

### DIFF
--- a/pages/instances/api-cli/creating-managing-instances-with-cliv2.mdx
+++ b/pages/instances/api-cli/creating-managing-instances-with-cliv2.mdx
@@ -84,9 +84,15 @@ Scaleway Instances provide you with resources to develop, test code and deploy y
 
 ## Creating an Instance
 
-1. Type the following command in your terminal to obtain a local-image UUID:
+1. Use the following command to browse all available Scaleway images:
 
-    `scw marketplace local-image get label=ubuntu_noble`
+    `scw marketplace image list`
+
+    The output shows one image per line. Spot the `LABEL` of your desired image, for example `ubuntu_noble`.
+
+2. You may request more information about the image using the following command:
+
+    `scw marketplace image get label=ubuntu_noble`
 
     Details of the image as well as its ID are displayed:
 
@@ -99,7 +105,7 @@ Scaleway Instances provide you with resources to develop, test code and deploy y
     CreatedAt    1 year ago
     Description  Ubuntu is the ideal distribution for scale-out computing, Ubuntu Server helps you make the most of your infrastructure.
     ```
-2. Run the following command to create an Instance:
+3. Run the following command to create an Instance:
 
     `scw instance server create zone=fr-par-1 image=ubuntu_noble type=DEV1-S`
 
@@ -164,7 +170,7 @@ Scaleway Instances provide you with resources to develop, test code and deploy y
     Volumes.0.Boot                false
     Volumes.0.Zone                fr-par-1
     SecurityGroup.ID              12345678-1234-1234-4321-123456789123
-    SecurityGroup.Name            Base group
+    SecurityGroup.Name            Default security group
     StateDetail                   -
     Arch                          x86_64
     Zone                          fr-par-1


### PR DESCRIPTION
### Description

The document was incorrectly advising about getting a `local-image` ID where an `image` is needed.
