### PR TITLE
feat(object-storage): document Key Manager permissions required for SSE-KMS

### DIFF
--- a/pages/iam/reference-content/permission-sets.mdx
+++ b/pages/iam/reference-content/permission-sets.mdx
@@ -416,6 +416,10 @@ Below is a list of the permission sets available at Scaleway.
 | KeyManagerKeyCreate    | Create permission to key manager       |
 | KeyManagerKeyRestore      | Restore permission to key manager           |
 
+<Message type="note">
+  `KeyManagerKeyEncrypt` and `KeyManagerKeyDecrypt` are also required by principals that never call Key Manager directly: uploading to and downloading from an Object Storage bucket encrypted with [SSE-KMS](/object-storage/how-to/enable-sse-kms/) needs them in addition to the relevant Object Storage permission sets.
+</Message>
+
 ### Labs
 
 #### Quantum

--- a/pages/iam/reference-content/permission-sets.mdx
+++ b/pages/iam/reference-content/permission-sets.mdx
@@ -417,7 +417,7 @@ Below is a list of the permission sets available at Scaleway.
 | KeyManagerKeyRestore      | Restore permission to key manager           |
 
 <Message type="note">
-  `KeyManagerKeyEncrypt` and `KeyManagerKeyDecrypt` are also required by principals that never call Key Manager directly: uploading to and downloading from an Object Storage bucket encrypted with [SSE-KMS](/object-storage/how-to/enable-sse-kms/) needs them in addition to the relevant Object Storage permission sets.
+  `KeyManagerKeyEncrypt` and `KeyManagerKeyDecrypt` are also required for principals that never call Key Manager directly: uploading to and downloading from an Object Storage bucket encrypted with [SSE-KMS](/object-storage/how-to/enable-sse-kms/) requires these permissions in addition to the relevant Object Storage permission sets.
 </Message>
 
 ### Labs

--- a/pages/object-storage/api-cli/enable-sse-kms.mdx
+++ b/pages/object-storage/api-cli/enable-sse-kms.mdx
@@ -30,7 +30,7 @@ In cases when you have some objects that are stored without SSE‑KMS, you can:
     - `KeyManagerKeyDecrypt` for: `GetObject`, `HeadObject`, `CopyObject`, `UploadPartCopy`, and `PostObject`
 
 <Message type="important">
