### PR TITLE
fix(dedibox): escape wildcard char

### DIFF
--- a/pages/dedibox-kvm-over-ip/how-to/hp-ilo.mdx
+++ b/pages/dedibox-kvm-over-ip/how-to/hp-ilo.mdx
@@ -41,7 +41,7 @@ The connection URL and your credentials display. Click on the link to access the
     <Message type="tip">
       Depending on the model of your dedicated server, iLO may propose either an **HTML5-based** KVM-over-IP interface or a **Java-based** one. Make sure to have [Java installed](https://www.java.com/en/download/help/download_options.html) on your local computer if you want to use this version.
     </Message>
-3. Click the **Disc icon** > **CD/DVD** > **Local *.iso file** and select the local installation image of your operating system.
+3. Click the **Disc icon** > **CD/DVD** > **Local \*.iso file** and select the local installation image of your operating system.
     <Message type="tip">
       You can also use one of the ISO files available on our [NAS](https://virtualmedia.online.net/) by clicking **Scripted Media URL**.
     </Message>


### PR DESCRIPTION
The wildcard of `*.iso` needs to be escaped; it isn’t Markdown syntax.