### PR TITLE
fix(docs): fix troubleshoot page title

### DIFF
--- a/pages/data-lab/troubleshooting/index.mdx
+++ b/pages/data-lab/troubleshooting/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Data Lab for Apache Spark™ Troubleshooting
+title: Data Lab for Apache Spark™
 description: Troubleshoot common issues with Scaleway Data Lab for Apache Spark™.
 dates:
   posted: 2025-03-13


### PR DESCRIPTION
### Description

Fixing a tiny display inconsistency on the Troubleshooting index page.