### PR TITLE
feat(changelog): vpc-peering-changed-vpc-transitive-peering-is-now-opt-i 2026-06-23

### DIFF
--- a/changelog/june2026/2026-06-23-vpc-peering-changed-vpc-transitive-peering-is-now-opt-i.mdx
+++ b/changelog/june2026/2026-06-23-vpc-peering-changed-vpc-transitive-peering-is-now-opt-i.mdx
@@ -1,0 +1,10 @@
+---
+title: VPC transitive peering is now opt-in
+status: changed
+date: 2026-06-23
+category: network
+product: vpc-peering
+---
+
+VPC transitive peering is now opt-in; transitivity can only be enabled when creating a VPC, and cannot be changed afterward.
+

--- a/changelog/june2026/2026-06-23-vpc-peering-changed-vpc-transitive-peering-is-now-opt-i.mdx
+++ b/changelog/june2026/2026-06-23-vpc-peering-changed-vpc-transitive-peering-is-now-opt-i.mdx
@@ -6,5 +6,5 @@ category: network
 product: vpc-peering
 ---
 
-Transitive peering for VPCs is now disabled by default, and can be enabled when creating a VPC. Once activated, it cannot be disabled afterward.
+[Transitive peering for VPCs](/vpc-peering/reference-content/understanding-transitive-peering/) is now disabled by default, and can be enabled when creating a VPC. Once activated, it cannot be disabled afterward.
 

--- a/changelog/june2026/2026-06-23-vpc-peering-changed-vpc-transitive-peering-is-now-opt-i.mdx
+++ b/changelog/june2026/2026-06-23-vpc-peering-changed-vpc-transitive-peering-is-now-opt-i.mdx
@@ -1,10 +1,10 @@
 ---
-title: VPC transitive peering is now opt-in
+title: Transitive peering for VPCs is now opt-in
 status: changed
 date: 2026-06-23
 category: network
 product: vpc-peering
 ---
 
-VPC transitive peering is now opt-in; transitivity can only be enabled when creating a VPC, and cannot be changed afterward.
+Transitive peering for VPCs is now disabled by default, and can be enabled when creating a VPC. Once activated, it cannot be disabled afterward.
 


### PR DESCRIPTION
Reporter: Pierre SCACCHI

This PR is a new changelog contribution. It has been created automatically.

Make sure to review it carefully before merging it.