### PR TITLE
feat(genapi): add concurrent requests for embedding to faq

### DIFF
--- a/pages/generative-apis/faq.mdx
+++ b/pages/generative-apis/faq.mdx
@@ -147,13 +147,13 @@ These limits are in place to protect you against:
 - Uncontrolled billing, as several models are known to be able to enter infinite generation loops (specific prompts can make the model generate the same sentence over and over, without stopping at all).
 If you require higher maximum output tokens, you can use [Managed Inference](https://console.scaleway.com/inference/deployments), where these limits do not apply (as your bill will be limited to the size of your deployment).
 
-### Can I increase maximum concurrent requests?
-By default, no, you cannot increase maximum concurrent requests above [limits for all model](/organizations-and-projects/additional-content/organization-quotas/#generative-apis) in Generative APIs.
+### Can I increase the maximum number of concurrent requests?
 
-Note that for embeddings models, you can provide an [array of strings](https://www.scaleway.com/en/developers/api/generative-apis/#path-embeddings-create-an-embedding) to embed. For example, with `qwen3-embedding-8b`, you can send up to `2048` strings of `32 000` input tokens **each**, in a single query. 
+By default, you cannot increase the maximum number of concurrent requests beyond the [limits for all model](/organizations-and-projects/additional-content/organization-quotas/#generative-apis) in Generative APIs.
 
-If you have a specific use cases requiring higher concurrent requests limits, we recommend to use [Managed Inference](https://console.scaleway.com/inference/deployments), where these limits do not apply or to [contact our support teams](https://console.scaleway.com/support/tickets/create?for=product&productName=generativeApi) with details about your use case and expected concurrent requests limits.
+However, for embedding models, you can batch multiple inputs by providing an [array of strings](https://www.scaleway.com/en/developers/api/generative-apis/#path-embeddings-create-an-embedding) in a single request. For example, with `qwen3-embedding-8b`, you can send up to `2048` strings of `32 000` input tokens **each**, in a single query. 
 
+If you have a specific use case that requires higher concurrency limits, we recommend using [Managed Inference](https://console.scaleway.com/inference/deployments), where these limits do not apply or, [contacting our support team](https://console.scaleway.com/support/tickets/create?for=product&productName=generativeApi) with details about your use case and your expected concurrency requirements.
 ## Compatibility and integration
 
 ### Can I use OpenAI libraries and APIs with Scaleway's Generative APIs?


### PR DESCRIPTION
Added a section about increasing maximum concurrent requests in Generative APIs, including details on embedding models.
