### PR TITLE
feat(changelog): dedibox-added-ubuntu-2604-lts-available 2026-05-29

### DIFF
--- a/changelog/may2026/2026-05-29-dedibox-added-ubuntu-2604-lts-available.mdx
+++ b/changelog/may2026/2026-05-29-dedibox-added-ubuntu-2604-lts-available.mdx
@@ -1,0 +1,10 @@
+---
+title: Ubuntu 26.04 LTS available
+status: added
+date: 2026-05-29
+category: bare-metal
+product: dedibox
+---
+
+You can now deploy Ubuntu 26.04 LTS (Resolute Raccoon) on compatible Dedibox dedicated servers.
+

--- a/changelog/may2026/2026-05-29-dedibox-added-ubuntu-2604-lts-available.mdx
+++ b/changelog/may2026/2026-05-29-dedibox-added-ubuntu-2604-lts-available.mdx
@@ -1,5 +1,5 @@
 ---
-title: Ubuntu 26.04 LTS available
+title: Ubuntu 26.04 LTS is now available
 status: added
 date: 2026-05-29
 category: bare-metal
@@ -7,4 +7,3 @@ product: dedibox
 ---
 
 You can now deploy Ubuntu 26.04 LTS (Resolute Raccoon) on compatible Dedibox dedicated servers.
-


### PR DESCRIPTION
Reporter: Léo Sarazin

This PR is a new changelog contribution. It has been created automatically.

Make sure to review it carefully before merging it.