### PR TITLE
fix(instances): remove invalid requirement from create instance howto

### DIFF
--- a/pages/instances/how-to/create-an-instance.mdx
+++ b/pages/instances/how-to/create-an-instance.mdx
@@ -22,7 +22,6 @@ Select a tab below for instructions on how to create an Instance via either our 
     - A Scaleway account logged into the [console](https://console.scaleway.com)
     - [Owner](/iam/concepts/#owner) status or [IAM permissions](/iam/concepts/#permission) allowing you to perform actions in the intended Organization
     - An [SSH key](/organizations-and-projects/how-to/create-ssh-key/)
-    - An [Instance](/instances/how-to/create-an-instance/)
 
     1. Click **CPU & GPU Instances** in the **Compute** section of the side menu. The [Instance dashboard](https://console.scaleway.com/instance/servers) displays.
     2. Click **Create Instance**. The [Instance creation page](https://console.scaleway.com/instance/servers) displays.
@@ -61,7 +60,6 @@ Select a tab below for instructions on how to create an Instance via either our 
     - A Scaleway account logged into the [console](https://console.scaleway.com)
     - [Owner](/iam/concepts/#owner) status or [IAM permissions](/iam/concepts/#permission) allowing you to perform actions in the intended Organization
     - An [RSA key pair](/organizations-and-projects/how-to/create-ssh-key/#how-to-generate-a-rsa-ssh-key-pair)
-    - An [Instance](/instances/how-to/create-an-instance/)
 
     1. Click **CPU & GPU Instances** in the **Compute** section of the side menu. The [Instance dashboard](https://console.scaleway.com/instance/servers) displays.
     2. Click **Create Instance**. The [Instance creation page](https://console.scaleway.com/instance/servers) displays.


### PR DESCRIPTION
### Description

The "How to create an Instance" documentation is incorrectly referring to itself and requiring the user to already have an Instance created.
