### PR TITLE
feat(apple-silicon): Added kernel extensions in console MTA-7329

### DIFF
--- a/pages/apple-silicon/api-cli/create-server-kexts-enabled-via-api.mdx
+++ b/pages/apple-silicon/api-cli/create-server-kexts-enabled-via-api.mdx
@@ -36,7 +36,7 @@ Kernel extensions are low-level components that extend macOS capabilities at the
     ```bash
     POST https://api.scaleway.com/apple-silicon/v1alpha1/zones/{zone}/servers
     ```
-    Replace `{zone}` with your desired Availability Zone (, `fr-par-3`). 
+    Replace `{zone}` with your desired Availability Zone (e.g., `fr-par-3`). 
 
     **Example Request (cURL)**
     ```bash

--- a/pages/apple-silicon/api-cli/create-server-kexts-enabled-via-api.mdx
+++ b/pages/apple-silicon/api-cli/create-server-kexts-enabled-via-api.mdx
@@ -8,8 +8,8 @@ dates:
 ---
 import Requirements from '@macros/iam/requirements.mdx'
 
-Some workloads on Apple Silicon servers require kernel extensions (`kexts`), for example, when using MacFUSE.  
-Kernel extensions are low-level components that extend macOS capabilities at the kernel level. On Scaleway Apple Silicon servers, kernel extensions are disabled by default for security and stability reasons. However, you can enable them when creating a server via the API by setting the `enable_kext` parameter.
+Some workloads on Apple silicon servers require kernel extensions (`kexts`), for example, when using macFUSE.  
+Kernel extensions are low-level components that extend macOS capabilities at the kernel level. On Scaleway Apple silicon servers, kernel extensions are disabled by default for security and stability reasons. However, you can enable them when creating a server via the API by setting the `enable_kext` parameter.
 
 <Message type="important">
   Enabling kernel extensions may affect system stability and security. Only enable this option if required for your use case (e.g., development, testing, or debugging kexts).
@@ -31,12 +31,12 @@ Kernel extensions are low-level components that extend macOS capabilities at the
     export SCW_SECRET_KEY="<YOUR_API_SECRET_KEY>"
     ```
 
