### PR TITLE
feat(iam): set credentials maximum duration

### DIFF
--- a/pages/iam/how-to/set-credentials-maximum-duration.mdx
+++ b/pages/iam/how-to/set-credentials-maximum-duration.mdx
@@ -1,5 +1,5 @@
 ---
-title: How to configure and manage credential maximum duration
+title: How to set and manage credential maximum duration
 description: This page shows you how to configure and manage a maximum time-to-live for API keys and console sessions in your Organization.
 dates:
   validation: 2026-01-05

--- a/pages/iam/menu.ts
+++ b/pages/iam/menu.ts
@@ -51,7 +51,7 @@ export const iamMenu = {
           slug: 'set-up-sso-with-authentik'
         },
             {
-          label: 'Set credentials maximum duration',
+          label: 'Set and manage credential maximum duration',
           slug: 'set-credentials-maximum-duration'
         },
         {


### PR DESCRIPTION
Using the current structure of the IAM doc.
This MR documents a feature front-ready of a new org setting : limiting max ttl of both console sessions and API keys duration