### PR TITLE
feat(webhosting): add PHP 8.4 and 8.5, update 8.2/8.3 support for Dedibox cPanel

### DIFF
--- a/pages/webhosting/reference-content/php-version-overview.mdx
+++ b/pages/webhosting/reference-content/php-version-overview.mdx
@@ -25,6 +25,8 @@ Below is an overview of the available PHP versions for the existing infrastructu
 | PHP 7.4         | Not supported                  | Supported                 | Supported                   |
 | PHP 8.0         | Not supported                  | Supported                 | Supported                   |
 | PHP 8.1         | Not supported                  | Supported                 | Supported                   |
-| PHP 8.2         | Not supported                  | Not supported                 | Supported                   |
-| PHP 8.3         | Not supported                  | Not supported                 | Supported                   |
+| PHP 8.2         | Not supported                  | Supported                 | Supported                   |
+| PHP 8.3         | Not supported                  | Supported                 | Supported                   |
+| PHP 8.4         | Not supported                  | Supported                 | Supported                   |
+| PHP 8.5         | Not supported                  | Supported                 | Supported                   |
 


### PR DESCRIPTION
## Description

Updates the PHP version overview page for Web Hosting (`pages/webhosting/reference-content/php-version-overview.mdx`):

- Adds **PHP 8.4** and **PHP 8.5** rows — supported on Dedibox cPanel and Scaleway cPanel, not supported on Dedibox Classic.
- Updates **PHP 8.2** and **PHP 8.3** to "Supported" for Dedibox cPanel (previously "Not supported").