### PR TITLE
feat(genapis): move managed inference changelogs under genapis MTA-7152

### DIFF
--- a/changelog/april2025/2025-04-11-managed-inference-added-custom-models-deployment-availa.mdx
+++ b/changelog/april2025/2025-04-11-managed-inference-added-custom-models-deployment-availa.mdx
@@ -3,7 +3,7 @@ title: Custom models deployment available in beta
 status: added
 date: 2025-04-11
 category: ai-data
-product: managed-inference
+product: generative-apis
 ---
 
 [Custom models](https://www.scaleway.com/en/docs/managed-inference/reference-content/supported-models/#custom-models) can now be deployed on Managed Inference.  

--- a/changelog/april2026/2026-04-29-managed-inference-changed-managed-inference-becomes-gen.mdx
+++ b/changelog/april2026/2026-04-29-managed-inference-changed-managed-inference-becomes-gen.mdx
@@ -3,7 +3,7 @@ title: Managed Inference becomes Generative APIs - Dedicated Deployment
 status: changed
 date: 2026-04-29
 category: ai-data
-product: managed-inference
+product: generative-apis
 ---
 
 Starting **1 May 2026**, Managed Inference becomes **Generative APIs - Dedicated Deployment**. All APIs, existing resources, pricing, and SLAs **remain unchanged**. All Managed Inference related content (such as documentation or Cockpit dashboards) will gradually be renamed **Generative APIs - Dedicated**.

--- a/changelog/august2024/2024-08-26-managed-inference-added-chat-and-embedding-apis-now-ret.mdx
+++ b/changelog/august2024/2024-08-26-managed-inference-added-chat-and-embedding-apis-now-ret.mdx
@@ -6,7 +6,7 @@ author:
     url: 'https://slack.scaleway.com'
 date: 2024-08-26
 category: ai-data
-product: managed-inference
+product: generative-apis
 ---
 
 Managed Inference endpoints now return usage stats (number of tokens in prompt, completion and totals) both for streaming and non-streaming responses.

--- a/changelog/february2025/2025-02-14-managed-inference-added-new-model-preview-deepseek-r1-d.mdx
+++ b/changelog/february2025/2025-02-14-managed-inference-added-new-model-preview-deepseek-r1-d.mdx
@@ -6,7 +6,7 @@ author:
     url: 'https://slack.scaleway.com'
 date: 2025-02-14
 category: ai-data
-product: managed-inference
+product: generative-apis
 ---
 
 [DeepSeek R1 Distilled Llama 70B](/managed-inference/reference-content/model-catalog/#deepseek-r1-distill-llama-70b) is now available on Managed Inference.

--- a/changelog/january2026/2026-01-12-managed-inference-added-new-supported-model-mistral-lar.mdx
+++ b/changelog/january2026/2026-01-12-managed-inference-added-new-supported-model-mistral-lar.mdx
@@ -3,7 +3,7 @@ title: New supported model - Mistral Large 3
 status: added
 date: 2026-01-12
 category: ai-data
-product: managed-inference
+product: generative-apis
 ---
 
 [Mistral Large 3](https://www.scaleway.com/en/docs/managed-inference/reference-content/model-catalog/#mistral-large-3-675b-instruct-2512) is now available on Managed Inference.

--- a/changelog/july2024/2024-07-01-managed-inference-added-managed-inference-is-available-.mdx
+++ b/changelog/july2024/2024-07-01-managed-inference-added-managed-inference-is-available-.mdx
@@ -6,7 +6,7 @@ author:
     url: 'https://slack.scaleway.com'
 date: 2024-07-01
 category: ai-data
-product: managed-inference
+product: generative-apis
 ---
 
 Managed Inference lets you deploy generative AI models and answer prompts from European end-consumers securely. Now available in public beta!

--- a/changelog/july2024/2024-07-23-managed-inference-changed-models-now-support-longer-and.mdx
+++ b/changelog/july2024/2024-07-23-managed-inference-changed-models-now-support-longer-and.mdx
@@ -6,7 +6,7 @@ author:
     url: 'https://slack.scaleway.com'
 date: 2024-07-23
 category: ai-data
-product: managed-inference
+product: generative-apis
 ---
 
 - All models on catalog now support conversations to their full context window (e.g Mixtral-8x7b up to 32K tokens, Llama3 up to 8k tokens).

--- a/changelog/june2025/2025-06-17-managed-inference-added-new-models-support-devstral.mdx
+++ b/changelog/june2025/2025-06-17-managed-inference-added-new-models-support-devstral.mdx
@@ -3,7 +3,7 @@ title: New supported model - Devstral
 status: added
 date: 2025-06-17
 category: ai-data
-product: managed-inference
+product: generative-apis
 ---
 
 [Devstral Small 2505](https://www.scaleway.com/en/docs/managed-inference/reference-content/model-catalog/#devstral-small-2505) is now available for deployment on Managed Inference.

--- a/changelog/may2025/2025-05-19-managed-inference-added-managed-inference-is-now-in-gen.mdx
+++ b/changelog/may2025/2025-05-19-managed-inference-added-managed-inference-is-now-in-gen.mdx
@@ -3,7 +3,7 @@ title: Managed Inference is now in General Availability
 status: added
 date: 2025-05-19
 category: ai-data
-product: managed-inference
+product: generative-apis
 ---
 
 Deploy latest AI models from our [model catalog](/managed-inference/reference-content/model-catalog/) to benefit from guaranteed performance and strong security within your VPC.

--- a/changelog/november2024/2024-11-28-managed-inference-added-new-models-support-nemotron-and.mdx
+++ b/changelog/november2024/2024-11-28-managed-inference-added-new-models-support-nemotron-and.mdx
@@ -6,7 +6,7 @@ author:
     url: 'https://slack.scaleway.com'
 date: 2024-11-28
 category: ai-data
-product: managed-inference
+product: generative-apis
 ---
 
 [Llama 3.1 Nemotron 70B](/managed-inference/reference-content/llama-3.1-nemotron-70b-instruct/) and [Molmo 72B](/managed-inference/reference-content/molmo-72b-0924) are available for deployment on Managed Inference.

--- a/changelog/october2024/2024-10-25-managed-inference-added-support-for-function-calling.mdx
+++ b/changelog/october2024/2024-10-25-managed-inference-added-support-for-function-calling.mdx
@@ -6,7 +6,7 @@ author:
     url: 'https://slack.scaleway.com'
 date: 2024-10-25
 category: ai-data
-product: managed-inference
+product: generative-apis
 ---
 
 Function calling allows a large language model (LLM) to interact with external tools or APIs. 

--- a/changelog/october2024/2024-10-30-managed-inference-added-terraform-support.mdx
+++ b/changelog/october2024/2024-10-30-managed-inference-added-terraform-support.mdx
@@ -6,7 +6,7 @@ author:
     url: 'https://slack.scaleway.com'
 date: 2024-10-30
 category: ai-data
-product: managed-inference
+product: generative-apis
 ---
 
 Managed Inference deployments can be created and managed with Infrastructure as Code using Scaleway's Terraform provider. 

--- a/changelog/september2024/2024-09-05-managed-inference-added-model-library-expanded.mdx
+++ b/changelog/september2024/2024-09-05-managed-inference-added-model-library-expanded.mdx
@@ -6,7 +6,7 @@ author:
     url: 'https://slack.scaleway.com'
 date: 2024-09-05
 category: ai-data
-product: managed-inference
+product: generative-apis
 ---
 
 [Meta Llama 3.1 8b](/managed-inference/reference-content/model-catalog/#llama-31-8b-instruct), [Meta Llama 3.1 70b](/managed-inference/reference-content/model-catalog/llama-31-70b-instruct) and [Mistral Nemo](/managed-inference/reference-content/model-catalog/#mistral-nemo-instruct-2407) are available for deployment on Managed Inference. 

--- a/changelog/september2024/2024-09-18-managed-inference-added-json-mode-and-structured-output.mdx
+++ b/changelog/september2024/2024-09-18-managed-inference-added-json-mode-and-structured-output.mdx
@@ -6,7 +6,7 @@ author:
     url: 'https://slack.scaleway.com'
 date: 2024-09-18
 category: ai-data
-product: managed-inference
+product: generative-apis
 ---
 
 All AI models can now reliably generate JSON output when required. The [Chat Completions API](https://www.scaleway.com/en/docs/managed-inference/reference-content/openai-compatibility/#supported-parameters) supports the `response_format` parameter, which can be set to either `json_object` or `json_schema`, following OpenAI's specifications exactly. 

--- a/changelog/september2024/2024-09-25-managed-inference-added-analyze-images-with-mistrals-vi.mdx
+++ b/changelog/september2024/2024-09-25-managed-inference-added-analyze-images-with-mistrals-vi.mdx
@@ -6,7 +6,7 @@ author:
     url: 'https://slack.scaleway.com'
 date: 2024-09-25
 category: ai-data
-product: managed-inference
+product: generative-apis
 ---
 
 You can now deploy your own secure `Pixtral-12b-2409` model with Scaleway Managed Inference. 

--- a/changelog/september2024/2024-09-30-managed-inference-changed-public-endpoints-have-moved-t.mdx
+++ b/changelog/september2024/2024-09-30-managed-inference-changed-public-endpoints-have-moved-t.mdx
@@ -6,7 +6,7 @@ author:
     url: 'https://slack.scaleway.com'
 date: 2024-09-30
 category: ai-data
-product: managed-inference
+product: generative-apis
 ---
 
 All new public endpoints for Managed Inference deployments will be using the `scaleway.com` domain.

--- a/changelog/september2025/2025-09-17-managed-inference-added-new-sxm-node-types-available.mdx
+++ b/changelog/september2025/2025-09-17-managed-inference-added-new-sxm-node-types-available.mdx
@@ -3,7 +3,7 @@ title: New SXM node types available
 status: added
 date: 2025-09-17
 category: ai-data
-product: managed-inference
+product: generative-apis
 ---
 
 **H100-SXM-2**, **H100-SXM-4** and **H100-SXM-8** nodes are now available in Managed Inference.


### PR DESCRIPTION
As part of merging the 2 doc sets for the AI product, we're moving "Managed Inference" changelogs under "Generative APIs"
