### PR TITLE
cockpit(fix): remove mention of unnecessary api key

### DIFF
--- a/pages/cockpit/how-to/send-metrics-logs-to-cockpit.mdx
+++ b/pages/cockpit/how-to/send-metrics-logs-to-cockpit.mdx
@@ -3,7 +3,7 @@ title: How to send metrics and logs to your Cockpit
 description: Learn how to send metrics and logs to your Cockpit using Scaleway's comprehensive guide. This tutorial covers sending Python logs to Scaleway's Cockpit for centralized monitoring and analysis using Grafana, ensuring efficient data management and analysis in your infrastructure.
 tags: metrics cockpit logs observability
 dates:
-  validation: 2026-01-21
+  validation: 2026-02-10
   posted: 2022-10-31
 ---
 import Requirements from '@macros/iam/requirements.mdx'
@@ -20,7 +20,6 @@ You can push logs with any Loki compatible agent such as the [Promtail](https://
  - A Scaleway account logged into the [console](https://console.scaleway.com)
  - [Owner](/iam/concepts/#owner) status or [IAM permissions](/iam/concepts/#permission) allowing you to perform actions in the intended Organization
  - Configured an agent. Read our dedicated [documentation](/cockpit/how-to/send-metrics-with-grafana-alloy/) to find out how to configure the Grafana Alloy agent
- - [Created](/iam/how-to/create-api-keys/) an API key and retrieved your API secret key
 
 
 <Message type="important">
@@ -68,7 +67,7 @@ You can push logs with any Loki compatible agent such as the [Promtail](https://
       handler = logging_loki.LokiHandler(
           url="https://000avb0d-34ae-66hh-643b-f9e0n3k17773.cockpit.fr-par.scw.cloud/loki/api/v1/push",
           tags={"job": "logs_from_python"},
-          auth=("$SCW_API_SECRET_KEY", "$COCKPIT_TOKEN_SECRET_KEY"),
+          auth=("$COCKPIT_TOKEN_SECRET_KEY"),
           version="1",
 
       )


### PR DESCRIPTION
Users don't need to have an API key to send logs, metrics and traces to Cockpit. 
