### PR TITLE
docs(cockpit): clarify OpenTelemetry data exports

### DIFF
--- a/pages/cockpit/how-to/manage-data-exports.mdx
+++ b/pages/cockpit/how-to/manage-data-exports.mdx
@@ -47,7 +47,7 @@ This page shows you how to create, update, and delete Cockpit [data exports](/co
             - Enter your OpenTelemetry endpoint in the **URL** field.
       For OTLP destinations, enter your endpoint URL without a specific OTLP path such as `/v1/logs` or `/v1/metrics`. The exporter will automatically concatenate the correct path to your URL.
 
-    You can also add headers to your OTLP export request:
+            You can also add headers to your OTLP export request:
     
     - Click **+ Add variable** 
     - Enter your header key in the **Key** field.

--- a/pages/cockpit/how-to/manage-data-exports.mdx
+++ b/pages/cockpit/how-to/manage-data-exports.mdx
@@ -103,7 +103,7 @@ To check whether a data export generates errors:
 2. Click **Explore**.
 3. Select your Cockpit metrics data source.
 4. Run the following PromQL queries:
-
+    For log exports, run: 
 ```promql
 sum(rate(observability_exporter_otelcol_exporter_send_failed_log_records_total[20m]))
 ```

--- a/pages/cockpit/how-to/manage-data-exports.mdx
+++ b/pages/cockpit/how-to/manage-data-exports.mdx
@@ -52,7 +52,9 @@ This page shows you how to create, update, and delete Cockpit [data exports](/co
             - Click **+ Add variable** 
             - Enter your header key in the **Key** field.
             - Enter your header value in the **Value** field.
-    - Optionally, click **+ Add variable** to add more headers.
+            - Optionally, click **+ Add variable** to add more headers.
+        </TabsTab>
+    </Tabs>
 7. In the **Products** drop-down, choose products whose metrics/logs you want to export.
 
     <Message type="note">

--- a/pages/cockpit/how-to/manage-data-exports.mdx
+++ b/pages/cockpit/how-to/manage-data-exports.mdx
@@ -51,7 +51,7 @@ This page shows you how to create, update, and delete Cockpit [data exports](/co
     
             - Click **+ Add variable** 
             - Enter your header key in the **Key** field.
-    - Enter your header value in the **Value** field.
+            - Enter your header value in the **Value** field.
     - Optionally, click **+ Add variable** to add more headers.
 7. In the **Products** drop-down, choose products whose metrics/logs you want to export.
 

--- a/pages/cockpit/how-to/manage-data-exports.mdx
+++ b/pages/cockpit/how-to/manage-data-exports.mdx
@@ -43,7 +43,7 @@ This page shows you how to create, update, and delete Cockpit [data exports](/co
     **OpenTelemetry**
 
     - Enter your OpenTelemetry endpoint in the **URL** field.
-      For OTLP/HTTP destinations, enter the endpoint base URL only, without a signal-specific path such as `/v1/logs` or `/v1/metrics`. Cockpit adds the OTLP signal path automatically.
+      For OTLP destinations, enter your endpoint URL without a specific OTLP path such as `/v1/logs` or `/v1/metrics`. The exporter will automatically concatenate the correct path to your URL.
 
     You can also add headers to your OTLP export request:
     

--- a/pages/cockpit/how-to/manage-data-exports.mdx
+++ b/pages/cockpit/how-to/manage-data-exports.mdx
@@ -33,27 +33,32 @@ This page shows you how to create, update, and delete Cockpit [data exports](/co
     <Message type="tip">
       If you have already created an export, navigate to your data source's **Settings** tab and click **Create export** in the dedicated section.
     </Message>
-6. Choose an export destination:
+6. Choose an export destination, and configure it according to the destination type.
 
-    <Tabs>
-        <TabsTab label="Datadog">
-            - Enter the URL of your Datadog site in the **URL** field. For example `https://api.datadoghq.eu/` for metrics or `https://http-intake.logs.datadoghq.eu/` for logs.
+    **Datadog**
 
-            - Enter your Datadog API key in the **Datadog API Key** field.
-        </TabsTab>
-        <TabsTab label="Open Telemetry">
-            - Enter your Open Telemetry endpoint in the **URL** field.
-            - Click **+ Add header** to add a header and attach extra information, like credentials or metadata, to your HTTP requests.
-            - Enter your token in the **Key** field.
-            - Enter your token value in the **Value** field.
-            - Optionally, click **+ Add header** to add more headers.
-        </TabsTab>
-    </Tabs>
+    - Enter the URL of your Datadog site in the **URL** field. For example `https://api.datadoghq.eu/` for metrics or `https://http-intake.logs.datadoghq.eu/` for logs.
+    - Enter your Datadog API key in the **Datadog API Key** field.
+
+    **OpenTelemetry**
+
+    - Enter your OpenTelemetry endpoint in the **URL** field.
+      For OTLP/HTTP destinations, enter the endpoint base URL only, without a signal-specific path such as `/v1/logs` or `/v1/metrics`. Cockpit adds the OTLP signal path automatically.
+
+    **HTTP headers**
+
+    - Click **+ Add header** to add a header and attach extra information, like credentials or metadata, to your HTTP requests.
+    - Enter your token in the **Key** field.
+    - Enter your token value in the **Value** field.
+    - Optionally, click **+ Add header** to add more headers.
+
 7. In the **Products** drop-down, choose products whose metrics/logs you want to export.
-        <Message type="note">
-         - Only products that provide metrics/logs to Cockpit are eligible for export. Find out which products are eligible in the [dedicated documentation](/cockpit/reference-content/cockpit-product-integration).
-         - Selecting **All current and future products** means that all present Scaleway resources sending metrics/logs to Cockpit, and any future ones you create, will automatically be exported.
-        </Message>
+
+    <Message type="note">
+      - Only products that provide metrics/logs to Cockpit are eligible for export. Find out which products are eligible in the [dedicated documentation](/cockpit/reference-content/cockpit-product-integration).
+      - Selecting **All current and future products** means that all present Scaleway resources sending metrics/logs to Cockpit, and any future ones you create, will automatically be exported.
+    </Message>
+
 8. In the **Data export details** section, enter a name for your data export, and optionally add a description.
 9. Review your purchase summary and click **Create data export** to confirm.
 
@@ -91,6 +96,25 @@ Your export displays in your data source's **Settings** tab, under the **Data ex
 ## How to monitor data exports
 
 You can monitor your data exports in real time from your Cockpit Grafana dashboard.
+
+To check whether a data export generates errors:
+
+1. [Log in to Cockpit's Grafana](/cockpit/how-to/access-grafana-and-managed-dashboards/).
+2. Click **Explore**.
+3. Select your Cockpit metrics data source.
+4. Run the following PromQL query for log exports:
+
+```promql
+sum(rate(observability_exporter_otelcol_exporter_send_failed_log_records_total[20m]))
+```
+
+For metrics exports, use the following PromQL query:
+
+```promql
+sum(rate(observability_exporter_otelcol_exporter_send_failed_metric_points_total[20m]))
+```
+
+A value greater than `0` means that Cockpit generated export send errors during the selected time range. These metrics count failed records or metric points, but do not include the error message returned by the destination endpoint.
 
 You are **responsible for how your exported data is used** and for **any changes in resource volume**. Adding resources naturally increases the number of generated metrics and logs, and the exported volume may fluctuate even without manual action (for example, autoscaling creates additional resources, resulting in more data to export).
 Find out how data exports are billed in the [dedicated documentation page](/cockpit/reference-content/cockpit-pricing/#billing-information-for-cockpit-data-exports).

--- a/pages/cockpit/how-to/manage-data-exports.mdx
+++ b/pages/cockpit/how-to/manage-data-exports.mdx
@@ -108,7 +108,7 @@ To check whether a data export generates errors:
 sum(rate(observability_exporter_otelcol_exporter_send_failed_log_records_total[20m]))
 ```
 
-For metrics exports, use the following PromQL query:
+    For metrics exports, run:
 
     ```promql
     sum(rate(observability_exporter_otelcol_exporter_send_failed_metric_points_total[20m]))

--- a/pages/cockpit/how-to/manage-data-exports.mdx
+++ b/pages/cockpit/how-to/manage-data-exports.mdx
@@ -56,7 +56,7 @@ This page shows you how to create, update, and delete Cockpit [data exports](/co
 
     <Message type="note">
       - Only products that provide metrics/logs to Cockpit are eligible for export. Find out which products are eligible in the [dedicated documentation](/cockpit/reference-content/cockpit-product-integration).
-      - Selecting **All current and future products** means that all present Scaleway resources sending metrics/logs to Cockpit, and any future ones you create, will automatically be exported.
+      - Selecting **All current and future products** means that the export will concern all current Scaleway products sending metrics/logs to your Cockpit, and any future new products that send metrics/logs to your Cockpit will also automatically be exported.
     </Message>
 
 8. In the **Data export details** section, enter a name for your data export, and optionally add a description.

--- a/pages/cockpit/how-to/manage-data-exports.mdx
+++ b/pages/cockpit/how-to/manage-data-exports.mdx
@@ -114,7 +114,7 @@ To check whether a data export generates errors:
     sum(rate(observability_exporter_otelcol_exporter_send_failed_metric_points_total[20m]))
     ```
 
-A value greater than `0` means that Cockpit generated export send errors during the selected time range. These metrics count failed records or metric points, but do not include the error message returned by the destination endpoint.
+    A value greater than `0` means that Cockpit generated export send errors during the selected time range. These metrics count failed records or metric points, but do not include the error message returned by the destination endpoint.
 
 You are **responsible for how your exported data is used** and for **any changes in resource volume**. Adding resources naturally increases the number of generated metrics and logs, and the exported volume may fluctuate even without manual action (for example, autoscaling creates additional resources, resulting in more data to export).
 Find out how data exports are billed in the [dedicated documentation page](/cockpit/reference-content/cockpit-pricing/#billing-information-for-cockpit-data-exports).

--- a/pages/cockpit/how-to/manage-data-exports.mdx
+++ b/pages/cockpit/how-to/manage-data-exports.mdx
@@ -104,9 +104,9 @@ To check whether a data export generates errors:
 3. Select your Cockpit metrics data source.
 4. Run the following PromQL queries:
     For log exports, run: 
-```promql
-sum(rate(observability_exporter_otelcol_exporter_send_failed_log_records_total[20m]))
-```
+    ```promql
+    sum(rate(observability_exporter_otelcol_exporter_send_failed_log_records_total[20m]))
+    ```
 
     For metrics exports, run:
 

--- a/pages/cockpit/how-to/manage-data-exports.mdx
+++ b/pages/cockpit/how-to/manage-data-exports.mdx
@@ -49,7 +49,7 @@ This page shows you how to create, update, and delete Cockpit [data exports](/co
 
             You can also add headers to your OTLP export request:
     
-    - Click **+ Add variable** 
+            - Click **+ Add variable** 
     - Enter your header key in the **Key** field.
     - Enter your header value in the **Value** field.
     - Optionally, click **+ Add variable** to add more headers.

--- a/pages/cockpit/how-to/manage-data-exports.mdx
+++ b/pages/cockpit/how-to/manage-data-exports.mdx
@@ -102,7 +102,7 @@ To check whether a data export generates errors:
 1. [Log in to Cockpit's Grafana](/cockpit/how-to/access-grafana-and-managed-dashboards/).
 2. Click **Explore**.
 3. Select your Cockpit metrics data source.
-4. Run the following PromQL query for log exports:
+4. Run the following PromQL queries:
 
 ```promql
 sum(rate(observability_exporter_otelcol_exporter_send_failed_log_records_total[20m]))

--- a/pages/cockpit/how-to/manage-data-exports.mdx
+++ b/pages/cockpit/how-to/manage-data-exports.mdx
@@ -39,7 +39,8 @@ This page shows you how to create, update, and delete Cockpit [data exports](/co
         <TabsTab label="Datadog">
 
             - Enter the URL of your Datadog site in the **URL** field. The default URL is `https://api.datadoghq.eu/` for metrics and `https://http-intake.logs.datadoghq.eu/` for logs.
-    - Enter your Datadog API key in the **Datadog API Key** field.
+            - Enter your Datadog API key in the **Datadog API Key** field.
+       </TabsTab>
 
         <TabsTab label="Open Telemetry">
 

--- a/pages/cockpit/how-to/manage-data-exports.mdx
+++ b/pages/cockpit/how-to/manage-data-exports.mdx
@@ -38,7 +38,7 @@ This page shows you how to create, update, and delete Cockpit [data exports](/co
     <Tabs>
         <TabsTab label="Datadog">
 
-    - Enter the URL of your Datadog site in the **URL** field. The default URL is `https://api.datadoghq.eu/` for metrics and `https://http-intake.logs.datadoghq.eu/` for logs.
+            - Enter the URL of your Datadog site in the **URL** field. The default URL is `https://api.datadoghq.eu/` for metrics and `https://http-intake.logs.datadoghq.eu/` for logs.
     - Enter your Datadog API key in the **Datadog API Key** field.
 
         <TabsTab label="Open Telemetry">

--- a/pages/cockpit/how-to/manage-data-exports.mdx
+++ b/pages/cockpit/how-to/manage-data-exports.mdx
@@ -37,7 +37,7 @@ This page shows you how to create, update, and delete Cockpit [data exports](/co
 
     **Datadog**
 
-    - Enter the URL of your Datadog site in the **URL** field. For example `https://api.datadoghq.eu/` for metrics or `https://http-intake.logs.datadoghq.eu/` for logs.
+    - Enter the URL of your Datadog site in the **URL** field. The default URL is `https://api.datadoghq.eu/` for metrics and `https://http-intake.logs.datadoghq.eu/` for logs.
     - Enter your Datadog API key in the **Datadog API Key** field.
 
     **OpenTelemetry**

--- a/pages/cockpit/how-to/manage-data-exports.mdx
+++ b/pages/cockpit/how-to/manage-data-exports.mdx
@@ -45,6 +45,7 @@ This page shows you how to create, update, and delete Cockpit [data exports](/co
         <TabsTab label="Open Telemetry">
 
             - Enter your OpenTelemetry endpoint in the **URL** field.
+
             For OTLP destinations, enter your endpoint URL without a specific OTLP path such as `/v1/logs` or `/v1/metrics`. The exporter will automatically concatenate the correct path to your URL.
 
             You can also add headers to your OTLP export request:

--- a/pages/cockpit/how-to/manage-data-exports.mdx
+++ b/pages/cockpit/how-to/manage-data-exports.mdx
@@ -35,7 +35,8 @@ This page shows you how to create, update, and delete Cockpit [data exports](/co
     </Message>
 6. Choose an export destination, and configure it according to the destination type.
 
-    **Datadog**
+    <Tabs>
+        <TabsTab label="Datadog">
 
     - Enter the URL of your Datadog site in the **URL** field. The default URL is `https://api.datadoghq.eu/` for metrics and `https://http-intake.logs.datadoghq.eu/` for logs.
     - Enter your Datadog API key in the **Datadog API Key** field.

--- a/pages/cockpit/how-to/manage-data-exports.mdx
+++ b/pages/cockpit/how-to/manage-data-exports.mdx
@@ -110,9 +110,9 @@ sum(rate(observability_exporter_otelcol_exporter_send_failed_log_records_total[2
 
 For metrics exports, use the following PromQL query:
 
-```promql
-sum(rate(observability_exporter_otelcol_exporter_send_failed_metric_points_total[20m]))
-```
+    ```promql
+    sum(rate(observability_exporter_otelcol_exporter_send_failed_metric_points_total[20m]))
+    ```
 
 A value greater than `0` means that Cockpit generated export send errors during the selected time range. These metrics count failed records or metric points, but do not include the error message returned by the destination endpoint.
 

--- a/pages/cockpit/how-to/manage-data-exports.mdx
+++ b/pages/cockpit/how-to/manage-data-exports.mdx
@@ -102,6 +102,7 @@ To check whether a data export generates errors:
 2. Click **Explore**.
 3. Select your Cockpit metrics data source.
 4. Run the following PromQL queries:
+
     For log exports, run: 
     ```promql
     sum(rate(observability_exporter_otelcol_exporter_send_failed_log_records_total[20m]))

--- a/pages/cockpit/how-to/manage-data-exports.mdx
+++ b/pages/cockpit/how-to/manage-data-exports.mdx
@@ -45,13 +45,12 @@ This page shows you how to create, update, and delete Cockpit [data exports](/co
     - Enter your OpenTelemetry endpoint in the **URL** field.
       For OTLP/HTTP destinations, enter the endpoint base URL only, without a signal-specific path such as `/v1/logs` or `/v1/metrics`. Cockpit adds the OTLP signal path automatically.
 
-    **HTTP headers**
-
-    - Click **+ Add header** to add a header and attach extra information, like credentials or metadata, to your HTTP requests.
-    - Enter your token in the **Key** field.
-    - Enter your token value in the **Value** field.
-    - Optionally, click **+ Add header** to add more headers.
-
+    You can also add headers to your OTLP export request:
+    
+    - Click **+ Add variable** 
+    - Enter your header key in the **Key** field.
+    - Enter your header value in the **Value** field.
+    - Optionally, click **+ Add variable** to add more headers.
 7. In the **Products** drop-down, choose products whose metrics/logs you want to export.
 
     <Message type="note">

--- a/pages/cockpit/how-to/manage-data-exports.mdx
+++ b/pages/cockpit/how-to/manage-data-exports.mdx
@@ -50,7 +50,7 @@ This page shows you how to create, update, and delete Cockpit [data exports](/co
             You can also add headers to your OTLP export request:
     
             - Click **+ Add variable** 
-    - Enter your header key in the **Key** field.
+            - Enter your header key in the **Key** field.
     - Enter your header value in the **Value** field.
     - Optionally, click **+ Add variable** to add more headers.
 7. In the **Products** drop-down, choose products whose metrics/logs you want to export.

--- a/pages/cockpit/how-to/manage-data-exports.mdx
+++ b/pages/cockpit/how-to/manage-data-exports.mdx
@@ -45,7 +45,7 @@ This page shows you how to create, update, and delete Cockpit [data exports](/co
         <TabsTab label="Open Telemetry">
 
             - Enter your OpenTelemetry endpoint in the **URL** field.
-      For OTLP destinations, enter your endpoint URL without a specific OTLP path such as `/v1/logs` or `/v1/metrics`. The exporter will automatically concatenate the correct path to your URL.
+            For OTLP destinations, enter your endpoint URL without a specific OTLP path such as `/v1/logs` or `/v1/metrics`. The exporter will automatically concatenate the correct path to your URL.
 
             You can also add headers to your OTLP export request:
     

--- a/pages/cockpit/how-to/manage-data-exports.mdx
+++ b/pages/cockpit/how-to/manage-data-exports.mdx
@@ -41,7 +41,7 @@ This page shows you how to create, update, and delete Cockpit [data exports](/co
     - Enter the URL of your Datadog site in the **URL** field. The default URL is `https://api.datadoghq.eu/` for metrics and `https://http-intake.logs.datadoghq.eu/` for logs.
     - Enter your Datadog API key in the **Datadog API Key** field.
 
-    **OpenTelemetry**
+        <TabsTab label="Open Telemetry">
 
     - Enter your OpenTelemetry endpoint in the **URL** field.
       For OTLP destinations, enter your endpoint URL without a specific OTLP path such as `/v1/logs` or `/v1/metrics`. The exporter will automatically concatenate the correct path to your URL.

--- a/pages/cockpit/how-to/manage-data-exports.mdx
+++ b/pages/cockpit/how-to/manage-data-exports.mdx
@@ -44,7 +44,7 @@ This page shows you how to create, update, and delete Cockpit [data exports](/co
 
         <TabsTab label="Open Telemetry">
 
-    - Enter your OpenTelemetry endpoint in the **URL** field.
+            - Enter your OpenTelemetry endpoint in the **URL** field.
       For OTLP destinations, enter your endpoint URL without a specific OTLP path such as `/v1/logs` or `/v1/metrics`. The exporter will automatically concatenate the correct path to your URL.
 
     You can also add headers to your OTLP export request:


### PR DESCRIPTION
### Description

  Clarifies the Cockpit data export instructions for OpenTelemetry destinations.

  This PR:
  - separates the Datadog, OpenTelemetry, and HTTP header instructions to make the destination setup clearer;
  - explains that OTLP/HTTP OpenTelemetry endpoints should use the base URL only, without `/v1/logs` or `/v1/metrics`, because Cockpit adds the OTLP signal path automatically;
  - adds Grafana Explore PromQL queries to check whether a data export generated failed log records or failed metric points.