### PR TITLE
fix(dedibox): specify the policy scope

### DIFF
--- a/pages/dedibox/how-to/give-iam-members-access-to-dedibox-console.mdx
+++ b/pages/dedibox/how-to/give-iam-members-access-to-dedibox-console.mdx
@@ -48,7 +48,7 @@ Policies can be created and attached directly to a user or a group.
 2. Click **+ Create Policy**.
 3. Enter a policy name and description. Optionally, add key-value tags and select a principal.
 4. Click **Add rules**. The rule creation wizard appears.
-5. Define the scope of the rule — either at the **Project** or **Organization** level — then click **Validate**.
+5. Define the scope of the rule to **Organization** then click **Validate**.
 6. Add a permission set to the rule:
    - Click **Bare Metal** in the products list.
    - Select `DediboxConsoleFullAccess`.


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

The permission DediboxConsoleFullAccess only exists at the organization level, this PR updates the documentation to explain that.
