### PR TITLE
fix(instances): add missing menu entry for cloud-init howto

### DIFF
--- a/pages/instances/menu.ts
+++ b/pages/instances/menu.ts
@@ -87,6 +87,10 @@ export const instancesMenu = {
           "slug": "use-boot-modes"
         },
         {
+          "label": "Use Cloud-init",
+          "slug": "use-cloud-init"
+        },
+        {
           "label": "Protect an Instance",
           "slug": "use-protected-instance"
         },


### PR DESCRIPTION
### Description

This adds a missing menu entry for cloud-init howto.