-2. Create an Apple Silicon server using the [API](https://www.scaleway.com/en/developers/api/apple-silicon/#path-servers-create-a-server). Set the `enable_kext` parameter to `true`.
+2. Create an Apple silicon server using the [API](https://www.scaleway.com/en/developers/api/apple-silicon/#path-servers-create-a-server). Set the `enable_kext` parameter to `true`.
     **API Endpoint:**
     ```bash
     POST https://api.scaleway.com/apple-silicon/v1alpha1/zones/{zone}/servers
     ```
-    Replace `{zone}` with your desired Availability Zone (e.g. `fr-par-3`). 
+    Replace `{zone}` with your desired Availability Zone (, `fr-par-3`). 
 
     **Example Request (cURL)**
     ```bash
@@ -58,11 +58,11 @@ Kernel extensions are low-level components that extend macOS capabilities at the
     | ------------- | ------- | ------------------------------------------------- |
     | `name`        | string  | Server name (optional, you can generate one)      |
     | `project_id`  | string  | Your Scaleway Project ID                          |
-    | `type`        | string  | Server type (e.g. `M2-M`, `M2-L`, `M1-M`)         |
+    | `type`        | string  | Server type (e.g., `M2-M`, `M2-L`, `M1-M`)         |
     | `enable_kext` | boolean | Enables kernel extension capability on the server |
 
     <Message type="tip">
-        Alternatively, you can create the server also using the [Scaleway CLI](https://cli.scaleway.com/apple-silicon/#create-a-server):
+        Alternatively, you can also create the server using the [Scaleway CLI](https://cli.scaleway.com/apple-silicon/#create-a-server):
         ```bash
         scw apple-silicon server create \
         name=mac-server-with-kext \
@@ -80,7 +80,7 @@ Kernel extensions are low-level components that extend macOS capabilities at the
     </Message>
 
 
-On success, the API returns a JSON with server details, including:
+On success, the API returns a JSON object with server details, including:
 
 - `id` — server UUID
 - `type` — chosen hardware
@@ -89,13 +89,13 @@ On success, the API returns a JSON with server details, including:
 - Credentials (`ssh_username`, `sudo_password`)
 - Status and creation timestamps
 
-## Installing MacFUSE
+## Installing macFUSE
 
-Once your server is running with kernel extensions enabled, you can install MacFUSE.
-MacFUSE adds support for FUSE file systems to macOS, which run in user space and are safer and easier to develop than conventional file systems.
+Once your server is running with kernel extensions enabled, you can install macFUSE.
+macFUSE adds support for FUSE file systems to macOS. These run in user space and are safer and easier to develop than conventional file systems.
 
-1. Connect to your Apple Silicon server [using Remote Desktop](/apple-silicon/how-to/access-remote-desktop-mac-mini/).
-2. Open Safari (or another browser) and download MacFUSE from [https://macfuse.github.io/](https://macfuse.github.io/).
+1. Connect to your Apple silicon server [using Remote Desktop](/apple-silicon/how-to/access-remote-desktop-mac-mini/).
+2. Open Safari (or another browser) and download macFUSE from [https://macfuse.github.io/](https://macfuse.github.io/).
 3. Run the installer.
 4. After installation, open **System Settings → Security & Privacy**. You should see an **Allow** button.
 5. Click **Allow**, then restart your server.

--- a/pages/apple-silicon/how-to/create-mac-mini.mdx
+++ b/pages/apple-silicon/how-to/create-mac-mini.mdx
@@ -1,9 +1,9 @@
 ---
 title: How to create a Mac mini
 description: This page explains how to create a Mac mini
-tags: mac-mini mac-mini apple-silicon
+tags: mac-mini apple-silicon
 dates:
-  validation: 2025-02-18
+  validation: 2026-07-24
   posted: 2021-05-26
 ---
 import Requirements from '@macros/iam/requirements.mdx'
@@ -21,12 +21,12 @@ This page shows how to create your first [Mac mini](/apple-silicon/concepts/#mac
   Due to license constraints, the minimum lease for Apple silicon is 24 hours. As a result, the earliest you can delete a Mac mini is 24 hours after the start of its lease.
 </Message>
 
-1. Click [Apple silicon](https://console.scaleway.com/asaas/servers) in the **Bare Metal** section of the side menu. The [Apple silicon creation page](https://console.scaleway.com/asaas/servers) displays.
+1. In the **Bare Metal** section of the side menu, click [Apple silicon](https://console.scaleway.com/asaas/servers). The Apple silicon creation page opens.
     <Message type="note">
-      Should your account already contain Mac minis, a list of these will be displayed rather than the Apple silicon creation page.
-      Alongside, you will see a (+ Create Mac mini) button, which you can click to create a new Mac mini.
+      If your account already contains Mac minis, they appear in a list.
+      There, you can click the **Create Mac mini** button to create a new Mac mini.
     </Message>
-2. Click **Create Mac mini**. The Mac mini creation wizard displays.
+2. Click **Create Mac mini**. The Mac mini creation wizard opens.
 3. Complete the following steps in the wizard:
     - Choose the **Standard** setup type for your Mac mini.
     - Choose an **Availability Zone**, which is the geographical region where your Mac mini will be deployed. The available Mac mini configurations depend on the Availability Zone:
@@ -36,9 +36,10 @@ This page shows how to create your first [Mac mini](/apple-silicon/concepts/#mac
       - If you choose a macOS version different from the default one, expect a delay of approximately 1 hour before the Mac mini becomes available. 
       - On Mac mini M2 Pro machines, you can also choose Asahi Linux as an alternative to macOS.
       - Optionally, configure the available public bandwidth for your server. This option may not be available for all offers.
-    - Choose whether to activate the **Private Networks 1 Gbps** feature. This lets you attach your Mac mini to one or more Scaleway Private Networks in a [VPC](/vpc/), enabling secure communication with other attached resources.
     - Enter a **Name** for your Mac mini, or leave the randomly-generated name in place.
-    - Verify the **Estimated cost** for your Mac mini based on your chosen specifications.
+    - Choose whether to activate the **Private Networks 1 Gbps** feature. This lets you attach your Mac mini to one or more Scaleway Private Networks in a [VPC](/vpc/), enabling secure communication with other attached resources.
+    - Choose whether to activate the **Kernel extensions** to support tools like macFUSE, allowing you to mount remote storage directly in Finder. This option can only be enabled at installation or reinstallation. For more details, see [Creating a server with kernel extensions enabled via API](/apple-silicon/api-cli/create-server-kexts-enabled-via-api/).
+    - In the **Summary** section, check the **Estimated cost** for your Mac mini based on your chosen specifications.
     - Select the commitment plan for your Mac mini. Two options are available:
       - **No commitment:** You can terminate the subscription of your Mac mini at any time after the initial 24 hours, a mandatory period required by Apple's software license. [Learn more about Apple's software license requirements (Section 3.A)](https://www.apple.com/legal/sla/docs/macOSSequoia.pdf).
       - **Commitment:** You subscribe to a [commitment plan for Apple silicon](/apple-silicon/concepts/#commitment-plan) and benefit from a discounted monthly price based on your choice.


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

- Kernel extensions can now be enabled from the console when creating a Mac mini, in addition to the API method.
- Fixed typos and aligned with most recent guidelines
