### PR TITLE
feat(instances): adjust to new Instance creation form for cloud-init

### DIFF
--- a/pages/instances/how-to/use-cloud-init.mdx
+++ b/pages/instances/how-to/use-cloud-init.mdx
@@ -50,10 +50,9 @@ As a Scaleway Instance user, you will need to leverage **user-data** to specify 
     - A Scaleway account logged into the [console](https://console.scaleway.com)
     - [Owner](/iam/concepts/#owner) status or [IAM permissions](/iam/concepts/#permission) allowing you to perform actions in the intended Organization
 
-    1. During [the process of creating an Instance](/instances/how-to/create-an-instance), click **+ Cloud-init** (between _Network configuration_ and _SSH keys_) to unfold the Cloud-init configuration dialog.
-    2. Click on <Icon name="toggle" /> to unlock the text field.
-    3. Paste your **user-data** into the text field.
-    4. Proceed to the remainder of the Instance creation process. The Instance starts with your **user-data**.
+    1. During [the process of creating an Instance](/instances/how-to/create-an-instance), under **Cloud-init (optional)**, click on <Icon name="toggle" /> to unlock the text field.
+    2. Paste your **user-data** into the text field.
+    3. Proceed to the remainder of the Instance creation process. The Instance starts with your **user-data**.
 
   </TabsTab>
   <TabsTab label="CLI">


### PR DESCRIPTION
### Description

This PR adjusts the Cloud-init howto to the Instances creation funnel, which now presents the _Cloud-init_ section more prominently.
