### PR TITLE
feat(adt): add changelog for support for serverless containers

### DIFF
--- a/changelog/august2026/2026-08-26-audit-trail-added-serverless-containers-events-available.mdx
+++ b/changelog/august2026/2026-08-26-audit-trail-added-serverless-containers-events-available.mdx
@@ -1,0 +1,9 @@
+---
+title: Serverless Containers events available in Audit Trail
+status: added
+date: 2026-08-26
+category: monitoring
+product: audit-trail
+---
+
+Serverless Containers activity can now be tracked in Audit Trail. Refer to [our documentation](/audit-trail/reference-content/adt-supported-endpoints/#serverless-containers) to see the list of available events.

--- a/changelog/august2026/2026-08-26-audit-trail-added-serverless-containers-events-available.mdx
+++ b/changelog/august2026/2026-08-26-audit-trail-added-serverless-containers-events-available.mdx
@@ -6,4 +6,4 @@ category: monitoring
 product: audit-trail
 ---
 
-Serverless Containers activity can now be tracked in Audit Trail. Refer to [our documentation](/audit-trail/reference-content/adt-supported-endpoints/#serverless-containers) to see the list of available events.
+Serverless Containers activity can now be tracked in Audit Trail. See [our documentation](/audit-trail/reference-content/adt-supported-endpoints/#serverless-containers) for the list of available events.


### PR DESCRIPTION
Adding a duplicate changelog file with another category-product pair so we can have the same changelog valid for 2 products.