### PR TITLE
fix(gen): fixed slack broken links and wording MTA-7434

### DIFF
--- a/pages/domains-and-dns/reference-content/access-migrated-domain.mdx
+++ b/pages/domains-and-dns/reference-content/access-migrated-domain.mdx
@@ -111,7 +111,7 @@ The migration is automatic for all BookMyName domain names and cannot be postpon
 
 ### Can I change my migration date?
 
-Migration dates cannot be changed. You can perform an outbound transfer before the migration if you do not wish to wait for the scheduled date. See [How to unlock an internal domain](/domains-and-dns/how-to/how-to/unlock-internal-domain/) for more information. 
+Migration dates cannot be changed. You can perform an outbound transfer before the migration if you do not wish to wait for the scheduled date. See [How to unlock an internal domain](/domains-and-dns/how-to/unlock-internal-domain/) for more information. 
 
 ### What if my domain expires during the migration?
 

--- a/pages/generative-apis/how-to/use-function-calling.mdx
+++ b/pages/generative-apis/how-to/use-function-calling.mdx
@@ -421,5 +421,5 @@ For more information about function calling and advanced implementations, refer 
 Function calling significantly extends the capabilities of language models by allowing them to interact with external tools and APIs. 
 
 <Message type="note">
-  We cannot wait to see what you will build with function calls. Tell us what you are up to, and share your experiments on the [Scaleway Slack community](https://slack.scaleway.com/) in the #ai channel.
+  We cannot wait to see what you will build with function calls. Tell us what you are up to, and share your experiments in the #ai channel of the [Scaleway Slack community](https://slack.scaleway.com/).
 </Message>

--- a/pages/generative-apis/how-to/use-function-calling.mdx
+++ b/pages/generative-apis/how-to/use-function-calling.mdx
@@ -421,5 +421,5 @@ For more information about function calling and advanced implementations, refer 
 Function calling significantly extends the capabilities of language models by allowing them to interact with external tools and APIs. 
 
 <Message type="note">
-  We cannot wait to see what you will build with function calls. Tell us what you are up to, and share your experiments on Scaleway's [Slack community](https://slack.scaleway.com/) in the #ai channel.
+  We cannot wait to see what you will build with function calls. Tell us what you are up to, and share your experiments on the [Scaleway Slack community](https://slack.scaleway.com/) in the #ai channel.
 </Message>

--- a/pages/ipam/reference-content/ipv6.mdx
+++ b/pages/ipam/reference-content/ipv6.mdx
@@ -125,7 +125,7 @@ Products other than those listed here do not officially support IPv6. These non-
 
 Open or upvote a [feature request](https://feature-request.scaleway.com/) to register your interest in IPv6 for these resources. 
 
-Alternatively, get in touch on the [Scaleway Community Slack](/tutorials/scaleway-slack-community/) to find out more about IPv6 compatibility of these or other products.
+Alternatively, get in touch on the [Scaleway Slack community](/tutorials/scaleway-slack-community/) to find out more about IPv6 compatibility of these or other products.
 
 ## IPv6 best practices
 

--- a/pages/public-gateways/troubleshooting/gateway-services-not-working.mdx
+++ b/pages/public-gateways/troubleshooting/gateway-services-not-working.mdx
@@ -28,4 +28,4 @@ If the address does ping, then you may be either experiencing another issue, whe
 
 It may also be useful to try the steps outlined in [this troubleshooting](/vpc/troubleshooting/autoconfig-not-working/).
 
-If the problem persists, contact us on the `#public-gateway` channel on the [Scaleway Slack community](https://slack.scaleway.com/).
+If the problem persists, contact us on the `#public-gateway` channel of the [Scaleway Slack community](https://slack.scaleway.com/).

--- a/pages/public-gateways/troubleshooting/gateway-services-not-working.mdx
+++ b/pages/public-gateways/troubleshooting/gateway-services-not-working.mdx
@@ -28,4 +28,4 @@ If the address does ping, then you may be either experiencing another issue, whe
 
 It may also be useful to try the steps outlined in [this troubleshooting](/vpc/troubleshooting/autoconfig-not-working/).
 
-If the problem persists, do not hesitate to [contact us on the #public-gateway channel on the Scaleway Community Slack](https://scaleway-community.slack.com/archives/C01NTFET64D).
+If the problem persists, contact us on the `#public-gateway` channel on the [Scaleway Slack community](https://slack.scaleway.com/).

--- a/pages/transactional-email/reference-content/dmarc-configuration.mdx
+++ b/pages/transactional-email/reference-content/dmarc-configuration.mdx
@@ -70,7 +70,7 @@ Below are a few examples of DMARC configuration scenarios for inspiration to [co
 <Message type="important">
 
   - Using the following examples could affect your email deliverability, make sure that you ask for help if you are not familiar with DMARC configuration.
-  - If you need help with DMARC configuration, you can contact the Transactional Email team in the #transactional-email channel on the [Scaleway Community Slack](https://scaleway-community.slack.com).
+  - If you need help with DMARC configuration, you can contact the Transactional Email team in the #transactional-email channel on the [Scaleway Slack community](https://scaleway-community.slack.com).
 
 </Message>
 

--- a/pages/transactional-email/reference-content/dmarc-configuration.mdx
+++ b/pages/transactional-email/reference-content/dmarc-configuration.mdx
@@ -70,7 +70,7 @@ Below are a few examples of DMARC configuration scenarios for inspiration to [co
 <Message type="important">
 
   - Using the following examples could affect your email deliverability, make sure that you ask for help if you are not familiar with DMARC configuration.
-  - If you need help with DMARC configuration, you can contact the Transactional Email team in the #transactional-email channel on the [Scaleway Slack community](https://scaleway-community.slack.com).
+  - If you need help with DMARC configuration, you can contact the Transactional Email team in the #transactional-email channel of the [Scaleway Slack community](https://scaleway-community.slack.com).
 
 </Message>
 

--- a/pages/vpc/faq.mdx
+++ b/pages/vpc/faq.mdx
@@ -70,7 +70,7 @@ Yes. You can attach a [Public Gateway](/public-gateways/how-to/create-a-public-g
 
 ### Do non-IP protocols work over Private Networks?
 
-Technically, any Ethernet payload should work over Private Networks. However, only IPv4 and IPv6 are officially supported. If you have real use cases for other protocols, let us know by reaching us on the [Scaleway Community Slack](https://scaleway-community.slack.com/).
+Technically, any Ethernet payload should work over Private Networks. However, only IPv4 and IPv6 are officially supported. If you have real use cases for other protocols, let us know by reaching us on the [Scaleway Slack community](https://scaleway-community.slack.com/).
 
 ## Quotas and limitations
 

--- a/pages/vpc/faq.mdx
+++ b/pages/vpc/faq.mdx
@@ -70,7 +70,7 @@ Yes. You can attach a [Public Gateway](/public-gateways/how-to/create-a-public-g
 
 ### Do non-IP protocols work over Private Networks?
 
-Technically, any Ethernet payload should work over Private Networks. However, only IPv4 and IPv6 are officially supported. If you have real use cases for other protocols, let us know by reaching us on the [Scaleway Slack community](https://scaleway-community.slack.com/).
+Technically, any Ethernet payload should work over Private Networks. However, only IPv4 and IPv6 are officially supported. If you have real use cases for other protocols, let us know by reaching out to us in the [Scaleway Slack community](https://scaleway-community.slack.com/).
 
 ## Quotas and limitations
 

--- a/pages/vpc/reference-content/vpc-migration.mdx
+++ b/pages/vpc/reference-content/vpc-migration.mdx
@@ -164,4 +164,4 @@ Read our [blog post](https://www.scaleway.com/en/blog/virtual-private-cloud-publ
 - [VPC API Documentation](https://www.scaleway.com/en/developers/api/vpc/)
 - [Scaleway Developers Tools](https://www.scaleway.com/en/developers/)
 - [Tutorials](/tutorials/?products=vpc)
-- Join the [#virtual-private-cloud channel](https://slack.scaleway.com/) on Slack
+- Join the `#virtual-private-cloud` channel on the [Scaleway Slack community](https://slack.scaleway.com/)

--- a/pages/vpc/reference-content/vpc-migration.mdx
+++ b/pages/vpc/reference-content/vpc-migration.mdx
@@ -164,4 +164,4 @@ Read our [blog post](https://www.scaleway.com/en/blog/virtual-private-cloud-publ
 - [VPC API Documentation](https://www.scaleway.com/en/developers/api/vpc/)
 - [Scaleway Developers Tools](https://www.scaleway.com/en/developers/)
 - [Tutorials](/tutorials/?products=vpc)
-- Join the `#virtual-private-cloud` channel on the [Scaleway Slack community](https://slack.scaleway.com/)
+- Join the `#virtual-private-cloud` channel of the [Scaleway Slack community](https://slack.scaleway.com/)

--- a/tutorials/migrating-docker-workloads-to-kubernetes-kapsule/index.mdx
+++ b/tutorials/migrating-docker-workloads-to-kubernetes-kapsule/index.mdx
@@ -401,7 +401,7 @@ kubectl apply -f hpa.yaml
   - [Kubernetes Concepts](https://kubernetes.io/docs/concepts/)
   - [Kubectl Cheat Sheet](https://kubernetes.io/docs/reference/kubectl/cheatsheet/)
 - **Community Support**:
-  - [Scaleway Slack Community](https://slack.scaleway.com/)
+  - [Scaleway Slack community](https://slack.scaleway.com/)
   - [Kubernetes Slack](https://slack.k8s.io/)
 
 ## Feedback and support

--- a/tutorials/migrating-docker-workloads-to-kubernetes-kapsule/index.mdx
+++ b/tutorials/migrating-docker-workloads-to-kubernetes-kapsule/index.mdx
@@ -401,7 +401,7 @@ kubectl apply -f hpa.yaml
   - [Kubernetes Concepts](https://kubernetes.io/docs/concepts/)
   - [Kubectl Cheat Sheet](https://kubernetes.io/docs/reference/kubectl/cheatsheet/)
 - **Community Support**:
-  - [Scaleway Community Slack](https://slack.scaleway.com/)
+  - [Scaleway Slack Community](https://slack.scaleway.com/)
   - [Kubernetes Slack](https://slack.k8s.io/)
 
 ## Feedback and support

--- a/tutorials/migrating-from-another-managed-kubernetes-service-to-scaleway-kapsule/index.mdx
+++ b/tutorials/migrating-from-another-managed-kubernetes-service-to-scaleway-kapsule/index.mdx
@@ -497,7 +497,7 @@ Conduct functional, performance, and end-to-end testing to verify the applicatio
   - [Ingress Controllers](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/)
 - **Community and Support**:
   - [Scaleway Support](https://console.scaleway.com/support/tickets)
-  - [Scaleway Community](https://slack.scaleway.com/)
+  - [Scaleway Slack community](https://slack.scaleway.com/)
   - [Kubernetes Slack](https://slack.k8s.io/)
 
 ## Feedback and assistance
@@ -505,5 +505,5 @@ Conduct functional, performance, and end-to-end testing to verify the applicatio
 If you encounter issues or have questions during your migration:
 
 - **Contact support**: Use the [Scaleway support portal](https://console.scaleway.com/support/tickets) for technical assistance.
-- **Community Slack**: Engage with other users and experts in the [Scaleway Community](https://slack.scaleway.com).
+- **Community Slack**: Engage with other users and experts in the [Scaleway Slack community](https://slack.scaleway.com).
 - **Provide feedback**: Your input helps improve services and documentation.

--- a/tutorials/mutli-node-rocket-chat-community-private-network/index.mdx
+++ b/tutorials/mutli-node-rocket-chat-community-private-network/index.mdx
@@ -438,4 +438,6 @@ Once everything is set up and working, you can remove the public flexible IP add
 
 ## Conclusion
 
-You have now configured a Rocket.Chat application based on several Instances and communicating internally using the Private Networks feature. The connection between these Instances is isolated from the internet and the internal network and only the Instances added to the Private Network can communicate with each other. For more advanced configuration options of Rocket.Chat, refer to the [official documentation](https://docs.rocket.chat/). More information about the Private Networks feature is available in our [feature documentation](/vpc/concepts/#private-networks). Do you have any remaining questions or suggestions? We welcome your feedback on Slack: [Scaleway Community](https://scaleway-community.slack.com/join/shared_invite/zt-19uuwgo5h-bofWNwE~jijt70lQkziQxg#/shared-invite/email). Join us in the `#private-network` chan.
+You have now configured a Rocket.Chat application based on several Instances and communicating internally using the Private Networks feature. The connection between these Instances is isolated from the internet and the internal network and only the Instances added to the Private Network can communicate with each other. For more advanced configuration options of Rocket.Chat, refer to the [Rocket.Chat documentation](https://docs.rocket.chat/). 
+
+For more information about the Private Networks feature, see the [Private Networks](/vpc/concepts/#private-networks) documentation.

--- a/tutorials/scaleway-slack-community/index.mdx
+++ b/tutorials/scaleway-slack-community/index.mdx
@@ -24,7 +24,7 @@ Slack is a real-time messaging platform that offers traditional IRC functionalit
 
 ## Signing up for Slack
 
-1. Navigate to the [Scaleway homepage](https://www.scaleway.com/en/) and click **Slack Community** in the **Resources** section at the bottom of the page, or access it directly via [this link](https://slack.scaleway.com/).
+1. Navigate to the [Scaleway homepage](https://www.scaleway.com/en/) and click **Slack Community** in the **Resources** section at the bottom of the page, or access it directly via [Scaleway Slack community](https://slack.scaleway.com/).
 
 2. You will be directed to the registration page. Choose one of the suggested **Single Sign-On (SSO)** methods or opt to **Continue with Email** by providing your email address.
     <Lightbox image={image} alt="Scaleway Slack Community signup page" size="large" />


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Name your pull request according to the [contribution guidelines](https://github.com/scaleway/docs-content/blob/main/docs/CONTRIBUTING.md).

### Description

- Fixed Slack community links
- Homogenized Slack community name
- Fixed typo in previously fixed domains link
