### PR TITLE
feat(genapi): add iam conditions for network restrictions

### DIFF
--- a/pages/generative-apis/faq.mdx
+++ b/pages/generative-apis/faq.mdx
@@ -285,7 +285,7 @@ You can find detailed information regarding the policies applied to Scaleway's A
 - [Security and Reliability in Generative APIs](/generative-apis/reference-content/security-and-reliability/)
 
 ### How can I secure network access to Generative APIs?
-**Serverless**: Request to Serverless models must be made through Internet. Restricting traffic to private endpoint within a VPC is not yet possible.
+**Serverless**: Request to Serverless models must be made through the internet. Restricting traffic to a private endpoint within a VPC is not yet possible.
 However, you can use Scaleway [IAM policy conditions](/iam/reference-content/understanding-policy-conditions/) to define granular access rules using Common Expression Language (CEL).
 For instance, you can ensure Generative APIs is only reachable from a specific office network or a trusted proxy, using the `inIpRange()` function.
 

--- a/pages/generative-apis/faq.mdx
+++ b/pages/generative-apis/faq.mdx
@@ -298,7 +298,7 @@ inIpRange(request.ip, "198.51.100.0/24")
 Result: Only requests originating from the `198.51.100.0/24` subnet are authorized.
 
 Note that IAM conditions are:
-* **Policy-based**: A condition only restricts the specific IAM policy it is attached to. For network restrictions to be fully effective, ensure each policies providing Generative APIs access rights also include an IAM condition restricting network access.
+* **Policy-based**: A condition only restricts the specific IAM policy it is attached to. For network restrictions to be fully effective, ensure each policy providing Generative APIs access rights also includes an IAM condition restricting network access.
 * **Owner exception**: Users with [Owner status](/iam/concepts/#owner) possess full administrative rights through global organization policies. Even if your custom policies include IP restrictions, an API key belonging to an Owner can still call Generative APIs from any IP address.
 
 **Dedicated Deployments**: A Dedicated Deployment can be configured to run in a specific Private Network within a VPC. You can additionnaly remove any Public Endpoints access to ensure your Deployment is not accessible from Internet.

--- a/pages/generative-apis/faq.mdx
+++ b/pages/generative-apis/faq.mdx
@@ -283,3 +283,22 @@ You can find detailed information regarding the policies applied to Scaleway's A
 
 - [Understand the Generative APIs Privacy Policy](/generative-apis/reference-content/data-privacy/)
 - [Security and Reliability in Generative APIs](/generative-apis/reference-content/security-and-reliability/)
+
+### How can I secure network access to Generative APIs?
+**Serverless**: Request to Serverless models must be made through Internet. Restricting traffic to private endpoint within a VPC is not yet possible.
+However, you can use Scaleway [IAM policy conditions](/iam/reference-content/understanding-policy-conditions/) to define granular access rules using Common Expression Language (CEL).
+For instance, you can ensure Generative APIs is only reachable from a specific office network or a trusted proxy, using the `inIpRange()` function.
+
+Example expression:
+
+```cel
+inIpRange(request.ip, "198.51.100.0/24")
+```
+
+Result: Only requests originating from the `198.51.100.0/24` subnet are authorized.
+
+Note that IAM conditions are:
+* **Policy-based**: A condition only restricts the specific IAM policy it is attached to. For network restrictions to be fully effective, ensure each policies providing Generative APIs access rights also include an IAM condition restricting network access.
+* **Owner exception**: Users with [Owner status](/iam/concepts/#owner) possess full administrative rights through global organization policies. Even if your custom policies include IP restrictions, an API key belonging to an Owner can still call Generative APIs from any IP address.
+
+**Dedicated Deployments**: A Dedicated Deployment can be configured to run in a specific Private Network within a VPC. You can additionnaly remove any Public Endpoints access to ensure your Deployment is not accessible from Internet.

--- a/pages/generative-apis/faq.mdx
+++ b/pages/generative-apis/faq.mdx
@@ -301,4 +301,4 @@ Note that IAM conditions are:
 * **Policy-based**: A condition only restricts the specific IAM policy it is attached to. For network restrictions to be fully effective, ensure each policy providing Generative APIs access rights also includes an IAM condition restricting network access.
 * **Owner exception**: Users with [Owner status](/iam/concepts/#owner) possess full administrative rights through global organization policies. Even if your custom policies include IP restrictions, an API key belonging to an Owner can still call Generative APIs from any IP address.
 
-**Dedicated Deployments**: A Dedicated Deployment can be configured to run in a specific Private Network within a VPC. You can additionnaly remove any Public Endpoints access to ensure your Deployment is not accessible from Internet.
+**Dedicated Deployments**: A Dedicated Deployment can be configured to run in a specific Private Network within a VPC. You can additionally remove any public endpoint's access to ensure your Deployment is not accessible from the internet.


### PR DESCRIPTION
Added a section on securing network access to Generative APIs, detailing IAM policy conditions and examples. Content is based on Serverless Containers existing description: https://www.scaleway.com/en/docs/serverless-containers/how-to/secure-a-container/#advanced-access-control-with-iam-conditions
