### PR TITLE
fix(jobs): remove variable in command

### DIFF
--- a/tutorials/backup-mongodb-jobs/index.mdx
+++ b/tutorials/backup-mongodb-jobs/index.mdx
@@ -53,12 +53,12 @@ Serverless Jobs are perfectly adapted for these autonomous tasks, as we do not n
 
 9. In the **Execution** tab, define the command below, and replace the placeholders with the ID of your Managed MongoDB® Database Instance ID and the name of your snapshot:
     ```bash
-    /scw mongodb snapshot create <MONGO_INSTANCE_ID> name="snapshot_$(date +%Y%m%d_%H%M%S)" expires-at=30d
+    /scw mongodb snapshot create <MONGO_INSTANCE_ID> name=<SNAPSHOT_NAME> expires-at=30d
     ```
 
 10. Click **Create job**.
 
-Your job will automatically create a snapshot named `snapshot_<DATE_TIME>` with a 30-day retention period every day at 18:00.
+Your job will automatically create a snapshot with a 30-day retention period every day at 18:00.
 
 ## Running the job
 


### PR DESCRIPTION
### Description

Variable syntax has been removed from command.

Serverless Jobs doesn't support variables passed in a command.
This feature will be available with the v1alpha2 version.
