### PR TITLE
feat(changelog): rabbitmq-added-cloud-essentials-for-rabbitmq-moves-to-g 2026-08-04

### DIFF
--- a/changelog/august2026/2026-08-04-rabbitmq-added-cloud-essentials-for-rabbitmq-moves-to-g.mdx
+++ b/changelog/august2026/2026-08-04-rabbitmq-added-cloud-essentials-for-rabbitmq-moves-to-g.mdx
@@ -1,0 +1,10 @@
+---
+title: Cloud Essentials for RabbitMQ moves to General Availability!
+status: added
+date: 2026-08-04
+category: integration-services
+product: rabbitmq
+---
+
+Cloud Essentials for RabbitMQ moves to General Availability!
+

--- a/changelog/august2026/2026-08-04-rabbitmq-added-cloud-essentials-for-rabbitmq-moves-to-g.mdx
+++ b/changelog/august2026/2026-08-04-rabbitmq-added-cloud-essentials-for-rabbitmq-moves-to-g.mdx
@@ -6,5 +6,5 @@ category: integration-services
 product: rabbitmq
 ---
 
-Cloud Essentials for RabbitMQ moves to General Availability!
+[Cloud Essentials for RabbitMQ](/rabbitmq/) is now in General Availability.
 

--- a/changelog/august2026/2026-08-04-rabbitmq-added-cloud-essentials-for-rabbitmq-moves-to-g.mdx
+++ b/changelog/august2026/2026-08-04-rabbitmq-added-cloud-essentials-for-rabbitmq-moves-to-g.mdx
@@ -1,5 +1,5 @@
 ---
-title: Cloud Essentials for RabbitMQ moves to General Availability!
+title: Cloud Essentials for RabbitMQ moves to General Availability
 status: added
 date: 2026-08-04
 category: integration-services


### PR DESCRIPTION
Reporter: Clement Ratier

This PR is a new changelog contribution. It has been created automatically.

Make sure to review it carefully before merging it.