### PR TITLE
fix(genapi): model context length

### DIFF
--- a/pages/generative-apis/reference-content/supported-models.mdx
+++ b/pages/generative-apis/reference-content/supported-models.mdx
@@ -45,7 +45,7 @@ Our API supports the most popular models for [Chat](/generative-apis/how-to/quer
 | Mistral      | `devstral-2-123b-instruct-2512`     | 200k | 8192 | [Modified MIT](https://huggingface.co/mistralai/Devstral-2-123B-Instruct-2512/blob/main/LICENSE) | [HF](https://huggingface.co/mistralai/Devstral-2-123B-Instruct-2512) |
 | Qwen      | `qwen3-235b-a22b-instruct-2507`     | 250k | 8192 | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | [HF](https://huggingface.co/Qwen/Qwen3-235B-A22B-Instruct-2507) |
 | Qwen      | `qwen3-coder-30b-a3b-instruct`     | 128k | 8192 | [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) | [HF](https://huggingface.co/Qwen/Qwen3-Coder-30B-A3B-Instruct) |
-| DeepSeek  | `deepseek-r1-distill-llama-70b`     | 32k | 4096 | [MIT](https://huggingface.co/datasets/choosealicense/licenses/blob/main/markdown/mit.md) | [HF](https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Llama-70B) |
+| DeepSeek  | `deepseek-r1-distill-llama-70b`     | 16k | 4096 | [MIT](https://huggingface.co/datasets/choosealicense/licenses/blob/main/markdown/mit.md) | [HF](https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Llama-70B) |
 
 <Message type="tip">
   If you are unsure which chat model to use, we currently recommend Mistral Small 3.2 24B Instruct (`mistral-small-3.2-24b-instruct-2506`) to get started.


### PR DESCRIPTION
Updated the token limit for the DeepSeek Distill Llama model from 32k to 16k.

### Your checklist for this pull request

- [ ] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

Please describe what you added or changed.
