### PR TITLE
fix(instances): fix typo in cloud-init howto

### DIFF
--- a/pages/instances/how-to/use-cloud-init.mdx
+++ b/pages/instances/how-to/use-cloud-init.mdx
@@ -273,6 +273,6 @@ nocloud
 <Message type="important">
   Beware of software reboot (i.e. any reboot command run from within the guest, like `reboot` or `shutdown -r now`): in this situation, the virtual machine hosting your Instance is not respawned. Therefore, you might fall into one of these situations:
   
-  - **Attaching its first public IP address o an instance already running with none, then performing a software reboot**: Once rebooted, the system will still have the CD-ROM drive plugged in and de `cidata` medium available, despite using the usual Scaleway datasource instead of NoCloud. Yet, unless this is an issue for you, in which case you must either issue a `reboot` or a `poweroff` then `poweron` action to the API, this should cause no harm.
+  - **Attaching its first public IP address to an instance already running with none, then performing a software reboot**: Once rebooted, the system will still have the CD-ROM drive plugged in and de `cidata` medium available, despite using the usual Scaleway datasource instead of NoCloud. Yet, unless this is an issue for you, in which case you must either issue a `reboot` or a `poweroff` then `poweron` action to the API, this should cause no harm.
   - **Detaching the last public IP address from an instance, then performing a software reboot**: Once rebooted, the CD-ROM drive will not be present, preventing the NoCloud datasource to trigger. The system falls back on [the None datasource](https://cloudinit.readthedocs.io/en/latest/reference/datasources/none.html).
 </Message>


### PR DESCRIPTION
### Description

Fix a small typo.
