### PR TITLE
docs(managed-databases): add encryption key size

### DIFF
--- a/pages/managed-databases-for-postgresql-and-mysql/api-cli/setting-up-encryption-at-rest.mdx
+++ b/pages/managed-databases-for-postgresql-and-mysql/api-cli/setting-up-encryption-at-rest.mdx
@@ -7,7 +7,7 @@ dates:
   posted: 2024-12-19
 ---
 
-[Encryption at rest](/managed-databases-for-postgresql-and-mysql/concepts/#encryption-at-rest) allows you to permanently encrypt your database data. The data is encrypted at volume level using [LUKS](https://en.wikipedia.org/wiki/Linux_Unified_Key_Setup). At Scaleway, `aes-xts-plain64` with `sha256` and a 512-bit key size (256 bits × 2 keys for XTS mode) is used for all Database Instances. The management of the encryption key is done by Scaleway.
+[Encryption at rest](/managed-databases-for-postgresql-and-mysql/concepts/#encryption-at-rest) lets you permanently encrypt your database data at the volume level using [LUKS](https://en.wikipedia.org/wiki/Linux_Unified_Key_Setup). All Database Instances at Scaleway use `aes-xts-plain64` with `sha256` and a 512-bit key size (256 bits × 2 keys for XTS mode). Scaleway manages the encryption key on your behalf.
 
 The feature can be activated upon Database Instance creation via the console and the API, or after creation exclusively through the API with the [upgrade endpoint](https://www.scaleway.com/en/developers/api/managed-databases-for-postgresql-and-mysql/#path-database-instances-upgrade-a-database-instance).
 

--- a/pages/managed-databases-for-postgresql-and-mysql/api-cli/setting-up-encryption-at-rest.mdx
+++ b/pages/managed-databases-for-postgresql-and-mysql/api-cli/setting-up-encryption-at-rest.mdx
@@ -7,7 +7,7 @@ dates:
   posted: 2024-12-19
 ---
 
-[Encryption at rest](/managed-databases-for-postgresql-and-mysql/concepts/#encryption-at-rest) allows you to permanently encrypt your database data. The data is encrypted at volume level using [LUKS](https://en.wikipedia.org/wiki/Linux_Unified_Key_Setup). The management of the encryption key is done by Scaleway.
+[Encryption at rest](/managed-databases-for-postgresql-and-mysql/concepts/#encryption-at-rest) allows you to permanently encrypt your database data. The data is encrypted at volume level using [LUKS](https://en.wikipedia.org/wiki/Linux_Unified_Key_Setup). At Scaleway, `aes-xts-plain64` with `sha256` and a 512-bit key size (256 bits × 2 keys for XTS mode) is used for all Database Instances. The management of the encryption key is done by Scaleway.
 
 The feature can be activated upon Database Instance creation via the console and the API, or after creation exclusively through the API with the [upgrade endpoint](https://www.scaleway.com/en/developers/api/managed-databases-for-postgresql-and-mysql/#path-database-instances-upgrade-a-database-instance).
 

--- a/pages/managed-databases-for-postgresql-and-mysql/concepts.mdx
+++ b/pages/managed-databases-for-postgresql-and-mysql/concepts.mdx
@@ -48,7 +48,7 @@ Refer to the [How to manage snapshots](/managed-databases-for-postgresql-and-mys
 Once activated on a Database Instance, encryption at rest cannot be disabled.
 </Message>
 
-Encryption at rest allows you to permanently encrypt your database data. The data is encrypted at volume level using [LUKS](https://en.wikipedia.org/wiki/Linux_Unified_Key_Setup). At Scaleway, `aes-xts-plain64` with `sha256` and a 512-bit key size (256 bits × 2 keys for XTS mode) is used for all Database Instances. The management of the encryption key is done by Scaleway.
+[Encryption at rest](/managed-databases-for-postgresql-and-mysql/concepts/#encryption-at-rest) lets you permanently encrypt your database data at the volume level using [LUKS](https://en.wikipedia.org/wiki/Linux_Unified_Key_Setup). All Database Instances at Scaleway use `aes-xts-plain64` with `sha256` and a 512-bit key size (256 bits × 2 keys for XTS mode). Scaleway manages the encryption key on your behalf.
 
 All databases, data (including logs), and snapshots will be encrypted. Logical backup encryption is not currently available.
 

--- a/pages/managed-databases-for-postgresql-and-mysql/concepts.mdx
+++ b/pages/managed-databases-for-postgresql-and-mysql/concepts.mdx
@@ -48,7 +48,7 @@ Refer to the [How to manage snapshots](/managed-databases-for-postgresql-and-mys
 Once activated on a Database Instance, encryption at rest cannot be disabled.
 </Message>
 
-Encryption at rest allows you to permanently encrypt your database data. The data is encrypted at volume level using [LUKS](https://en.wikipedia.org/wiki/Linux_Unified_Key_Setup). At Scaleway `aes-xts-plain64` is used as the default. The management of the encryption key is done by Scaleway.
+Encryption at rest allows you to permanently encrypt your database data. The data is encrypted at volume level using [LUKS](https://en.wikipedia.org/wiki/Linux_Unified_Key_Setup). At Scaleway, `aes-xts-plain64` with `sha256` and a 512-bit key size (256 bits × 2 keys for XTS mode) is used for all Database Instances. The management of the encryption key is done by Scaleway.
 
 All databases, data (including logs), and snapshots will be encrypted. Logical backup encryption is not currently available.
 


### PR DESCRIPTION
## Summary

- Add the documented LUKS cipher hash and key size for Managed Databases encryption at rest.
- Apply the same wording to the concepts page and API setup guide.

## Context

Scaleway Support confirmed that Managed Databases disk encryption uses `aes-xts-plain64` with `sha256` and a 512-bit key size (256 bits × 2 keys for XTS mode), and that this applies to all Database Instances.

## Checks

- `git diff --check`