### PR TITLE
fix(instance): ssh-keys are updated upon boot

### DIFF
--- a/pages/organizations-and-projects/how-to/create-ssh-key.mdx
+++ b/pages/organizations-and-projects/how-to/create-ssh-key.mdx
@@ -160,7 +160,7 @@ You must upload the content of the public part of the SSH key pair you just gene
 
 3. Enter a name for your SSH key, paste the content of the public key copied earlier into the **Public key** box, then click **Add SSH key**.
 
-    You can now [connect to your Instances via SSH](/instances/how-to/connect-to-instance/) after their next boot.
+    You can [connect to your Instances via SSH](/instances/how-to/connect-to-instance/) after their next boot.
 
 ## Troubleshooting
 

--- a/pages/organizations-and-projects/how-to/create-ssh-key.mdx
+++ b/pages/organizations-and-projects/how-to/create-ssh-key.mdx
@@ -160,7 +160,7 @@ You must upload the content of the public part of the SSH key pair you just gene
 
 3. Enter a name for your SSH key, paste the content of the public key copied earlier into the **Public key** box, then click **Add SSH key**.
 
-    You can now [connect to your Instances via SSH](/instances/how-to/connect-to-instance/).
+    You can now [connect to your Instances via SSH](/instances/how-to/connect-to-instance/) after their next boot.
 
 ## Troubleshooting
 


### PR DESCRIPTION
The previous message was invalid for already-running instances.

### Your checklist for this pull request

- [ ] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

ssh-keys are updated upon boot, updating them in the organization has no effect until next boot so ssh-key updating has no immediate effect for already started instances.
