### PR TITLE
docs(kaspule): fix typo in RBAC, use scaleway:group instead of scalew…

### DIFF
--- a/pages/kubernetes/reference-content/set-iam-permissions-and-implement-rbac.mdx
+++ b/pages/kubernetes/reference-content/set-iam-permissions-and-implement-rbac.mdx
@@ -72,7 +72,7 @@ Default `ClusterRoleBinding` and `ClusterRole` configurations have been set up:
 
 These groups can be edited and will not be reconciled by Kapsule/Kosmos. If these roles are misconfigured and cut off access to the cluster, the IAM permission set `KubernetesSystemMastersGroupAccess` should be assigned to the application or user. This permission set allows bypassing the entire RBAC layer.
 
-Users or applications can be added to zero, one, or more IAM groups. IAM groups are mapped to Kubernetes groups in the format `scaleway:groups:GROUPID`.
+Users or applications can be added to zero, one, or more IAM groups. IAM groups are mapped to Kubernetes groups in the format `scaleway:group:GROUPID`.
 
 **Example:**
 
@@ -133,7 +133,7 @@ Groups      [scaleway:group:55eb7ac5-9afe-4e40-8d54-4fbb232cac21 scaleway:cluste
       namespace: dev
     subjects:
     - kind: Group
-      name: scaleway:groups:<GROUP_ID>
+      name: scaleway:group:<GROUP_ID>
     roleRef:
       kind: Role
       name: developers

--- a/pages/kubernetes/reference-content/set-iam-permissions-and-implement-rbac.mdx
+++ b/pages/kubernetes/reference-content/set-iam-permissions-and-implement-rbac.mdx
@@ -72,7 +72,7 @@ Default `ClusterRoleBinding` and `ClusterRole` configurations have been set up:
 
 These groups can be edited and will not be reconciled by Kapsule/Kosmos. If these roles are misconfigured and cut off access to the cluster, the IAM permission set `KubernetesSystemMastersGroupAccess` should be assigned to the application or user. This permission set allows bypassing the entire RBAC layer.
 
-Users or applications can be added to zero, one, or more IAM groups. IAM groups are mapped to Kubernetes groups in the format `scaleway:group:GROUPID`.
+You can add users or applications to zero, one, or several IAM groups. Each IAM group maps to a Kubernetes group in the format `scaleway:group:GROUPID`.
 
 **Example:**
 


### PR DESCRIPTION
### Your checklist for this pull request

- [ x] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

Fix typo in Kubernetes RBAC on SCW group usage.
