### PR TITLE
docs(wireguard): fix swapped ip addresses

### DIFF
--- a/tutorials/wireguard-mesh-vpn/index.mdx
+++ b/tutorials/wireguard-mesh-vpn/index.mdx
@@ -104,12 +104,12 @@ Your file should look like the following:
 ```
 [Interface]
 PrivateKey = IMR/CZzu5hVJNPqWXhj+H4cHUbCPlvn91VwN3jVNOGw=
-Address = 192.168.1.2
+Address = 192.168.1.1
 ListenPort = 52345
 
 [Peer]
 PublicKey = vIsJ+ZXVc8t8mkkpUIaqHKu9hE8PERT0lxb5nowDkx8=
-AllowedIPs = 192.168.1.1
+AllowedIPs = 192.168.1.2
 Endpoint = 163.172.141.6:52345
 ```
 ### On the second Instance:


### PR DESCRIPTION
## Summary
- Fixed swapped `Address` / `AllowedIPs` values in the PAR-1 instance's `wg0.conf` example under "Your file should look like the following" — they were reversed relative to the PAR-1/AMS-1 IP scheme described earlier in the tutorial.

## Test plan
- [X] Visual review of the corrected config block in `tutorials/wireguard-mesh-vpn/index.mdx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)