### PR TITLE
fix(ckpt): Updated how to configure custom alerts on Scaleway metrics

### DIFF
--- a/pages/cockpit/how-to/configure-alerts-for-scw-resources.mdx
+++ b/pages/cockpit/how-to/configure-alerts-for-scw-resources.mdx
@@ -19,16 +19,15 @@ Cockpit does not support the Grafana alert manager nor Grafana-managed alert rul
 
 Once the conditions of your alert rule are met, the rule evaluation engine of your data source forwards the firing alert to the Scaleway alert manager, which then sends a notification to the contacts you have configured in the Scaleway console or in Grafana.
 
-You can also create alerting rules on your custom data sources.
+You can also create alerting rules on both Scaleway data sources or your custom data sources.
 
-This page shows you how to create alert rules in Grafana for monitoring Scaleway resources integrated with Cockpit, such as Instances, Object Storage, and Kubernetes. These alerts rely on Scaleway-provided metrics, which are preconfigured and available in the **Metrics browser** drop-down when using the **Scaleway Metrics data source** in the Grafana interface. This page explains how to use the `Scaleway Metrics` data source, interpret metrics, set alert conditions, and activate alerts.
+This page shows you how to create alert rules in Grafana for monitoring Scaleway resources integrated with Cockpit, such as Object Storage or Kubernetes. These alerts rely on Scaleway-provided metrics, which are available in the **Metrics browser** drop-down when using the **Scaleway Metrics data source** in the Grafana interface. This page explains how to use the `Scaleway Metrics` data source, interpret metrics, set alert conditions, and activate alerts.
 
 <Requirements />
 
 - A Scaleway account logged into the [console](https://console.scaleway.com)
 - [Owner](/iam/concepts/#owner) status or [IAM permissions](/iam/concepts/#permission) allowing you to perform actions in the intended Organization
 - Scaleway resources you can monitor
-- [Created Grafana credentials](/cockpit/how-to/retrieve-grafana-credentials/) with the **Editor** role
 - [Enabled](/cockpit/how-to/enable-alert-manager/) the Scaleway alert manager in the same region as the resources you want to be alerted for
 - [Added](/cockpit/how-to/enable-alert-manager/#how-to-add-contacts) contacts in the Scaleway console or contact points in Grafana (with the `Scaleway Alerting` alert manager of the same region as your `Scaleway Metrics` data source), otherwise alerts will not be delivered
 
@@ -36,7 +35,7 @@ This page shows you how to create alert rules in Grafana for monitoring Scaleway
 
 Data source managed alert rules allow you to configure alerts managed by the data source of your choice, instead of using Grafana's managed alerting system **which is not supported by Cockpit**.
 
-1. [Log in to Grafana](/cockpit/how-to/access-grafana-and-managed-dashboards/) using your credentials.
+1. [Log in to Grafana](/cockpit/how-to/access-grafana-and-managed-dashboards/) using your Scaleway credentials.
 2. Click the Grafana icon in the top left side of your screen to open the menu.
 3. Click the arrow next to **Alerting** on the left-side menu, then click **Alert rules**.
 4. Click **+ New alert rule**.
@@ -54,33 +53,9 @@ Data source managed alert rules allow you to configure alerts managed by the dat
 
 ## Define your metric and alert conditions
 
-Switch between the tabs below to create alerts for a Scaleway Instance, an Object Storage bucket, a Kubernetes cluster Pod, or Cockpit logs.
+Switch between the tabs below to create alerts for an Object Storage bucket, a Kubernetes cluster Pod, or Cockpit logs ingestion.
 
 <Tabs>
-  <TabsTab label="Scaleway Instance">
-    The steps below explain how to create the metric selection and configure an alert condition that triggers when **your Instance consumes more than 10% of a single CPU core over the past 5 minutes.**
-
-      1. In the query field next to the **Loading metrics... >** button, paste the following query. Make sure that the values for the labels you have selected (for example, `resource_id`) correspond to those of the target resource.
-         ```bash
-         rate(instance_server_cpu_seconds_total{resource_id="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"}[5m]) > 0.1
-         ```
-         <Message type="tip">
-            The `instance_server_cpu_seconds_total` metric records how many seconds of CPU time your Instance has used in total. It is helpful to detect unexpected CPU usage spikes.
-         </Message>
-      2. In the **Set alert evaluation behavior** section, specify how long the condition must be met before triggering the alert.
-      3. Enter a name in the **Namespace** and **Group** fields to categorize and manage your alert rules. Rules that share the same group will use the same configuration, including the evaluation interval which determines how often the rule is evaluated (by default: every 1 minute). You can modify this interval later in the group settings.
-         <Message type="note">
-            The evaluation interval is different from the pending period set in step 2. The evaluation interval controls how often the rule is checked, while the pending period defines how long the condition must be continuously met before the alert fires.
-         </Message>
-      4. In the **Configure labels and notifications** section, click **+ Add labels**. A pop-up appears.
-      5. Enter a label and value name and click **Save**. You can skip this step if you want your alerts to be sent to the contacts you may already have created in the Scaleway console.
-         <Message type="note">
-            In Grafana, notifications are sent by matching alerts to notification policies based on labels. This step is about deciding how alerts will reach you or your team (Slack, email, etc.) based on labels you attach to them. Then, you can set up rules that define who receives notifications in the **Notification policies** page.
-            For example, if your alert named `alert-for-high-cpu-usage` has the label `team = instances-team`, you are telling Grafana to send a notification to the Instances team when the alert gets triggered. Find out how to [configure notification policies in Grafana](/tutorials/configure-slack-alerting/#configuring-a-notification-policy).
-         </Message>
-      6. Click **Save rule and exit** in the top right corner of your screen to save and activate your alert.
-      7. Optionally, check that your configuration works by temporarily lowering the threshold. This will trigger the alert and notify your [contacts](/cockpit/concepts/#contact-points).
-    </TabsTab>
     <TabsTab label="Object Storage bucket">
       The steps below explain how to create the metric selection and configure an alert condition that triggers when **the object count in your bucket exceeds a specific threshold**.
 
@@ -134,7 +109,7 @@ Switch between the tabs below to create alerts for a Scaleway Instance, an Objec
       6. Click **Save rule and exit** in the top right corner of your screen to save and activate your alert.
       7. Optionally, check that your configuration works by temporarily lowering the threshold. This will trigger the alert and notify your [contacts](/cockpit/concepts/#contact-points).
     </TabsTab>
-    <TabsTab label="Cockpit logs">
+    <TabsTab label="Cockpit logs ingestion">
       The steps below explain how to create the metric selection and configure an alert condition that triggers when **no logs are stored for 5 minutes, which may indicate your app or system is broken**.
 
       1. In the query field next to the **Loading metrics... >** button, paste the following query. Make sure that the values for the labels you have selected (for example, `resource_name`) correspond to those of the target resource.
@@ -160,8 +135,6 @@ Switch between the tabs below to create alerts for a Scaleway Instance, an Objec
     </TabsTab>
 </Tabs>
 
-        **You can configure up to a maximum of 10 alerts** for the `Scaleway Metrics` data source.
-
         <Message type="tip">
          You can also build your PromQL expressions and find the right metrics from the Grafana-managed tab, with the metrics explorer (book icon) and **+ Operations** button. However, remember to click the **Data source-managed** tab once you are done building them to proceed with the final configuration steps.
          <Lightbox image={AlertsViaGrafanaUI} alt="" />
@@ -169,7 +142,7 @@ Switch between the tabs below to create alerts for a Scaleway Instance, an Objec
 
 ## View firing alerts
 
-    1. [Log in to Grafana](/cockpit/how-to/access-grafana-and-managed-dashboards/) using your credentials.
+    1. [Log in to Grafana](/cockpit/how-to/access-grafana-and-managed-dashboards/) using your Scaleway credentials.
     2. Click the Grafana icon in the top left side of your screen to open the menu.
     3. Click the arrow next to **Alerting** on the left-side menu, then click **Alert rules**.
     4. Click the **Firing** tab under the **State** section to filter for firing rules.


### PR DESCRIPTION
### Your checklist for this pull request

- [x ] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

Removed deprecated mentions or no-longer-required-section (e.g. instances CPU is now a preconfigured alert) and updated wording.