### PR TITLE
chore(rabbitmq): clarify endpoint limitations

### DIFF
--- a/pages/rabbitmq/concepts.mdx
+++ b/pages/rabbitmq/concepts.mdx
@@ -37,6 +37,17 @@ An application that receives messages from a RabbitMQ queue.
 
 A property of queues/exchanges that ensures that they survive broker restarts.
 
+## Endpoint
+
+A network access point that allows applications to connect to a RabbitMQ deployment. Cloud Essentials for RabbitMQ supports two types of endpoints:
+
+- **Public endpoint**: Allows access to your deployment over the public internet
+- **Private endpoint**: Allows secure communication with other resources within a Private Network
+
+<Message type="info">
+**Endpoint limitations**: Each Cloud Essentials for RabbitMQ deployment is limited to a maximum of **one public endpoint** and **one private endpoint**. You cannot create multiple endpoints of the same type for a single deployment.
+</Message>
+
 ## Exchange
 
 An Advanced Message Queuing Protocol (AMQP) 0-9-1 entity that receives messages from producers and routes them to zero or more queues based on rules (bindings).

--- a/pages/rabbitmq/how-to/create-rabbitmq-deployment.mdx
+++ b/pages/rabbitmq/how-to/create-rabbitmq-deployment.mdx
@@ -39,7 +39,7 @@ This page explains how to create a RabbitMQ deployment using the Scaleway consol
 
     - Set up public connectivity to access your deployment over the public internet.
 
-    <Message type="info">
+    <Message type="note">
     **Endpoint limitations**: Each Cloud Essentials for RabbitMQ deployment is limited to a maximum of **one public endpoint** and **one private endpoint**. You cannot create multiple endpoints of the same type for a single deployment.
     </Message>
 

--- a/pages/rabbitmq/how-to/create-rabbitmq-deployment.mdx
+++ b/pages/rabbitmq/how-to/create-rabbitmq-deployment.mdx
@@ -39,6 +39,10 @@ This page explains how to create a RabbitMQ deployment using the Scaleway consol
 
     - Set up public connectivity to access your deployment over the public internet.
 
+    <Message type="info">
+    **Endpoint limitations**: Each Cloud Essentials for RabbitMQ deployment is limited to a maximum of **one public endpoint** and **one private endpoint**. You cannot create multiple endpoints of the same type for a single deployment.
+    </Message>
+
 
 9. Create credentials to log in to your RabbitMQ deployment. These credentials will grant `admin` access to the user.
 


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

This pull request addresses the lack of information regarding endpoint limitations for rabbitmq deployments. Specifically, it updates the technical documentation to explicitly state that each deployment is restricted to a maximum of one public endpoint and one private endpoint.
Previously, the documentation did not clearly specify these limits, which led to confusion and integration errors for frontend users. Adding this information ensures users are properly informed during the deployment process.