### PR TITLE
docs(guidelines): refine terminology

### DIFF
--- a/pages/guidelines.mdx
+++ b/pages/guidelines.mdx
@@ -108,7 +108,7 @@ Scaleway Documentation pages should conform to the following structure:
 | [Metadata](#metadata)           | At the top of the page, used for indexing, search and the generation of the page title (H1). The `dates` section is crucial for tracking and displaying when pages were first created and last updated. |
 | [Introduction](#introduction)       | A few sentences (or short paragraphs), that briefly explain the purpose of the documentation and give any necessary preliminary information. This will be displayed in search results for the page in Scaleway's internal search engine. |
 | [Requirements](#requirements)       | Bullet points stating what the user must already have accomplished before starting any instructions on this documentation page. Necessary for How tos, Quickstarts and Tutorials. May not be relevant for other page types, e.g. FAQ, Concepts. |
-| Page body       | The content depends on the [page type](#page-types). Split long pages into subsections with [headers](#headers). Always use [numbered lists](#numbered-steps) when explaining steps a user should take. See also [page content](#page-content) |
+| Page body       | The content depends on the [page type](#page-types). Split long pages into subsections with [headings](#headings). Always use [numbered lists](#numbered-steps) when explaining steps a user should take. See also [page content](#page-content) |
 
 If you are creating a new page, it may be easiest to duplicate an existing page and adapt it to your requirements. See the raw files on our GitHub repo for this purpose, for example [this tutorial](https://raw.githubusercontent.com/scaleway/docs-content/main/tutorials/install-openvpn/index.mdx).
 
@@ -116,13 +116,13 @@ More information about the different sections of each page can be found by follo
 
 ## Page content
 
-### Headers
+### Headings
 
 - There can be only one H1 on each page (the page title, defined in the [metadata](#metadata))
 - Use H2s (e.g. `## My subtitle`) to divide the page into subsections, and H3s (e.g. `### My sub-subtitle`) to divide the subsections (if appropriate). You can go up to 5 hierarchy levels (H5). In the right "Jump-to" menu, only H2s and H3s are visible and clickable.
-- Headers also serve as anchors. Link to a header anchor as follows `[text to display](#header-with-spaces-replaced-by-dashes)`
-- No headers should be orphaned. If you begin with H2, go down in sequence. The next step should either be another H2 or a level lower (in this case, H3).
-- All headers should be in [sentence case](https://en.wikipedia.org/wiki/Letter_case#Sentence_case). Product names should nonetheless be capitalized as appropriate.
+- Headings also serve as anchors. Link to a heading anchor as follows `[text to display](#heading-with-spaces-replaced-by-dashes)`
+- No heading should be orphaned. If you begin with H2, go down in sequence. The next step should either be another H2 or a level lower (in this case, H3).
+- All headings should be in [sentence case](https://en.wikipedia.org/wiki/Letter_case#Sentence_case). Product names should nonetheless be capitalized as appropriate.
 
 ### Numbered steps
 
@@ -337,7 +337,7 @@ Always capitalize Scaleway product names (e.g. Instance, Load Balancer, Kubernet
 
 Do not capitalize names of product features (e.g. security group, bucket, snapshot), **unless** the feature name is a created word or phrase with a meaning specific to Scaleway, (e.g. InstantApp, Easy Deploy).
 
-Titles and headers should be written in sentence case.
+Titles and headings should be written in sentence case.
 
 ### Bold text
 


### PR DESCRIPTION
This is a change required for a test. In front-end terminology "heading" is more correct than "header". Our AGENTS.md test doesn't take into account some of our heading rules. Making the terminology more precise might help.
