### PR TITLE
fix(kubernetes): update Kosmos node-agent to k8s-agent from GitHub

### DIFF
--- a/pages/kubernetes/how-to/edit-kosmos-cluster.mdx
+++ b/pages/kubernetes/how-to/edit-kosmos-cluster.mdx
@@ -71,10 +71,10 @@ In order to add external nodes to your multi-cloud cluster, you must first [crea
     ssh <user>@<server_ip>
     ```
 
-2. Download the `node-agent` program:
+2. Download the `k8s-agent` program. The releases and source code are available on [GitHub](https://github.com/scaleway/k8s-agent).
 
     ```bash
-    wget https://scwcontainermulticloud.s3.fr-par.scw.cloud/node-agent_linux_amd64 && chmod +x node-agent_linux_amd64
+    sudo wget -O /usr/local/bin/k8s-agent https://github.com/scaleway/k8s-agent/releases/latest/download/k8s-agent_linux_amd64 && sudo chmod +x /usr/local/bin/k8s-agent
     ```
 
 3. Export the required environment variables:
@@ -86,10 +86,10 @@ In order to add external nodes to your multi-cloud cluster, you must first [crea
 4. Execute the program to attach the node to the multi-cloud pool:
 
     ```bash
-    sudo -E ./node-agent_linux_amd64 -loglevel 0 -no-controller
+    sudo /usr/local/bin/k8s-agent
     ```
     <Message type="note">
-      There is also an ARM binary (named `node-agent_linux_arm64`) for ARM-based nodes.
+      There is also an ARM binary (named `k8s-agent_linux_arm64`) available on the [releases page](https://github.com/scaleway/k8s-agent/releases/latest) for ARM-based nodes.
     </Message>
 
 ## How to detach nodes from your multi-cloud pool
@@ -113,6 +113,5 @@ In order to add external nodes to your multi-cloud cluster, you must first [crea
 The Kubernetes version of the existing nodes in your multi-cloud pool can be upgraded in place. Your workload will theoretically keep running during the upgrade, but it is best to drain the node before the upgrade.
 
 1. In the Pools section of your Kosmos cluster, click **Upgrade** next to the node pool. This will not cause any of your existing nodes to upgrade, but will instead ensure that any new nodes added to the pool will start up with the newer version.
-2. Run the installer program as you would do for a fresh node install, with the additional option `-self-update`. If the option is not available, download the program again from the Object Storage bucket.
-3. Now the node will register itself with the Apiserver. Once it is ready, you will see the same node with two kubelet versions. The older node should end up `NotReady` after 5m, you can safely delete it with `kubectl`.
-4. Detach the older node in Scaleway API.
+2. Download the latest version of the `k8s-agent` and relaunch it as you would do for a fresh node install. Refer to [How to configure external nodes to join the cluster](#how-to-configure-external-nodes-to-join-the-cluster) for the installation steps.
+3. The node will upgrade in place and rejoin the cluster with the new Kubernetes version.


### PR DESCRIPTION
Update Kosmos external node documentation to use the new open-source k8s-agent from https://github.com/scaleway/k8s-agent