### PR TITLE
fix(iam): add ObservabilityGrafanaEditor permission in permission sets

### DIFF
--- a/pages/iam/reference-content/permission-sets.mdx
+++ b/pages/iam/reference-content/permission-sets.mdx
@@ -383,7 +383,8 @@ Below is a list of the permission sets available at Scaleway.
 
 | Permission set               | Description                                                                           |
 | :--------------------------: | :-----------------------------------------------------------------------------------: |
-| ObservabilityReadOnly        | List and read access to Observability                                         |
+| ObservabilityReadOnly        | List and read access to Observability                                                 |
+| ObservabilityGrafanaEditor   | Editor access to Cockpit Grafana, read-only access to all other Cockpit features      |
 | ObservabilityFullAccess      | Full access to create, read, list, edit and delete Observability                      |
 
 
@@ -399,7 +400,7 @@ Below is a list of the permission sets available at Scaleway.
 | SecretManagerSecretCreate    | Permission to create secrets and their versions in Secret Manager. Does not include permission to update secrets and versions             |
 | SecretManagerSecretDelete    | Permission to delete secrets and their versions in Secret Manager            |
 | SecretManagerSecretWrite     | Permission to edit the metadata (name, tags, description, etc.) of secrets and their versions in Secret Manager. Does not include permission to create secrets and versions           |
-| SecretManagerSecretRestore    | Restore permission on Secret Manager secrets and their versions         |
+| SecretManagerSecretRestore   | Restore permission on Secret Manager secrets and their versions         |
 
 #### Key Manager
 


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

ObservabilityGrafanaEditor permission is missing in the documentation, this PR add it.
