### PR TITLE
fix: bucket policy example json in manage-object-visibility.mdx

### DIFF
--- a/pages/object-storage/how-to/manage-object-visibility.mdx
+++ b/pages/object-storage/how-to/manage-object-visibility.mdx
@@ -53,7 +53,7 @@ You can manage the visibility of multiple objects at a time using a [bucket poli
       "Resource": [
         "my-bucket/public-objects"
         ]
-    },
+    }
   ]
 }
 ```


### PR DESCRIPTION
an extra comma was added to the example json, which made it invalid and caused error:

> An error occurred (MalformedPolicy) when calling the PutBucketPolicy operation: This policy contains invalid Json

### Your checklist for this pull request

- [ ] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

Please describe what you added or changed.
