### PR TITLE
fix(iam) use correct case for the startWith() function

### DIFF
--- a/pages/iam/reference-content/supported-products-resource-level.mdx
+++ b/pages/iam/reference-content/supported-products-resource-level.mdx
@@ -15,4 +15,4 @@ The following table provides details about the Scaleway products that are integr
 |---------------------|--------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
 | IAM                 | **Integrated**                              | Access per user, policy, application, group, SSH key, or API key. Global product. |
 | Key Manager         | **Integrated**                              | Access per key (not per key version). Regional product. |
-| Secret Manager      | **Integrated**                              | Access per secret (not per secret version). Regional product. Example use case: restricting access to a secret folder using `resource.name.startswith("/folder/")`. |
+| Secret Manager      | **Integrated**                              | Access per secret (not per secret version). Regional product. Example use case: restricting access to a secret folder using `resource.name.startsWith("/folder/")`. |

--- a/pages/iam/reference-content/understanding-resource-level-conditions.mdx
+++ b/pages/iam/reference-content/understanding-resource-level-conditions.mdx
@@ -54,10 +54,10 @@ The Scaleway console and API only validate the **syntax** of a condition express
   This example applies to Secret Manager specifically — other integrated products may not have an equivalent notion of folders.
 </Message>
 
-To grant access only to resources within a given folder, you can use the `startswith()` function on `resource.name`:
+To grant access only to resources within a given folder, you can use the `startsWith()` function on `resource.name`:
 
 ```
-resource.name.startswith("/folder/")
+resource.name.startsWith("/folder/")
 ```
 
 This expression matches `/folder/secret1` and `/folder/subfolder/secret2`, but not `/secret3`.
@@ -103,7 +103,7 @@ By default, adding a resource-level condition to a rule breaks **listing** actio
 For example, to preserve listing behavior alongside the folder example above:
 
 ```
-resource.name.startswith("/folder/") || !has(resource.id)
+resource.name.startsWith("/folder/") || !has(resource.id)
 ```
 
 More generally, resource-level conditions can affect console behavior in ways beyond listing actions. We recommend testing your conditions carefully after applying them, to confirm they behave as expected.


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

The function is named `startsWith` with a uppercase W, and it does not work when used in lowercase.
