### PR TITLE
docs(s3cmd): upload with mime type

### DIFF
--- a/pages/object-storage/api-cli/managing-lifecycle-cliv2.mdx
+++ b/pages/object-storage/api-cli/managing-lifecycle-cliv2.mdx
@@ -223,6 +223,13 @@ In a terminal, access the folder containing the file you want to upload, then ru
     upload: '/path/to/object/my-object' -> 's3://my-bucket/my-object'  [1 of 1]
     3259 of 3259   100% in    0s     8.47 KB/s  done
     ```
+
+    <Message type="tip">
+By default, s3cmd does not send any mime type, and the object will be stored as `plain text`. Using `--guess-mime-type` and `--no-mime-magic`, you can make your bucket provide the file with the mime type associated to the extension. This example will store my-object-.css with a `text/css` content-type instead of `text/plain`.
+    ```
+    s3cmd --guess-mime-type --no-mime-magic put /path/to/object/my-object.css s3://my-bucket/my-object.css
+    ```
+    </Message>
 </TabsTab>
 <TabsTab label="MinIO Client (mc)">
 In a terminal, access the folder containing the file you want to upload, then run the following command:

--- a/pages/object-storage/api-cli/managing-lifecycle-cliv2.mdx
+++ b/pages/object-storage/api-cli/managing-lifecycle-cliv2.mdx
@@ -225,7 +225,7 @@ In a terminal, access the folder containing the file you want to upload, then ru
     ```
 
     <Message type="tip">
-By default, s3cmd does not send any mime type, and the object will be stored as `plain text`. Using `--guess-mime-type` and `--no-mime-magic`, you can make your bucket provide the file with the mime type associated to the extension. This example will store my-object-.css with a `text/css` content-type instead of `text/plain`.
+Object Storage uses the MIME type sent by s3cmd. If Object Storage is unable to determine the MIME type because the client (in this case s3cmd) has not sent any, then it first tries to infer the correct MIME type from the file extension; and if it cannot find a matching type, it falls back to the default MIME type, which is `binary/octet-stream`.
     ```
     s3cmd --guess-mime-type --no-mime-magic put /path/to/object/my-object.css s3://my-bucket/my-object.css
     ```

--- a/pages/object-storage/api-cli/managing-lifecycle-cliv2.mdx
+++ b/pages/object-storage/api-cli/managing-lifecycle-cliv2.mdx
@@ -226,9 +226,6 @@ In a terminal, access the folder containing the file you want to upload, then ru
 
     <Message type="tip">
 Object Storage uses the MIME type sent by s3cmd. If Object Storage is unable to determine the MIME type because the client (in this case s3cmd) has not sent any, then it first tries to infer the correct MIME type from the file extension; and if it cannot find a matching type, it falls back to the default MIME type, which is `binary/octet-stream`.
-    ```
-    s3cmd --guess-mime-type --no-mime-magic put /path/to/object/my-object.css s3://my-bucket/my-object.css
-    ```
     </Message>
 </TabsTab>
 <TabsTab label="MinIO Client (mc)">

--- a/tutorials/s3cmd/index.mdx
+++ b/tutorials/s3cmd/index.mdx
@@ -146,6 +146,13 @@ Enter the following command to upload files into a bucket. Here, we upload the f
 s3cmd put movie1.avi photo1.jpg s3://mynewbucket
 ```
 
+<Message type="tip">
+By default, s3cmd does not send any mime type, and the object will be stored as `plain text`. Using `--guess-mime-type` and `--no-mime-magic`, you can make your bucket provide the file with the mime type associated to the extension. This example will store my-object-.css with a `text/css` content-type instead of `text/plain`.
+```
+s3cmd --guess-mime-type --no-mime-magic put my-object.css s3://mynewbucket/my-object.css
+```
+</Message>
+
 An output similar to the following displays:
 
 ```bash

--- a/tutorials/s3cmd/index.mdx
+++ b/tutorials/s3cmd/index.mdx
@@ -148,9 +148,6 @@ s3cmd put movie1.avi photo1.jpg s3://mynewbucket
 
 <Message type="tip">
 Object Storage uses the MIME type sent by s3cmd. If Object Storage is unable to determine the MIME type because the client (in this case s3cmd) has not sent any, then it first tries to infer the correct MIME type from the file extension; and if it cannot find a matching type, it falls back to the default MIME type, which is `binary/octet-stream`.
-```
-s3cmd --guess-mime-type --no-mime-magic put my-object.css s3://mynewbucket/my-object.css
-```
 </Message>
 
 An output similar to the following displays:

--- a/tutorials/s3cmd/index.mdx
+++ b/tutorials/s3cmd/index.mdx
@@ -147,7 +147,7 @@ s3cmd put movie1.avi photo1.jpg s3://mynewbucket
 ```
 
 <Message type="tip">
-By default, s3cmd does not send any mime type, and the object will be stored as `plain text`. Using `--guess-mime-type` and `--no-mime-magic`, you can make your bucket provide the file with the mime type associated to the extension. This example will store my-object-.css with a `text/css` content-type instead of `text/plain`.
+Object Storage uses the MIME type sent by s3cmd. If Object Storage is unable to determine the MIME type because the client (in this case s3cmd) has not sent any, then it first tries to infer the correct MIME type from the file extension; and if it cannot find a matching type, it falls back to the default MIME type, which is `binary/octet-stream`.
 ```
 s3cmd --guess-mime-type --no-mime-magic put my-object.css s3://mynewbucket/my-object.css
 ```


### PR DESCRIPTION
### Your checklist for this pull request

- [ x] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

By default, uploading a file with s3cmd result in a file with the mime type "plain text".
If you are using the bucket as a website, it is a problem.

The PR indicates that during the upload, it might be usefull to set the mime type.