### PR TITLE
feat(genapi): add information to glm-5.2 limited context

### DIFF
--- a/pages/generative-apis/reference-content/supported-models.mdx
+++ b/pages/generative-apis/reference-content/supported-models.mdx
@@ -19,9 +19,9 @@ This page provides a quick overview of available models in Scaleway's catalog an
 
 ## Models technical summary
 
-| Model name | Available in Serverless? | Maximum context window (tokens) | Maximum output (tokens) - Serverless | Modalities | License \* |
+| Model name | Available in Serverless? | Maximum context window (tokens) | Maximum output (tokens) - Serverless | Modalities | License\* |
 |------------|--------------|--------------|------------|-----------|-----------|
-| [`glm-5.2`](#glm-52)| Yes | 256k** | 16k | Text, Code | [MIT](https://huggingface.co/zai-org/GLM-5.2/blob/main/LICENSE) |
+| [`glm-5.2`](#glm-52)| Yes | 256k\*\* | 16k | Text, Code | [MIT](https://huggingface.co/zai-org/GLM-5.2/blob/main/LICENSE) |
 | [`gpt-oss-120b`](#gpt-oss-120b)| Yes | 128k | 32k | Text | [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0) |
 | [`gpt-oss-20b`](#gpt-oss-20b) | No | 131k | N/A | Text | [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)  |
 | [`whisper-large-v3`](#whisper-large-v3) | Yes | - | - | Audio transcription | [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0) |
@@ -65,7 +65,8 @@ This page provides a quick overview of available models in Scaleway's catalog an
 | [`minimax-m2.5`](#minimax-m25) | No | 197k | N/A | Code | [MIT](https://choosealicense.com/licenses/mit/) |
 
 \*Licences which are not open-weight and may restrict commercial usage (such as `CC-BY-NC-4.0`), do not apply to usage through Scaleway Products due to existing partnerships between Scaleway and the corresponding providers. Original licences are provided for transparency only.
-\**GLM 5.2 supports 1 million context. During preview stage, the context is limited to 256k to ensure consistent token generation speed.
+
+\*\*GLM 5.2 supports 1 million context. During preview stage, the context is limited to 256k to ensure consistent token generation speed.
 
 ## Model details
 <Message type="note">
@@ -97,6 +98,7 @@ Released in April 2026, Gemma-4-31b-it is a frontier small-sized model to perfor
 | Hugging Face model card | [google/gemma-4-31B-it](https://huggingface.co/google/gemma-4-31B-it) |
 
 \*Some providers recommend enabling reasoning by using additional arguments such as `"chat_template_kwargs": {"enable_thinking": true}`. These fields are not supported on Generative APIs, and we recommend using the `reasoning_effort` property, which is equivalent.
+
 \*\*Maximum context length is only mentioned when an instance's VRAM size limits context length. Otherwise, maximum context length is the one defined by the model.
 
 #### Model name

--- a/pages/generative-apis/reference-content/supported-models.mdx
+++ b/pages/generative-apis/reference-content/supported-models.mdx
@@ -21,7 +21,7 @@ This page provides a quick overview of available models in Scaleway's catalog an
 
 | Model name | Available in Serverless? | Maximum context window (tokens) | Maximum output (tokens) - Serverless | Modalities | License \* |
 |------------|--------------|--------------|------------|-----------|-----------|
-| [`glm-5.2`](#glm-52)| Yes | 256k | 16k | Text, Code | [MIT](https://huggingface.co/zai-org/GLM-5.2/blob/main/LICENSE) |
+| [`glm-5.2`](#glm-52)| Yes | 256k** | 16k | Text, Code | [MIT](https://huggingface.co/zai-org/GLM-5.2/blob/main/LICENSE) |
 | [`gpt-oss-120b`](#gpt-oss-120b)| Yes | 128k | 32k | Text | [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0) |
 | [`gpt-oss-20b`](#gpt-oss-20b) | No | 131k | N/A | Text | [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)  |
 | [`whisper-large-v3`](#whisper-large-v3) | Yes | - | - | Audio transcription | [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0) |
@@ -65,6 +65,7 @@ This page provides a quick overview of available models in Scaleway's catalog an
 | [`minimax-m2.5`](#minimax-m25) | No | 197k | N/A | Code | [MIT](https://choosealicense.com/licenses/mit/) |
 
 \*Licences which are not open-weight and may restrict commercial usage (such as `CC-BY-NC-4.0`), do not apply to usage through Scaleway Products due to existing partnerships between Scaleway and the corresponding providers. Original licences are provided for transparency only.
+\**GLM 5.2 supports 1 million context. During preview stage, the context is limited to 256k to ensure consistent token generation speed.
 
 ## Model details
 <Message type="note">


### PR DESCRIPTION
Updated the maximum context window note for 'glm-5.2' model to clarify its preview limitations.
