### PR TITLE
Ext fix generative apis

### DIFF
--- a/pages/generative-apis/reference-content/supported-models.mdx
+++ b/pages/generative-apis/reference-content/supported-models.mdx
@@ -79,7 +79,7 @@ Our [Embeddings API](/generative-apis/how-to/query-embedding-models) provides bu
 
 These models are not accessible anymore from Generative APIs. They can still however be deployed on dedicated [Managed Inference](https://console.scaleway.com/inference/deployments) deployments.
 
-| Provider | Model string | Deprecation Date | EOL date | Requests routed to model
+| Provider | Model string | Deprecation date | EOL date | Requests routed to model
 |-----------------|-----------------|-----------------|-----------------|-----------------|
 | Mistral | `mistral-small-3.1-24b-instruct-2503`  | 14th August, 2025 | 14th November, 2025 | `mistral-small-3.2-24b-instruct-2506` |
 | Mistral | `devstral-small-2505`  | 14th August, 2025 | 14th November, 2025 | `qwen3-coder-30b-a3b-instruct` |

--- a/pages/generative-apis/reference-content/supported-models.mdx
+++ b/pages/generative-apis/reference-content/supported-models.mdx
@@ -77,7 +77,8 @@ Our [Embeddings API](/generative-apis/how-to/query-embedding-models) provides bu
 
 ## End of Life (EOL) models
 
-These models are not accessible anymore from Generative APIs. They can still however be deployed on dedicated [Managed Inference](https://console.scaleway.com/inference/deployments) deployments.
+**Between the Deprecation date and the End Of Life date**, models can still be accessed in Generative APIs, but their End of Life (EOL) is planned according to our [model lifecycle policy](/generative-apis/reference-content/model-lifecycle/). Deprecated models should not be queried anymore. We recommend to use newer models available in Generative APIs or to deploy these models in dedicated [Managed Inference](https://console.scaleway.com/inference/deployments) deployments.
+**After the End Of Life date**, these models are not accessible anymore from Generative APIs. They can still however be deployed on dedicated [Managed Inference](https://console.scaleway.com/inference/deployments) deployments.
 
 | Provider | Model string | Deprecation date | EOL date | Requests routed to model
 |-----------------|-----------------|-----------------|-----------------|-----------------|

--- a/pages/generative-apis/reference-content/supported-models.mdx
+++ b/pages/generative-apis/reference-content/supported-models.mdx
@@ -79,13 +79,13 @@ Our [Embeddings API](/generative-apis/how-to/query-embedding-models) provides bu
 
 These models are not accessible anymore from Generative APIs. They can still however be deployed on dedicated [Managed Inference](https://console.scaleway.com/inference/deployments) deployments.
 
-| Provider | Model string | EOL date | Requests routed to model
-|-----------------|-----------------|-----------------|-----------------|
-| Mistral | `mistral-small-3.1-24b-instruct-2503`  | 14th November, 2025 | `mistral-small-3.2-24b-instruct-2506` |
-| Mistral | `devstral-small-2505`  | 14th November, 2025 | `qwen3-coder-30b-a3b-instruct` |
-| Qwen      | `qwen2.5-coder-32b-instruct`     | 14th November, 2025 | `qwen3-coder-30b-a3b-instruct` |
-| Meta    | `llama-3.1-70b-instruct` | 25th May, 2025 | `llama-3.3-70b-instruct` |
-| SBERT      | `sentence-t5-xxl`  | 26 February, 2025 | None |
-| Deepseek | `deepseek-r1-distill-llama-70b` | 16th April, 2026 | `llama-3.3-70b-instruct` |
-| Mistral | `mistral-nemo-instruct-2407` | 16th April, 2026 | `mistral-small-3.2-24b-instruct-2506` |
-| Meta | `llama-3.1-8b-instruct` | 16th April, 2026 | `mistral-small-3.2-24b-instruct-2506` |
+| Provider | Model string | Deprecation Date | EOL date | Requests routed to model
+|-----------------|-----------------|-----------------|-----------------|-----------------|
+| Mistral | `mistral-small-3.1-24b-instruct-2503`  | 14th August, 2025 | 14th November, 2025 | `mistral-small-3.2-24b-instruct-2506` |
+| Mistral | `devstral-small-2505`  | 14th August, 2025 | 14th November, 2025 | `qwen3-coder-30b-a3b-instruct` |
+| Qwen      | `qwen2.5-coder-32b-instruct`     | 14th August, 2025 | 14th November, 2025 | `qwen3-coder-30b-a3b-instruct` |
+| Meta    | `llama-3.1-70b-instruct` | 25th February, 2025 | 25th May, 2025 | `llama-3.3-70b-instruct` |
+| SBERT      | `sentence-t5-xxl`  | 26th November, 2024 | 26 February, 2025 | None |
+| Deepseek | `deepseek-r1-distill-llama-70b` | 16th January, 2026 | 16th April, 2026 | `llama-3.3-70b-instruct` |
+| Mistral | `mistral-nemo-instruct-2407` | 16th January, 2026 | 16th April, 2026 | `mistral-small-3.2-24b-instruct-2506` |
+| Meta | `llama-3.1-8b-instruct` | 16th January, 2026 | 16th April, 2026 | `mistral-small-3.2-24b-instruct-2506` |

--- a/pages/generative-apis/reference-content/supported-models.mdx
+++ b/pages/generative-apis/reference-content/supported-models.mdx
@@ -97,3 +97,6 @@ These models are not accessible anymore from Generative APIs. They can still how
 | Qwen      | `qwen2.5-coder-32b-instruct`     | 14th November, 2025 | `qwen3-coder-30b-a3b-instruct` |
 | Meta    | `llama-3.1-70b-instruct` | 25th May, 2025 | `llama-3.3-70b-instruct` |
 | SBERT      | `sentence-t5-xxl`  | 26 February, 2025 | None |
+| Deepseek | `deepseek-r1-distill-llama-70b` | 16th April, 2026 | `llama-3.3-70b-instruct` |
+| Mistral | `mistral-nemo-instruct-2407` | 16th April, 2026 | `mistral-small-3.2-24b-instruct-2506` |
+| Meta | `llama-3.1-8b-instruct` | 16th April, 2026 | `mistral-small-3.2-24b-instruct-2506` |

--- a/pages/generative-apis/reference-content/supported-models.mdx
+++ b/pages/generative-apis/reference-content/supported-models.mdx
@@ -75,17 +75,6 @@ Our [Embeddings API](/generative-apis/how-to/query-embedding-models) provides bu
 
 **Do not see a model you want to use?** [Tell us or vote for what you would like to add here.](https://feature-request.scaleway.com/?tags=ai-services)
 
-## Deprecated models
-
-These models can still be accessed in Generative APIs, but their End of Life (EOL) is planned according to our [model lifecycle policy](/generative-apis/reference-content/model-lifecycle/).
-Deprecated models should not be queried anymore. We recommend to use newer models available in Generative APIs or to deploy these models in dedicated [Managed Inference](https://console.scaleway.com/inference/deployments) deployments.
-
-| Provider | Model string | Deprecation date | End of Life (EOL) date | After End of Life date, requests routed to model
-|-----------------|-----------------|-----------------|-----------------|-----------------|
-| Deepseek | `deepseek-r1-distill-llama-70b`  |  16th January, 2026 | 16th April, 2026 | `llama-3.3-70b-instruct` |
-| Mistral | `mistral-nemo-instruct-2407`  | 16th January, 2026 | 16th April, 2026 | `mistral-small-3.2-24b-instruct-2506` |
-| Meta     | `llama-3.1-8b-instruct`     | 16th January, 2026 | 16th April, 2026 | `mistral-small-3.2-24b-instruct-2506` |
-
 ## End of Life (EOL) models
 
 These models are not accessible anymore from Generative APIs. They can still however be deployed on dedicated [Managed Inference](https://console.scaleway.com/inference/deployments) deployments.


### PR DESCRIPTION
### Description

Updated the "End of Life (EOL) models" section to include the three models reaching EOL on April 16, 2026:
- Deepseek `deepseek-r1-distill-llama-70b`
- Mistral `mistral-nemo-instruct-2407`
- Meta `llama-3.1-8b-instruct`