### PR TITLE
docs(cockpit): fix go binary URL for download

### DIFF
--- a/tutorials/pushing-metrics-logs-from-scw-instance/index.mdx
+++ b/tutorials/pushing-metrics-logs-from-scw-instance/index.mdx
@@ -84,7 +84,7 @@ The only file we will be editing in this tutorial is the `agent.yaml` file to ad
 5. Install [Golang](https://go.dev/) on your Instance using the following commands:
 
             ```bash
-            wget https://github.com/grafana/agent/releases/download/v0.34.3/grafana-agent-0.34.3-1.amd64.deb
+            wget https://go.dev/dl/go1.20.linux-amd64.tar.gz
             sudo tar -C /usr/local/ -xzf go1.20.linux-amd64.tar.gz
             ```
 6. Run the following command to set Golang in your environment:


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

The file downloaded with wget (grafana-agent) did not correspond to the expected filename in the line below (the go binary). I suppose it was a bad copy/paste

