### PR TITLE
fix(cr): include both category names on instructions

### DIFF
--- a/pages/container-registry/how-to/connect-docker-cli.mdx
+++ b/pages/container-registry/how-to/connect-docker-cli.mdx
@@ -19,7 +19,7 @@ Docker is a tool that makes it easy to manage container images. You can use Dock
 - [Docker](https://www.docker.com/) installed on your local computer
 
 
-1. Click **Container Registry** in the **Containers** section of the [Scaleway console](https://console.scaleway.com) side menu. The Container Registry namespaces dashboard displays.
+1. Click **Container Registry** under the **Storage** or **Containers** sections of the [Scaleway console](https://console.scaleway.com) side menu. The Container Registry namespaces dashboard displays.
 2. Click <Icon name="more" />, then **Push instructions** next to the namespace you want to push to. A pop-up displays.
 3. Copy the push instructions.
 4. Open a terminal window on your local computer.
@@ -38,5 +38,3 @@ Docker is a tool that makes it easy to manage container images. You can use Dock
     ```
 
 You are now logged in and ready to push and pull images to and from your Container Registry with Docker.
-
-

--- a/pages/container-registry/how-to/create-namespace.mdx
+++ b/pages/container-registry/how-to/create-namespace.mdx
@@ -11,7 +11,7 @@ import Requirements from '@macros/iam/requirements.mdx'
 
 [Scaleway Container Registry](/container-registry/concepts/#container-registry) is a fully-managed, mutualized container registry, designed to facilitate the storage, management, and deployment of container images. The service simplifies the development-to-production workflow, as there is no need to operate your own Container Registry or worry about the underlying infrastructure.
 
-Within your Container Registry, [namespaces](/container-registry/concepts/#namespace) allow you to manage your registry in a clear, simple and human-readable way. A namespace is a collection of container images, each bearing the unique identifier of that namespace. To start using your Container Registry, you first need to create a namespace.
+Within your Container Registry, [namespaces](/container-registry/concepts/#namespace) allow you to manage your registry in a clear, simple, and human-readable way. A namespace is a collection of container images, each bearing the unique identifier of that namespace. To start using your Container Registry, you first need to create a namespace.
 
 <Requirements />
 
@@ -19,7 +19,7 @@ Within your Container Registry, [namespaces](/container-registry/concepts/#names
 - [Owner](/iam/concepts/#owner) status or [IAM permissions](/iam/concepts/#permission) allowing you to perform actions in the intended Organization
 
 
-1. Click **Container Registry** in the **Containers** section of the [Scaleway console](https://console.scaleway.com) side menu. If you do not have a Registry already created, the product creation page is displayed.
+1. Click **Container Registry** under the **Storage** or **Container** sections of the [Scaleway console](https://console.scaleway.com) side menu. If you do not have a Registry already created, the product creation page is displayed.
 2. Click **Create namespace** to launch the namespace creation wizard.
 3. Enter the following required information for your namespace:
     * A **Name** for the namespace
@@ -28,8 +28,6 @@ Within your Container Registry, [namespaces](/container-registry/concepts/#names
     * The namespace's **Privacy Policies**
 
     <Message type="note">
-      A namespace can either be [public or private](/container-registry/concepts/#namespace-privacy-policies). Anyone will be able to pull container images from a public namespace. Privacy policies may be set at image level.
+      A namespace can either be [public or private](/container-registry/concepts/#namespace-privacy-policies). Anyone will be able to pull container images from a public namespace. Privacy policies may be set at the image level.
     </Message>
 4. Click **Create namespace** to create the namespace.
-
-

--- a/pages/container-registry/how-to/delete-image.mdx
+++ b/pages/container-registry/how-to/delete-image.mdx
@@ -17,12 +17,10 @@ import Requirements from '@macros/iam/requirements.mdx'
 - [Pushed an image](/container-registry/how-to/push-images/) to your namespace
 
 
-1. Click **Container Registry** in the **Containers** section of the [Scaleway console](https://console.scaleway.com) side menu. The Container Registry namespaces dashboard displays.
+1. Click **Container Registry** under the **Storage** or **Containers** sections of the [Scaleway console](https://console.scaleway.com) side menu. The Container Registry namespaces dashboard displays.
 2. Click the namespace's name to list its images.
 3. Click <Icon name="more" /> next to the image name, then **Delete**. A pop-up displays.
 4. Confirm the deletion of the image in the pop-up.
     <Message type="important">
       This action is irreversible, and all data stored in the image will be deleted.
     </Message>
-
-

--- a/pages/container-registry/how-to/delete-namespace.mdx
+++ b/pages/container-registry/how-to/delete-namespace.mdx
@@ -16,15 +16,13 @@ import Requirements from '@macros/iam/requirements.mdx'
 - A [Container Registry namespace](/container-registry/how-to/create-namespace/)
 
 
-1. Click **Container Registry** in the **Containers** section of the [Scaleway console](https://console.scaleway.com) side menu. The Container Registry namespaces dashboard displays.
+1. Click **Container Registry** under the **Storage** or **Containers** sections of the [Scaleway console](https://console.scaleway.com) side menu. The Container Registry namespaces dashboard displays.
 2. Click <Icon name="more" /> next to the namespace you want to delete, then click **Delete** in the drop-down menu. A pop-up displays.
 3. Type **DELETE** to confirm the deletion of the namespace. Then click **Delete namespace**.
     <Message type="tip">
-      A namespace can also be deleted from the **Namespace settings** tab, by clicking on the **Delete namespace** button.
+      A namespace can also be deleted from the **Namespace settings** tab by clicking the **Delete namespace** button.
     </Message>
 
     <Message type="important">
       This action is irreversible, and all data associated with this namespace will be deleted.
     </Message>
-
-

--- a/pages/container-registry/how-to/display-image-versions.mdx
+++ b/pages/container-registry/how-to/display-image-versions.mdx
@@ -9,7 +9,7 @@ dates:
 import Requirements from '@macros/iam/requirements.mdx'
 
 
-Scaleway Container Registry supports image versioning. This allows you to track any changes in your container image versions, and easily revert your deployment if needed. You can choose which image version you want to pull, and delete any versions that you no longer need.
+Scaleway Container Registry supports image versioning. This allows you to track any changes in your container image versions and easily revert your deployment if needed. You can choose which image version you want to pull, and delete any versions that you no longer need.
 
 <Requirements />
 
@@ -18,11 +18,9 @@ Scaleway Container Registry supports image versioning. This allows you to track 
 - A [Container Registry namespace](/container-registry/how-to/create-namespace/)
 
 
-1. Click **Container Registry** in the **Containers** section of the [Scaleway console](https://console.scaleway.com) side menu. The Container Registry namespaces dashboard displays.
+1. Click **Container Registry** under the **Storage** or **Containers** sections of the [Scaleway console](https://console.scaleway.com) side menu. The Container Registry namespaces dashboard displays.
 2. Click the namespace's name to list its images.
 3. To view pull instructions for a specific version, click <Icon name="more" /> next to the version. Then click **Pull instructions**.
     <Message type="tip">
       If a specific version is no longer required, click <Icon name="more" /> > **Delete** next to the identifier to delete it.
     </Message>
-
-

--- a/pages/container-registry/how-to/manage-image-privacy-settings.mdx
+++ b/pages/container-registry/how-to/manage-image-privacy-settings.mdx
@@ -19,10 +19,8 @@ The [image privacy policy](/container-registry/concepts/#image-privacy-policies)
 - An image [pushed](/container-registry/how-to/push-images/) to your namespace
 
 
-1. Click **Container Registry** in the **Containers** section of the [Scaleway console](https://console.scaleway.com) side menu. The Container Registry namespaces dashboard displays.
+1. Click **Container Registry** under the **Storage** or **Containers** sections of the [Scaleway console](https://console.scaleway.com) side menu. The Container Registry namespaces dashboard displays.
 2. Click the namespace's name to list its images.
 3. Click <Icon name="more" /> next to the container image name, then click **Privacy policy** in the pop-up menu.
 4. Select the new image privacy policy to apply. The policy can either be **Public**, **Private** or **Inheritance from namespace policy**.
 5. Click **Update privacy policy** to set the policy.
-
-

--- a/pages/container-registry/how-to/manage-namespace-privacy-policies.mdx
+++ b/pages/container-registry/how-to/manage-namespace-privacy-policies.mdx
@@ -19,12 +19,10 @@ A namespace's privacy policy specifies whether everyone is granted access to pul
 - An image [pushed](/container-registry/how-to/push-images/) to your namespace
 
 
-1. Click **Container Registry** in the **Containers** section of the [Scaleway console](https://console.scaleway.com) side menu. The Container Registry namespaces dashboard displays.
+1. Click **Container Registry** under the **Storage** or **Containers** sections of the [Scaleway console](https://console.scaleway.com) side menu. The Container Registry namespaces dashboard displays.
 2. Click the namespace's name to list its images.
 3. Click the **Namespace settings** tab, then configure the policy by selecting either **Public** or **Private**.
 
 <Message type="note">
   Each container image may additionally have its [own privacy policies](/container-registry/how-to/manage-image-privacy-settings/).
 </Message>
-
-

--- a/pages/container-registry/how-to/pull-images.mdx
+++ b/pages/container-registry/how-to/pull-images.mdx
@@ -20,7 +20,7 @@ After [configuring Docker on your local machine](/container-registry/how-to/conn
 - Access to your [namespace](/container-registry/how-to/connect-docker-cli/)
 
 
-1. Click **Container Registry** in the **Containers** section of the side menu. A list of your namespaces displays.
+1. Click **Container Registry** under the **Storage** or **Containers** sections of the side menu. A list of your namespaces displays.
 2. Click the namespace you want to pull an image from.
 3. Click <Icon name="more" />, then **Pull instructions** next to the image you want to pull. A pop-up displays.
 4. Copy the command line instructions to pull the image with Docker. Then click **OK** to close the pop-up.
@@ -28,5 +28,3 @@ After [configuring Docker on your local machine](/container-registry/how-to/conn
   <Message type="note">
     The current configuration allows you up to 20 pulls/min per image.
   </Message>
-
-

--- a/pages/container-registry/quickstart.mdx
+++ b/pages/container-registry/quickstart.mdx
@@ -22,7 +22,7 @@ Discover the Container Registry interface in the Scaleway console.
 
 ## How to create a Container Registry namespace
 
-1. Click **Container Registry** in the **Containers** section of the [Scaleway console](https://console.scaleway.com) side menu. If you do not have a Registry already created, the product creation page is displayed.
+1. Click **Container Registry** under the **Storage** or **Containers** sections of the [Scaleway console](https://console.scaleway.com) side menu. If you do not have a Registry already created, the product creation page is displayed.
 2. Click **Create namespace** to launch the namespace creation wizard.
 3. Enter the following required information for your namespace:
     * A **Name** for the namespace
@@ -31,7 +31,7 @@ Discover the Container Registry interface in the Scaleway console.
     * The namespace's **Privacy Policies**
 
     <Message type="note">
-      A namespace can either be [public or private](/container-registry/concepts/#namespace-privacy-policies). Anyone will be able to pull container images from a public namespace. Privacy policies may be set at image level.
+      A namespace can either be [public or private](/container-registry/concepts/#namespace-privacy-policies). Anyone will be able to pull container images from a public namespace. Privacy policies may be set at the image level.
     </Message>
 4. Click **Create namespace** to create the namespace.
 
@@ -42,7 +42,7 @@ Discover the Container Registry interface in the Scaleway console.
 - Installed [Docker](https://www.docker.com/) on your local computer
 - [Generated your API key](/iam/how-to/create-api-keys/)
 
-1. Click **Container Registry** in the **Containers** section of the [Scaleway console](https://console.scaleway.com) side menu. The Container Registry namespaces dashboard displays.
+1. Click **Container Registry** under the **Storage** or **Containers** sections of the [Scaleway console](https://console.scaleway.com) side menu. The Container Registry namespaces dashboard displays.
 2. Click <Icon name="more" />, then **Push instructions** next to the namespace you want to push to. A pop-up displays.
 3. Copy the push instructions. Then click **X** to close the pop-up.
 4. Open a terminal window on your local computer. Then log into the namespace by running the following command from the terminal:
@@ -69,7 +69,7 @@ You are now logged in and ready to push and pull images to and from your Contain
 </Message>
 
 1. Open a terminal window on your local computer.
-2. Pull the latest release of the [Ubuntu](https://hub.docker.com/_/ubuntu/) docker image:
+2. Pull the latest release of the [Ubuntu](https://hub.docker.com/_/ubuntu/) Docker image:
     ```
     docker pull ubuntu:latest
     ```
@@ -77,7 +77,7 @@ You are now logged in and ready to push and pull images to and from your Contain
     ```
     docker tag ubuntu:latest rg.fr-par.scw.cloud/mynamespace/ubuntu:latest
     ```
-4. Push the image to your Container Registry namespace using docker:
+4. Push the image to your Container Registry namespace using Docker:
     ```
     docker push rg.fr-par.scw.cloud/mynamespace/ubuntu:latest
     ```
@@ -88,7 +88,7 @@ You are now logged in and ready to push and pull images to and from your Contain
 
 ## How to pull an image from your Container Registry namespace
 
-1. Click **Container Registry** in the **Containers** section of the side menu. A list of your namespaces displays.
+1. Click **Container Registry** under the **Storage** or **Containers** sections of the side menu. A list of your namespaces displays.
 2. Click the namespace you want to pull an image from.
 3. Click <Icon name="more" />, then **Pull Instructions** next to the image you want to pull. A pop-up displays.
 4. Copy the command line instructions to pull the image with Docker. Then click **OK** to close the pop-up.

--- a/tutorials/migrating-docker-workloads-to-kubernetes-kapsule/index.mdx
+++ b/tutorials/migrating-docker-workloads-to-kubernetes-kapsule/index.mdx
@@ -62,7 +62,7 @@ Your Kubernetes cluster needs access to your Docker images. You can use:
 ### 2.1 Create a namespace in Scaleway Container Registry
 
 
-1. Click **Container Registry** in the **Containers** section of the [Scaleway console](https://console.scaleway.com) side menu. If you do not have a Registry already created, the product creation page is displayed.
+1. Click **Container Registry** under the **Storage** or **Containers** sections of the [Scaleway console](https://console.scaleway.com) side menu. If you do not have a Registry already created, the product creation page is displayed.
 2. Click **Create namespace** to launch the namespace creation wizard.
 3. Enter the following required information for your namespace:
     * A **Name** for the namespace
@@ -224,7 +224,7 @@ spec:
 ```
 
 <Message type="note">
-   Replace image name and container port as per your application.
+   Replace the image name and container port as per your application.
 </Message>
 
 ### 5.2 Create a service manifest


### PR DESCRIPTION
### Description

Container Registry is now featured under 2 categories in the console: Containers and Storage. However, the doc only mentioned one of them. I've changed the necessary pages to include both access options.
