### PR TITLE
fix(generative-apis): replace future tense with present tense

### DIFF
--- a/pages/generative-apis/api-cli/understanding-errors.mdx
+++ b/pages/generative-apis/api-cli/understanding-errors.mdx
@@ -10,7 +10,7 @@ dates:
 Scaleway uses conventional HTTP response codes to indicate the success or failure of an API request. 
 In general, codes in the 2xx range indicate success, codes in the 4xx range indicate an error caused by the information provided, and codes in the 5xx range show an error from Scaleway servers.
 
-If the response code is not within the 2xx range, the response will contain an error object. The structure of the error object depends on how recent the model being used is:
+If the response code is not within the 2xx range, the API returns an error object. The structure of the error object depends on how recent the model being used is:
 
 <Tabs>
 


### PR DESCRIPTION
Replaced future-tense wording with present tense in the error response description to align with the Scaleway documentation writing guidelines.
