### PR TITLE
feat(iam): fixing a 404 on the identity federation doc

### DIFF
--- a/pages/iam/menu.ts
+++ b/pages/iam/menu.ts
@@ -44,7 +44,7 @@ export const iamMenu = {
         },
         {
           label: 'Set up identity federation',
-          slug: 'Set-up-identity-federation'
+          slug: 'set-up-identity-federation'
         },
         {
           label: 'Set up SSO with Authentik',


### PR DESCRIPTION
I don't know when we broke it but the identity federation page is in 404 due to a wrong case in the navigation slug.