-Object Storage permission sets alone are not sufficient to read and write objects encrypted with SSE-KMS. An [application](/iam/concepts/#application) that has `ObjectStorageFullAccess` and no Key Manager permission set receives an "access denied" error when it calls `PutObject` on a bucket that has default encryption enabled, even when the KEK and the bucket are in the same Project.
+Object Storage permission sets alone are not sufficient to read (`ObjectStorageReadOnly`, `ObjectStorageObjectsRead`) and write (`ObjectStorageObjectsWrite`, `ObjectStorageObjectsDelete`) objects encrypted with SSE-KMS. For example, when an [application](/iam/concepts/#application) has only `ObjectStorageFullAccess` and no Key Manager permission set, it receives an "access denied" error when it calls `PutObject` on a bucket that has default encryption enabled, even when the KEK and the bucket are in the same Project.
 </Message>
 
 ## Enabling SSE-KMS for an object upload

--- a/pages/object-storage/api-cli/enable-sse-kms.mdx
+++ b/pages/object-storage/api-cli/enable-sse-kms.mdx
@@ -28,7 +28,7 @@ In cases when you have some objects that are stored without SSE‑KMS, you can:
 - [Key Manager permission sets](/iam/reference-content/permission-sets/#key-manager) for every [principal](/iam/concepts/#principal) that reads or writes objects in the bucket: `KeyManagerKeyEncrypt` for `PutObject`, and `KeyManagerKeyDecrypt` for `GetObject`
 
 <Message type="important">
-Object Storage permission sets alone are not sufficient to read and write objects encrypted with SSE-KMS. An [application](/iam/concepts/#application) holding `ObjectStorageFullAccess` and no Key Manager permission set gets an access denied error when it calls `PutObject` on a bucket that has default encryption enabled, even when the KEK and the bucket are in the same Project.
+Object Storage permission sets alone are not sufficient to read and write objects encrypted with SSE-KMS. An [application](/iam/concepts/#application) that has `ObjectStorageFullAccess` and no Key Manager permission set receives an "access denied" error when it calls `PutObject` on a bucket that has default encryption enabled, even when the KEK and the bucket are in the same Project.
 </Message>
 
 ## Enabling SSE-KMS for an object upload

--- a/pages/object-storage/api-cli/enable-sse-kms.mdx
+++ b/pages/object-storage/api-cli/enable-sse-kms.mdx
@@ -25,6 +25,11 @@ In cases when you have some objects that are stored without SSE‑KMS, you can:
 - [Owner](/iam/concepts/#owner) status or [IAM permissions](/iam/concepts/#permission) allowing you to perform actions in the intended Organization
 - An [Object Storage bucket](/object-storage/how-to/create-a-bucket/)
 - Installed and initialized the [AWS CLI](/object-storage/api-cli/object-storage-aws-cli/)
+- [Key Manager permission sets](/iam/reference-content/permission-sets/#key-manager) for every [principal](/iam/concepts/#principal) that reads or writes objects in the bucket: `KeyManagerKeyEncrypt` for `PutObject`, and `KeyManagerKeyDecrypt` for `GetObject`
+
+<Message type="important">
+Object Storage permission sets alone are not sufficient to read and write objects encrypted with SSE-KMS. An [application](/iam/concepts/#application) holding `ObjectStorageFullAccess` and no Key Manager permission set gets an access denied error when it calls `PutObject` on a bucket that has default encryption enabled, even when the KEK and the bucket are in the same Project.
+</Message>
 
 ## Enabling SSE-KMS for an object upload
 

--- a/pages/object-storage/api-cli/enable-sse-kms.mdx
+++ b/pages/object-storage/api-cli/enable-sse-kms.mdx
@@ -25,7 +25,9 @@ In cases when you have some objects that are stored without SSE‑KMS, you can:
 - [Owner](/iam/concepts/#owner) status or [IAM permissions](/iam/concepts/#permission) allowing you to perform actions in the intended Organization
 - An [Object Storage bucket](/object-storage/how-to/create-a-bucket/)
 - Installed and initialized the [AWS CLI](/object-storage/api-cli/object-storage-aws-cli/)
-- [Key Manager permission sets](/iam/reference-content/permission-sets/#key-manager) for every [principal](/iam/concepts/#principal) that reads or writes objects in the bucket: `KeyManagerKeyEncrypt` for `PutObject`, and `KeyManagerKeyDecrypt` for `GetObject`
+- [Key Manager permission sets](/iam/reference-content/permission-sets/#key-manager) for every [principal](/iam/concepts/#principal) that reads or writes objects in the bucket: 
+    - `KeyManagerKeyEncrypt` for: `PutObject`, `UploadPart`, `CompleteMultipartUpload`, `CopyObject`, and `UploadPartCopy`
+    - `KeyManagerKeyDecrypt` for: `GetObject`, `HeadObject`, `CopyObject`, `UploadPartCopy`, and `PostObject`
 
 <Message type="important">
 Object Storage permission sets alone are not sufficient to read and write objects encrypted with SSE-KMS. An [application](/iam/concepts/#application) that has `ObjectStorageFullAccess` and no Key Manager permission set receives an "access denied" error when it calls `PutObject` on a bucket that has default encryption enabled, even when the KEK and the bucket are in the same Project.

--- a/pages/object-storage/how-to/enable-sse-kms.mdx
+++ b/pages/object-storage/how-to/enable-sse-kms.mdx
@@ -21,7 +21,7 @@ This page explains how to use SSE-KMS with the Scaleway Console. To use it with 
 - [Key Manager permission sets](/iam/reference-content/permission-sets/#key-manager) for every [principal](/iam/concepts/#principal) that reads or writes objects in the bucket: `KeyManagerKeyEncrypt` to upload or copy objects, and `KeyManagerKeyDecrypt` to download or copy them
 
 <Message type="important">
-Object Storage permission sets alone are not sufficient to read and write objects encrypted with SSE-KMS. A principal that has `ObjectStorageFullAccess` and no Key Manager permission set receives an "access denied" error when it uploads an object to a bucket that has default encryption enabled, even when the KEK and the bucket are in the same Project.
+Object Storage permission sets alone are not sufficient to read (`ObjectStorageReadOnly`, `ObjectStorageObjectsRead`) and write (`ObjectStorageObjectsWrite`, `ObjectStorageObjectsDelete`) objects encrypted with SSE-KMS. For example, when a principal has only `ObjectStorageFullAccess` and no Key Manager permission set, it receives an "access denied" error when it uploads an object to a bucket that has default encryption enabled, even when the KEK and the bucket are in the same Project.
 </Message>
 
 ## How to enable SSE-KMS during bucket creation

--- a/pages/object-storage/how-to/enable-sse-kms.mdx
+++ b/pages/object-storage/how-to/enable-sse-kms.mdx
@@ -18,7 +18,11 @@ This page explains how to use SSE-KMS with the Scaleway Console. To use it with 
 - A Scaleway account logged into the [console](https://console.scaleway.com)
 - [Owner](/iam/concepts/#owner) status or [IAM permissions](/iam/concepts/#permission) allowing you to perform actions in the intended Organization
 - An [Object Storage bucket](/object-storage/how-to/create-a-bucket/) (optional)
+- [Key Manager permission sets](/iam/reference-content/permission-sets/#key-manager) for every [principal](/iam/concepts/#principal) that reads or writes objects in the bucket: `KeyManagerKeyEncrypt` to upload objects, and `KeyManagerKeyDecrypt` to download them
 
+<Message type="important">
+Object Storage permission sets alone are not sufficient to read and write objects encrypted with SSE-KMS. A principal holding `ObjectStorageFullAccess` and no Key Manager permission set gets an access denied error when it uploads an object to a bucket that has default encryption enabled, even when the KEK and the bucket are in the same Project.
+</Message>
 
 ## How to enable SSE-KMS during bucket creation
 

--- a/pages/object-storage/how-to/enable-sse-kms.mdx
+++ b/pages/object-storage/how-to/enable-sse-kms.mdx
@@ -18,7 +18,7 @@ This page explains how to use SSE-KMS with the Scaleway Console. To use it with 
 - A Scaleway account logged into the [console](https://console.scaleway.com)
 - [Owner](/iam/concepts/#owner) status or [IAM permissions](/iam/concepts/#permission) allowing you to perform actions in the intended Organization
 - An [Object Storage bucket](/object-storage/how-to/create-a-bucket/) (optional)
-- [Key Manager permission sets](/iam/reference-content/permission-sets/#key-manager) for every [principal](/iam/concepts/#principal) that reads or writes objects in the bucket: `KeyManagerKeyEncrypt` to upload objects, and `KeyManagerKeyDecrypt` to download them
+- [Key Manager permission sets](/iam/reference-content/permission-sets/#key-manager) for every [principal](/iam/concepts/#principal) that reads or writes objects in the bucket: `KeyManagerKeyEncrypt` to upload or copy objects, and `KeyManagerKeyDecrypt` to download or copy them
 
 <Message type="important">
 Object Storage permission sets alone are not sufficient to read and write objects encrypted with SSE-KMS. A principal that has `ObjectStorageFullAccess` and no Key Manager permission set receives an "access denied" error when it uploads an object to a bucket that has default encryption enabled, even when the KEK and the bucket are in the same Project.

--- a/pages/object-storage/how-to/enable-sse-kms.mdx
+++ b/pages/object-storage/how-to/enable-sse-kms.mdx
@@ -21,7 +21,7 @@ This page explains how to use SSE-KMS with the Scaleway Console. To use it with 
 - [Key Manager permission sets](/iam/reference-content/permission-sets/#key-manager) for every [principal](/iam/concepts/#principal) that reads or writes objects in the bucket: `KeyManagerKeyEncrypt` to upload objects, and `KeyManagerKeyDecrypt` to download them
 
 <Message type="important">
-Object Storage permission sets alone are not sufficient to read and write objects encrypted with SSE-KMS. A principal holding `ObjectStorageFullAccess` and no Key Manager permission set gets an access denied error when it uploads an object to a bucket that has default encryption enabled, even when the KEK and the bucket are in the same Project.
+Object Storage permission sets alone are not sufficient to read and write objects encrypted with SSE-KMS. A principal that has `ObjectStorageFullAccess` and no Key Manager permission set receives an "access denied" error when it uploads an object to a bucket that has default encryption enabled, even when the KEK and the bucket are in the same Project.
 </Message>
 
 ## How to enable SSE-KMS during bucket creation


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

Enabling SSE-KMS on a bucket requires the IAM principal that reads and writes objects to hold Key Manager permission sets, in addition to its Object Storage ones. That requirement is not documented on the SSE-KMS pages, and it costs a failed deployment to discover.

I was able to confirm it on a small project, failing to upload a document on S3 without `KeyManagerKeyEncrypt`.