### PR TITLE
fix(genapis): add intro to clarify product

### DIFF
--- a/pages/generative-apis/how-to/create-deployment.mdx
+++ b/pages/generative-apis/how-to/create-deployment.mdx
@@ -8,7 +8,9 @@ dates:
 ---
 import Requirements from '@macros/iam/requirements.mdx'
 
-Generative APIs - Dedicated Deployment is a fully managed service that lets you deploy, run, and scale AI models in a *dedicated* environment, offering predictable throughput and enhanced security features such as private network isolation and access control. Unlike the [Serverless offering](/generative-apis/faq/#what-is-the-difference-between-serverless-and-dedicated-deployment), which gives you access to pre‑configured model endpoints, Dedicated Deployment requires you to create a deployment, allowing you to customize configuration options such as quantization, instance size, etc. This page walks you through the steps to create that deployment.
+Generative APIs – Dedicated Deployment is a fully managed service for deploying and running AI models in a private, dedicated environment. Unlike the pre-configured endpoints of the Serverless offering, Dedicated Deployment requires you to create a deployment, letting you customize settings such as quantization and instance size. This page walks you through the steps to create that deployment.
+
+For information on the differences between Serverless and Dedicated Deployment, see the [Generative APIs FAQ](/generative-apis/faq/).
 
 <Requirements />
 

--- a/pages/generative-apis/how-to/create-deployment.mdx
+++ b/pages/generative-apis/how-to/create-deployment.mdx
@@ -8,6 +8,7 @@ dates:
 ---
 import Requirements from '@macros/iam/requirements.mdx'
 
+Generative APIs - Dedicated Deployment is a fully managed service that lets you deploy, run, and scale AI models in a *dedicated* environment, offering predictable throughput and enhanced security features such as private network isolation and access control. Unlike the [Serverless offering](/generative-apis/faq/#what-is-the-difference-between-serverless-and-dedicated-deployment), which gives you access to pre‑configured model endpoints, Dedicated Deployment requires you to create a deployment, allowing you to customize configuration options such as quantization, instance size, etc. This page walks you through the steps to create that deployment.
 
 <Requirements />
 
@@ -31,7 +32,7 @@ import Requirements from '@macros/iam/requirements.mdx'
       <Message type="tip">
         Each model comes with a default quantization. Select lower bits quantization to improve performance and enable the model to run on smaller GPU nodes, while potentially reducing precision.
       </Message>
-    - Select a node type, the GPU Instance that will be used with your deployment.
+    - Select a node type, i.e., the GPU Instance that will be used with your deployment.
     - Choose the number of nodes for your deployment. Note that this feature is currently in [Public Beta](https://www.scaleway.com/en/betas/).
       <Message type="tip">
         High availability is only guaranteed with two or more nodes.

--- a/pages/generative-apis/how-to/create-deployment.mdx
+++ b/pages/generative-apis/how-to/create-deployment.mdx
@@ -34,7 +34,7 @@ For information on the differences between Serverless and Dedicated Deployment, 
       <Message type="tip">
         Each model comes with a default quantization. Select lower bits quantization to improve performance and enable the model to run on smaller GPU nodes, while potentially reducing precision.
       </Message>
-    - Select a node type, i.e., the GPU Instance that will be used with your deployment.
+    - Select a node type, that is, the GPU Instance that will be used with your deployment.
     - Choose the number of nodes for your deployment. Note that this feature is currently in [Public Beta](https://www.scaleway.com/en/betas/).
       <Message type="tip">
         High availability is only guaranteed with two or more nodes.

--- a/pages/generative-apis/how-to/create-deployment.mdx
+++ b/pages/generative-apis/how-to/create-deployment.mdx
@@ -10,7 +10,7 @@ import Requirements from '@macros/iam/requirements.mdx'
 
 Generative APIs – Dedicated Deployment is a fully managed service for deploying and running AI models in a private, dedicated environment. Unlike the pre-configured endpoints of the Serverless offering, Dedicated Deployment requires you to create a deployment, letting you customize settings such as quantization and instance size. This page walks you through the steps to create that deployment.
 
-For information on the differences between Serverless and Dedicated Deployment, see the [Generative APIs FAQ](/generative-apis/faq/).
+To get started using Serverless models, see [How to query language models](/generative-apis/how-to/query-language-models/).
 
 <Requirements />
 


### PR DESCRIPTION
Adding an intro to clarify which "flavor" of the product the page is about. Some user feedback indicates that it may not be clear.
